### PR TITLE
chore(deps): bump serde-saphyr to 0.0.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,6 +702,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "granit-parser"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7e736dfe3881c53a7dce0685eb18202d0d9fe6911782f9870946eb9ee89d778"
+dependencies = [
+ "arraydeque",
+ "smallvec",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1645,17 +1655,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "saphyr-parser-bw"
-version = "0.0.611"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67dec0c833db75dc98957956b303fe447ffc5eb13f2325ef4c2350f7f3aa69e3"
-dependencies = [
- "arraydeque",
- "smallvec",
- "thiserror",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1683,18 +1682,18 @@ dependencies = [
 
 [[package]]
 name = "serde-saphyr"
-version = "0.0.25"
+version = "0.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75e214449d107a81daf1453eb46c9314457660509534883e82db6faca2034a8a"
+checksum = "dcc7fe48e34d02a97bc8e6253b8b91e5a47fe2c47eaacb5149cefbb69922eaf0"
 dependencies = [
  "ahash",
  "annotate-snippets",
  "base64",
  "encoding_rs_io",
  "getrandom 0.3.4",
+ "granit-parser",
  "nohash-hasher",
  "num-traits",
- "saphyr-parser-bw",
  "serde",
  "smallvec",
  "zmij",

--- a/crates/riri-pnpm/Cargo.toml
+++ b/crates/riri-pnpm/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 [dependencies]
 riri-common = { workspace = true }
 serde = { workspace = true }
-serde-saphyr = "0.0.25"
+serde-saphyr = "0.0.26"
 thiserror = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary

- Bumps `serde-saphyr` from 0.0.25 to 0.0.26 (continuation of the `serde_yml` → `serde-saphyr` migration; pure-Rust YAML deserializer).
- Brings in upstream `granit-parser v0.0.2` replacing `saphyr-parser-bw v0.0.611`.

## Test plan

- [x] `cargo test -p riri-pnpm`
- [x] `cargo clippy -p riri-pnpm --all-targets -- -D warnings`