### PR TITLE
fix(ci): use separate commit for Cargo.lock update instead of amend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,8 +88,7 @@ jobs:
       - name: Commit Cargo.lock
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
-          commit_options: "--amend --no-edit"
-          push_options: "--force-with-lease"
+          commit_message: "chore: update Cargo.lock"
           file_pattern: Cargo.lock
 
   bench-baseline:


### PR DESCRIPTION
## Summary
- Replace `--amend --no-edit` + `--force-with-lease` with a separate commit for Cargo.lock update
- Amending the release-please commit changed the SHA, causing release-please to close the PR