### PR TITLE
ci: add benchmark & size comparison on PRs

### DIFF
--- a/.github/actions/bench-compare/.gitignore
+++ b/.github/actions/bench-compare/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/.github/actions/bench-compare/.npmrc
+++ b/.github/actions/bench-compare/.npmrc
@@ -1,0 +1,2 @@
+engine-strict=true
+save-exact=true

--- a/.github/actions/bench-compare/action.yml
+++ b/.github/actions/bench-compare/action.yml
@@ -1,0 +1,61 @@
+name: Benchmark Comparison
+description: Compare criterion benchmarks, binary sizes, test counts, and peak RSS between base and PR
+author: Samuel MARLHENS
+
+inputs:
+  criterion-dir:
+    description: Path to target/criterion directory
+    required: true
+    default: target/criterion
+  pr-baseline:
+    description: Criterion baseline name for PR
+    required: false
+    default: pr
+  base-baseline:
+    description: Criterion baseline name for base
+    required: false
+    default: base
+  pr-binary-sizes:
+    description: 'JSON object of PR binary sizes in bytes, e.g. {"riri-nce": 1234}'
+    required: false
+    default: "{}"
+  base-binary-sizes:
+    description: 'JSON object of base binary sizes in bytes, e.g. {"riri-nce": 1234}'
+    required: false
+    default: "{}"
+  pr-test-count:
+    description: Number of tests in PR branch
+    required: false
+    default: "0"
+  base-test-count:
+    description: Number of tests in base branch
+    required: false
+    default: "0"
+  pr-peak-rss-kb:
+    description: Peak RSS in KB for PR branch
+    required: false
+    default: "0"
+  base-peak-rss-kb:
+    description: Peak RSS in KB for base branch
+    required: false
+    default: "0"
+  threshold:
+    description: Regression percentage threshold to fail the check
+    required: false
+    default: "10"
+  token:
+    description: GitHub token for API access
+    required: false
+    default: ${{ github.token }}
+
+outputs:
+  has-regression:
+    description: Whether a benchmark regression was detected
+  max-regression:
+    description: Maximum regression percentage found
+  comment-id:
+    description: ID of the created/updated PR comment
+
+runs:
+  using: node24
+  main: dist/index.js

