### PR TITLE
chore: ignore .worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ dhat-heap.json
 
 # Node
 node_modules/
+
+# Git worktrees
+.worktrees/


### PR DESCRIPTION
## Summary
- Adds `.worktrees/` to `.gitignore` so local git worktrees do not appear as untracked.

## Test plan
- [x] N/A — gitignore-only change.