--- a/.github/actions/bench-compare/package-lock.json
+++ b/.github/actions/bench-compare/package-lock.json
@@ -1,0 +1,693 @@
+{
+  "name": "bench-compare-action",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "bench-compare-action",
+      "version": "1.0.0",
+      "dependencies": {
+        "@actions/core": "3.0.0",
+        "@actions/github": "9.0.0"
+      },
+      "devDependencies": {
+        "@types/node": "24.12.2",
+        "rolldown": "1.0.0-rc.13",
+        "typescript": "6.0.2"
+      },
+      "engines": {
+        "node": ">=24"
+      }
+    },
+    "node_modules/@actions/core": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.0.tgz",
+      "integrity": "sha512-zYt6cz+ivnTmiT/ksRVriMBOiuoUpDCJJlZ5KPl2/FRdvwU3f7MPh9qftvbkXJThragzUZieit2nyHUyw53Seg==",
+      "license": "MIT",
+      "dependencies": {
+        "@actions/exec": "^3.0.0",
+        "@actions/http-client": "^4.0.0"
+      }
+    },
+    "node_modules/@actions/exec": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-3.0.0.tgz",
+      "integrity": "sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@actions/io": "^3.0.2"
+      }
+    },
+    "node_modules/@actions/github": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/github/-/github-9.0.0.tgz",
+      "integrity": "sha512-yJ0RoswsAaKcvkmpCE4XxBRiy/whH2SdTBHWzs0gi4wkqTDhXMChjSdqBz/F4AeiDlP28rQqL33iHb+kjAMX6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@actions/http-client": "^3.0.2",
+        "@octokit/core": "^7.0.6",
+        "@octokit/plugin-paginate-rest": "^14.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^17.0.0",
+        "@octokit/request": "^10.0.7",
+        "@octokit/request-error": "^7.1.0",
+        "undici": "^6.23.0"
+      }
+    },
+    "node_modules/@actions/github/node_modules/@actions/http-client": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-3.0.2.tgz",
+      "integrity": "sha512-JP38FYYpyqvUsz+Igqlc/JG6YO9PaKuvqjM3iGvaLqFnJ7TFmcLyy2IDrY0bI0qCQug8E9K+elv5ZNfw62ZJzA==",
+      "license": "MIT",
+      "dependencies": {
+        "tunnel": "^0.0.6",
+        "undici": "^6.23.0"
+      }
+    },
+    "node_modules/@actions/http-client": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.0.tgz",
+      "integrity": "sha512-QuwPsgVMsD6qaPD57GLZi9sqzAZCtiJT8kVBCDpLtxhL5MydQ4gS+DrejtZZPdIYyB1e95uCK9Luyds7ybHI3g==",
+      "license": "MIT",
+      "dependencies": {
+        "tunnel": "^0.0.6",
+        "undici": "^6.23.0"
+      }
+    },
+    "node_modules/@actions/io": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-3.0.2.tgz",
+      "integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
+      "license": "MIT"
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
+      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
+      "integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+      "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
+      "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^6.0.0",
+        "@octokit/graphql": "^9.0.3",
+        "@octokit/request": "^10.0.6",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "before-after-hook": "^4.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
+      "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
+      "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^10.0.6",
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
+      "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
+      "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "10.0.8",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.8.tgz",
+      "integrity": "sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^11.0.3",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "fast-content-type-parse": "^3.0.0",
+        "json-with-bigint": "^3.5.3",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
+      "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^27.0.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.123.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.123.0.tgz",
+      "integrity": "sha512-YtECP/y8Mj1lSHiUWGSRzy/C6teUKlS87dEfuVKT09LgQbUsBW1rNg+MiJ4buGu3yuADV60gbIvo9/HplA56Ew==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.13.tgz",
+      "integrity": "sha512-5ZiiecKH2DXAVJTNN13gNMUcCDg4Jy8ZjbXEsPnqa248wgOVeYRX0iqXXD5Jz4bI9BFHgKsI2qmyJynstbmr+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.13.tgz",
+      "integrity": "sha512-tz/v/8G77seu8zAB3A5sK3UFoOl06zcshEzhUO62sAEtrEuW/H1CcyoupOrD+NbQJytYgA4CppXPzlrmp4JZKA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.13.tgz",
+      "integrity": "sha512-8DakphqOz8JrMYWTJmWA+vDJxut6LijZ8Xcdc4flOlAhU7PNVwo2MaWBF9iXjJAPo5rC/IxEFZDhJ3GC7NHvug==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.13.tgz",
+      "integrity": "sha512-4wBQFfjDuXYN/SVI8inBF3Aa+isq40rc6VMFbk5jcpolUBTe5cYnMsHZ51nFWsx3PVyyNN3vgoESki0Hmr/4BA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.13.tgz",
+      "integrity": "sha512-JW/e4yPIXLms+jmnbwwy5LA/LxVwZUWLN8xug+V200wzaVi5TEGIWQlh8o91gWYFxW609euI98OCCemmWGuPrw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.13.tgz",
+      "integrity": "sha512-ZfKWpXiUymDnavepCaM6KG/uGydJ4l2nBmMxg60Ci4CbeefpqjPWpfaZM7PThOhk2dssqBAcwLc6rAyr0uTdXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.13.tgz",
+      "integrity": "sha512-bmRg3O6Z0gq9yodKKWCIpnlH051sEfdVwt+6m5UDffAQMUUqU0xjnQqqAUm+Gu7ofAAly9DqiQDtKu2nPDEABA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.13.tgz",
+      "integrity": "sha512-8Wtnbw4k7pMYN9B/mOEAsQ8HOiq7AZ31Ig4M9BKn2So4xRaFEhtCSa4ZJaOutOWq50zpgR4N5+L/opnlaCx8wQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.13.tgz",
+      "integrity": "sha512-D/0Nlo8mQuxSMohNJUF2lDXWRsFDsHldfRRgD9bRgktj+EndGPj4DOV37LqDKPYS+osdyhZEH7fTakTAEcW7qg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.13.tgz",
+      "integrity": "sha512-eRrPvat2YaVQcwwKi/JzOP6MKf1WRnOCr+VaI3cTWz3ZoLcP/654z90lVCJ4dAuMEpPdke0n+qyAqXDZdIC4rA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.13.tgz",
+      "integrity": "sha512-PsdONiFRp8hR8KgVjTWjZ9s7uA3uueWL0t74/cKHfM4dR5zXYv4AjB8BvA+QDToqxAFg4ZkcVEqeu5F7inoz5w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.13.tgz",
+      "integrity": "sha512-hCNXgC5dI3TVOLrPT++PKFNZ+1EtS0mLQwfXXXSUD/+rGlB65gZDwN/IDuxLpQP4x8RYYHqGomlUXzpO8aVI2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.13.tgz",
+      "integrity": "sha512-viLS5C5et8NFtLWw9Sw3M/w4vvnVkbWkO7wSNh3C+7G1+uCkGpr6PcjNDSFcNtmXY/4trjPBqUfcOL+P3sWy/g==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.9.1",
+        "@emnapi/runtime": "1.9.1",
+        "@napi-rs/wasm-runtime": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.13.tgz",
+      "integrity": "sha512-Fqa3Tlt1xL4wzmAYxGNFV36Hb+VfPc9PYU+E25DAnswXv3ODDu/yyWjQDbXMo5AGWkQVjLgQExuVu8I/UaZhPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.13.tgz",
+      "integrity": "sha512-/pLI5kPkGEi44TDlnbio3St/5gUFeN51YWNAk/Gnv6mEQBOahRBh52qVFVBpmrnU01n2yysvBML9Ynu7K4kGAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.13.tgz",
+      "integrity": "sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/before-after-hook": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
+      "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/fast-content-type-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
+      "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/json-with-bigint": {
+      "version": "3.5.8",
+      "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.8.tgz",
+      "integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==",
+      "license": "MIT"
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.13.tgz",
+      "integrity": "sha512-bvVj8YJmf0rq4pSFmH7laLa6pYrhghv3PRzrCdRAr23g66zOKVJ4wkvFtgohtPLWmthgg8/rkaqRHrpUEh0Zbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.123.0",
+        "@rolldown/pluginutils": "1.0.0-rc.13"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.13",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.13",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.13",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.13",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.13",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.13",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.13",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.13",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.13",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.13",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.13",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.13",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.13",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.13",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.13"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
+      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/universal-user-agent": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "license": "ISC"
+    }
+  }
+}

--- a/.github/actions/bench-compare/package.json
+++ b/.github/actions/bench-compare/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "bench-compare-action",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "bundle": "rolldown -c rolldown.config.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@actions/core": "3.0.0",
+    "@actions/github": "9.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "24.12.2",
+    "rolldown": "1.0.0-rc.13",
+    "typescript": "6.0.2"
+  },
+  "engines": {
+    "node": ">=24"
+  }
+}

--- a/.github/actions/bench-compare/rolldown.config.ts
+++ b/.github/actions/bench-compare/rolldown.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "rolldown";
+
+export default defineConfig({
+  input: "src/index.ts",
+  output: {
+    file: "dist/index.js",
+    format: "esm",
+    sourcemap: false,
+  },
+  platform: "node",
+  resolve: {
+    conditionNames: ["node", "import"],
+  },
+});

--- a/.github/actions/bench-compare/src/comment.ts
+++ b/.github/actions/bench-compare/src/comment.ts
@@ -1,0 +1,51 @@
+import * as github from "@actions/github";
+
+const COMMENT_TAG = "<!-- bench-compare -->";
+
+type Octokit = ReturnType<typeof github.getOctokit>;
+
+async function findExistingComment(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  prNumber: number,
+): Promise<number | null> {
+  const comments = await octokit.paginate(octokit.rest.issues.listComments, {
+    owner,
+    repo,
+    issue_number: prNumber,
+    per_page: 100,
+  });
+
+  const existing = comments.find((c: { body?: string | null }) => c.body?.includes(COMMENT_TAG) ?? false);
+  return existing?.id ?? null;
+}
+
+export async function createOrUpdateComment(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  prNumber: number,
+  body: string,
+): Promise<number> {
+  const taggedBody = `${body}\n${COMMENT_TAG}`;
+  const existingId = await findExistingComment(octokit, owner, repo, prNumber);
+
+  if (existingId) {
+    await octokit.rest.issues.updateComment({
+      owner,
+      repo,
+      comment_id: existingId,
+      body: taggedBody,
+    });
+    return existingId;
+  }
+
+  const { data: comment } = await octokit.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: prNumber,
+    body: taggedBody,
+  });
+  return comment.id;
+}

--- a/.github/actions/bench-compare/src/criterion.ts
+++ b/.github/actions/bench-compare/src/criterion.ts
@@ -1,0 +1,113 @@
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+interface Estimate {
+  point_estimate: number;
+  standard_error: number;
+  confidence_interval: { lower_bound: number; upper_bound: number };
+}
+
+interface Estimates {
+  mean: Estimate;
+  median: Estimate;
+  median_abs_dev: Estimate;
+  slope?: Estimate;
+  std_dev: Estimate;
+}
+
+export interface BenchmarkResult {
+  name: string;
+  baseNs: number;
+  prNs: number;
+  diffPct: number;
+}
+
+async function dirExists(path: string): Promise<boolean> {
+  try {
+    const { stat } = await import("node:fs/promises");
+    const s = await stat(path);
+    return s.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    const { stat } = await import("node:fs/promises");
+    const s = await stat(path);
+    return s.isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Recursively find all benchmark directories that contain both baselines.
+ * Criterion stores results as: <criterion-dir>/<bench-id>/<baseline>/estimates.json
+ * The bench-id may contain nested directories (e.g., "group/function").
+ */
+async function findBenchmarkDirs(
+  criterionDir: string,
+  baseBaseline: string,
+  prBaseline: string,
+): Promise<{ name: string; dir: string }[]> {
+  const results: { name: string; dir: string }[] = [];
+
+  async function walk(dir: string, prefix: string): Promise<void> {
+    const entries = await readdir(dir, { withFileTypes: true });
+    const subdirs = entries.filter((e) => e.isDirectory());
+
+    const hasBase = await dirExists(join(dir, baseBaseline));
+    const hasPr = await dirExists(join(dir, prBaseline));
+
+    if (hasBase && hasPr) {
+      const baseEstimates = join(dir, baseBaseline, "estimates.json");
+      const prEstimates = join(dir, prBaseline, "estimates.json");
+
+      if ((await fileExists(baseEstimates)) && (await fileExists(prEstimates))) {
+        results.push({ name: prefix || dir, dir });
+        return;
+      }
+    }
+
+    for (const sub of subdirs) {
+      if (sub.name === baseBaseline || sub.name === prBaseline) continue;
+      const subPath = join(dir, sub.name);
+      const subPrefix = prefix ? `${prefix}/${sub.name}` : sub.name;
+      await walk(subPath, subPrefix);
+    }
+  }
+
+  await walk(criterionDir, "");
+  return results;
+}
+
+export async function compareBenchmarks(
+  criterionDir: string,
+  baseBaseline: string,
+  prBaseline: string,
+): Promise<BenchmarkResult[]> {
+  if (!(await dirExists(criterionDir))) {
+    return [];
+  }
+
+  const benchDirs = await findBenchmarkDirs(criterionDir, baseBaseline, prBaseline);
+  const results: BenchmarkResult[] = [];
+
+  for (const { name, dir } of benchDirs) {
+    const baseFile = join(dir, baseBaseline, "estimates.json");
+    const prFile = join(dir, prBaseline, "estimates.json");
+
+    const baseEstimates: Estimates = JSON.parse(await readFile(baseFile, "utf-8"));
+    const prEstimates: Estimates = JSON.parse(await readFile(prFile, "utf-8"));
+
+    const baseNs = baseEstimates.mean.point_estimate;
+    const prNs = prEstimates.mean.point_estimate;
+    const diffPct = baseNs === 0 ? 0 : ((prNs - baseNs) / baseNs) * 100;
+
+    results.push({ name, baseNs, prNs, diffPct });
+  }
+
+  return results.sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/.github/actions/bench-compare/src/format.ts
+++ b/.github/actions/bench-compare/src/format.ts
@@ -1,0 +1,122 @@
+import type { BenchmarkResult } from "./criterion.js";
+
+function formatNs(ns: number): string {
+  if (ns >= 1_000_000_000) return `${(ns / 1_000_000_000).toFixed(2)} s`;
+  if (ns >= 1_000_000) return `${(ns / 1_000_000).toFixed(2)} ms`;
+  if (ns >= 1_000) return `${(ns / 1_000).toFixed(1)} us`;
+  return `${ns.toFixed(1)} ns`;
+}
+
+function formatBytes(bytes: number): string {
+  const abs = Math.abs(bytes);
+  if (abs >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MiB`;
+  if (abs >= 1024) return `${(bytes / 1024).toFixed(1)} KiB`;
+  return `${bytes} B`;
+}
+
+function formatPct(pct: number): string {
+  const sign = pct > 0 ? "+" : "";
+  return `${sign}${pct.toFixed(2)}%`;
+}
+
+function regressionIcon(pct: number, threshold: number): string {
+  if (pct > threshold) return ":x:";
+  if (pct > 0) return ":warning:";
+  if (pct < -1) return ":white_check_mark:";
+  return "";
+}
+
+export function formatBenchmarkTable(results: BenchmarkResult[], threshold: number): string {
+  if (results.length === 0) return "_No criterion benchmarks found._";
+
+  const rows = results
+    .map((r) => {
+      const icon = regressionIcon(r.diffPct, threshold);
+      return `| ${r.name} | ${formatNs(r.baseNs)} | ${formatNs(r.prNs)} | ${formatPct(r.diffPct)} | ${icon} |`;
+    })
+    .join("\n");
+
+  return `| Benchmark | Base | PR | \u0394 | |
+|-----------|------|----|---|---|
+${rows}`;
+}
+
+export function formatBinarySizeTable(prSizes: Record<string, number>, baseSizes: Record<string, number>): string {
+  const binaries = [...new Set([...Object.keys(prSizes), ...Object.keys(baseSizes)])].sort();
+
+  if (binaries.length === 0) return "_No binary size data._";
+
+  const rows = binaries
+    .map((name) => {
+      const pr = prSizes[name];
+      const base = baseSizes[name];
+
+      if (pr != null && base != null) {
+        const diff = pr - base;
+        const pct = base === 0 ? 0 : (diff / base) * 100;
+        return `| \`${name}\` | ${formatBytes(base)} | ${formatBytes(pr)} | ${formatBytes(diff)} | ${formatPct(pct)} |`;
+      }
+      if (pr != null) {
+        return `| \`${name}\` | _new_ | ${formatBytes(pr)} | - | - |`;
+      }
+      return `| \`${name}\` | ${formatBytes(base!)} | _removed_ | - | - |`;
+    })
+    .join("\n");
+
+  return `| Binary | Base | PR | Diff | % |
+|--------|------|----|------|---|
+${rows}`;
+}
+
+export function formatRssTable(prRssKb: number, baseRssKb: number): string {
+  if (prRssKb === 0 && baseRssKb === 0) return "_No memory data._";
+
+  const diffKb = prRssKb - baseRssKb;
+  const pct = baseRssKb === 0 ? 0 : (diffKb / baseRssKb) * 100;
+
+  return `| Metric | Base | PR | Diff | % |
+|--------|------|----|------|---|
+| Peak RSS | ${formatBytes(baseRssKb * 1024)} | ${formatBytes(prRssKb * 1024)} | ${formatBytes(diffKb * 1024)} | ${formatPct(pct)} |`;
+}
+
+export function formatTestCountTable(prCount: number, baseCount: number): string {
+  const diff = prCount - baseCount;
+  const diffStr = diff > 0 ? `+${diff}` : diff === 0 ? "0" : `${diff}`;
+
+  return `| | Base | PR | Diff |
+|--|------|----|------|
+| Test count | ${baseCount} | ${prCount} | ${diffStr} |`;
+}
+
+export function buildFullComment(
+  benchmarkTable: string,
+  sizeTable: string,
+  rssTable: string,
+  testTable: string,
+  threshold: number,
+  maxRegression: number,
+): string {
+  const regressionStatus =
+    maxRegression > threshold ? `**regression detected: ${maxRegression.toFixed(1)}%**` : "none detected";
+
+  return `## Benchmark & Size Comparison
+
+### Criterion Benchmarks
+
+${benchmarkTable}
+
+### Binary Size
+
+${sizeTable}
+
+### Memory (Peak RSS)
+
+${rssTable}
+
+### Tests
+
+${testTable}
+
+---
+<sub>Threshold: ${threshold}% \u00b7 Regression: ${regressionStatus}</sub>`;
+}

--- a/.github/actions/bench-compare/src/index.ts
+++ b/.github/actions/bench-compare/src/index.ts
@@ -1,0 +1,3 @@
+import { run } from "./main.js";
+
+run();

--- a/.github/actions/bench-compare/src/main.ts
+++ b/.github/actions/bench-compare/src/main.ts
@@ -1,0 +1,78 @@
+import * as core from "@actions/core";
+import * as github from "@actions/github";
+import { compareBenchmarks } from "./criterion.js";
+import { createOrUpdateComment } from "./comment.js";
+import {
+  buildFullComment,
+  formatBenchmarkTable,
+  formatBinarySizeTable,
+  formatRssTable,
+  formatTestCountTable,
+} from "./format.js";
+
+export async function run(): Promise<void> {
+  try {
+    const criterionDir = core.getInput("criterion-dir", { required: true });
+    const prBaseline = core.getInput("pr-baseline");
+    const baseBaseline = core.getInput("base-baseline");
+    const prBinarySizes: Record<string, number> = JSON.parse(core.getInput("pr-binary-sizes"));
+    const baseBinarySizes: Record<string, number> = JSON.parse(core.getInput("base-binary-sizes"));
+    const prTestCount = parseInt(core.getInput("pr-test-count"), 10);
+    const baseTestCount = parseInt(core.getInput("base-test-count"), 10);
+    const prPeakRssKb = parseInt(core.getInput("pr-peak-rss-kb"), 10);
+    const basePeakRssKb = parseInt(core.getInput("base-peak-rss-kb"), 10);
+    const threshold = parseFloat(core.getInput("threshold"));
+    const token = core.getInput("token");
+
+    core.info(`Comparing criterion baselines: ${baseBaseline} vs ${prBaseline}`);
+    core.info(`Criterion directory: ${criterionDir}`);
+    core.info(`Threshold: ${threshold}%`);
+
+    const benchResults = await compareBenchmarks(criterionDir, baseBaseline, prBaseline);
+
+    core.info(`Found ${benchResults.length} benchmark(s)`);
+    for (const r of benchResults) {
+      core.info(`  ${r.name}: ${r.diffPct.toFixed(2)}%`);
+    }
+
+    const maxRegression = benchResults.reduce((max, r) => Math.max(max, r.diffPct), 0);
+    const hasRegression = maxRegression > threshold;
+
+    const benchmarkTable = formatBenchmarkTable(benchResults, threshold);
+    const sizeTable = formatBinarySizeTable(prBinarySizes, baseBinarySizes);
+    const rssTable = formatRssTable(prPeakRssKb, basePeakRssKb);
+    const testTable = formatTestCountTable(prTestCount, baseTestCount);
+
+    const commentBody = buildFullComment(benchmarkTable, sizeTable, rssTable, testTable, threshold, maxRegression);
+
+    await core.summary.addRaw(commentBody).write();
+    core.info("Job summary written");
+
+    const prNumber = github.context.payload.pull_request?.number;
+
+    if (prNumber && token) {
+      const octokit = github.getOctokit(token);
+      const { owner, repo } = github.context.repo;
+
+      const commentId = await createOrUpdateComment(octokit, owner, repo, prNumber, commentBody);
+
+      core.info(`PR comment posted/updated: ${commentId}`);
+      core.setOutput("comment-id", commentId.toString());
+    } else {
+      core.warning("No PR number or token — skipping PR comment");
+    }
+
+    core.setOutput("has-regression", hasRegression.toString());
+    core.setOutput("max-regression", maxRegression.toFixed(2));
+
+    if (hasRegression) {
+      core.setFailed(`Benchmark regression of ${maxRegression.toFixed(1)}% exceeds threshold of ${threshold}%`);
+    }
+  } catch (error) {
+    if (error instanceof Error) {
+      core.setFailed(error.message);
+    } else {
+      core.setFailed("An unexpected error occurred");
+    }
+  }
+}

--- a/.github/actions/bench-compare/tsconfig.json
+++ b/.github/actions/bench-compare/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
         uses: actions/checkout@v6
       - name: Install Rust
         run: rustup update stable && rustup default stable
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
       - name: Check formatting
         run: cargo fmt --all -- --check
       - name: Check errors

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,6 +20,8 @@ jobs:
         uses: actions/checkout@v6
       - name: Install Rust
         run: rustup update stable && rustup default stable
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
       - name: Check formatting
         run: cargo fmt --all -- --check
       - name: Check errors


### PR DESCRIPTION
## Summary

- Add `Swatinem/rust-cache` to existing CI workflows
- Add custom TypeScript GitHub Action for benchmark comparison
- Add `pr-bench` workflow: criterion benchmarks, binary size, peak RSS, test count
- Post unified PR comment with comparison table, fail on regression >10%

## Test plan

- [ ] Verify `pr-bench` workflow triggers on PR
- [ ] Verify PR comment posts with all 4 sections
- [ ] Verify comment updates on re-push (no duplicates)
- [ ] Verify threshold failure on artificial regression