### PR TITLE
feat(nce): add policy module for engines.node lifecycle rewrite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1411,6 +1411,7 @@ name = "riri-nce"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
  "comfy-table",
  "console",
@@ -1418,11 +1419,13 @@ dependencies = [
  "dhat",
  "insta",
  "riri-common",
+ "riri-node-lifecycle",
  "riri-npm",
  "riri-pnpm",
  "riri-semver-range",
  "riri-task-runner",
  "riri-yarn",
+ "semver",
  "serde_json",
  "tempfile",
  "thiserror",

--- a/crates/riri-nce/Cargo.toml
+++ b/crates/riri-nce/Cargo.toml
@@ -7,15 +7,18 @@ license.workspace = true
 
 [dependencies]
 riri-common = { workspace = true, features = ["sort"] }
+riri-node-lifecycle = { workspace = true }
 riri-npm = { workspace = true }
 riri-pnpm = { workspace = true }
 riri-semver-range = { workspace = true }
 riri-yarn = { workspace = true }
 riri-task-runner = { workspace = true }
 anyhow = { workspace = true }
+chrono = { workspace = true }
 clap = { workspace = true }
 comfy-table = { workspace = true }
 console = { workspace = true }
+semver = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 

--- a/crates/riri-nce/src/lib.rs
+++ b/crates/riri-nce/src/lib.rs
@@ -4,6 +4,7 @@
 //! dependency entries and compares them against the project's `package.json`.
 
 mod compute;
+mod lifecycle;
 mod mutate;
 mod npm_bump;
 mod policy;
@@ -12,6 +13,7 @@ pub use compute::{
     CheckEnginesInput, CheckEnginesOutput, EngineRangeToSet, check_engines,
     compute_engines_constraint, get_constraint_from_engines,
 };
+pub use lifecycle::{LifecycleConfig, LifecycleOutput, check_engines_with_lifecycle};
 pub use mutate::{apply_engines_to_lockfile, apply_engines_update};
 pub use npm_bump::{NpmBumpError, NpmBumpResult, derive_npm_floor, maybe_bump_npm};
 pub use policy::{EolWarning, PolicyContext, PolicyResult, RewriteError, rewrite_node_range};

--- a/crates/riri-nce/src/lib.rs
+++ b/crates/riri-nce/src/lib.rs
@@ -5,9 +5,11 @@
 
 mod compute;
 mod mutate;
+mod policy;
 
 pub use compute::{
     CheckEnginesInput, CheckEnginesOutput, EngineRangeToSet, check_engines,
     compute_engines_constraint, get_constraint_from_engines,
 };
 pub use mutate::{apply_engines_to_lockfile, apply_engines_update};
+pub use policy::{EolWarning, PolicyContext, PolicyResult, RewriteError, rewrite_node_range};

--- a/crates/riri-nce/src/lib.rs
+++ b/crates/riri-nce/src/lib.rs
@@ -5,6 +5,7 @@
 
 mod compute;
 mod mutate;
+mod npm_bump;
 mod policy;
 
 pub use compute::{
@@ -12,4 +13,5 @@ pub use compute::{
     compute_engines_constraint, get_constraint_from_engines,
 };
 pub use mutate::{apply_engines_to_lockfile, apply_engines_update};
+pub use npm_bump::{NpmBumpError, NpmBumpResult, derive_npm_floor, maybe_bump_npm};
 pub use policy::{EolWarning, PolicyContext, PolicyResult, RewriteError, rewrite_node_range};

--- a/crates/riri-nce/src/lifecycle.rs
+++ b/crates/riri-nce/src/lifecycle.rs
@@ -1,0 +1,342 @@
+//! Lifecycle pipeline pass on top of [`check_engines`].
+//!
+//! Wraps [`check_engines`] with two extra steps:
+//!   1. Rewrite `engines.node` under a [`Policy`] gate.
+//!   2. Optionally bump `engines.npm` to the floor required by the rewritten node range.
+
+use crate::compute::{CheckEnginesInput, CheckEnginesOutput, EngineRangeToSet, check_engines};
+use crate::npm_bump::{NpmBumpResult, derive_npm_floor, maybe_bump_npm};
+use crate::policy::{EolWarning, PolicyContext, PolicyResult, RewriteError, rewrite_node_range};
+use chrono::{DateTime, NaiveDate, Utc};
+use riri_common::EngineConstraintKey;
+use riri_node_lifecycle::{LifecycleData, Policy};
+
+#[derive(Debug, Clone)]
+pub struct LifecycleConfig<'a> {
+    pub data: &'a LifecycleData,
+    pub policy: Policy,
+    pub today: NaiveDate,
+    pub allow_eol: bool,
+    pub bump_npm: bool,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct LifecycleOutput {
+    pub policy: Option<Policy>,
+    pub data_fetched_at: Option<DateTime<Utc>>,
+    pub warnings: Vec<EolWarning>,
+    pub dropped_disjuncts: Vec<String>,
+    pub bumped_disjuncts: Vec<(String, String)>,
+    pub unsatisfiable: bool,
+    pub npm_bump: Option<NpmBumpResult>,
+}
+
+/// Runs [`check_engines`] then applies the lifecycle pass and (optionally) the
+/// npm coupling pass.
+///
+/// # Errors
+///
+/// Returns [`RewriteError`] when the rewritten node range fails to parse.
+pub fn check_engines_with_lifecycle(
+    input: &CheckEnginesInput<'_>,
+    cfg: &LifecycleConfig<'_>,
+) -> Result<(CheckEnginesOutput, LifecycleOutput), RewriteError> {
+    let mut output = check_engines(input);
+    let mut lifecycle = LifecycleOutput {
+        policy: Some(cfg.policy),
+        data_fetched_at: Some(cfg.data.fetched_at),
+        ..LifecycleOutput::default()
+    };
+
+    let node_to = output
+        .computed_engines
+        .get(&EngineConstraintKey::Node)
+        .cloned();
+    if let Some(node_to) = node_to {
+        let ctx = PolicyContext {
+            data: cfg.data,
+            policy: cfg.policy,
+            today: cfg.today,
+            allow_eol: cfg.allow_eol,
+            precision: input.precision,
+        };
+        let pr = rewrite_node_range(&node_to, &ctx)?;
+        apply_policy_result(&pr, &node_to, &mut output, input);
+        lifecycle.warnings = pr.eol_warnings;
+        lifecycle.dropped_disjuncts = pr.dropped_disjuncts;
+        lifecycle.bumped_disjuncts = pr.bumped_disjuncts;
+        lifecycle.unsatisfiable = pr.unsatisfiable;
+    }
+
+    if cfg.bump_npm
+        && let Some(node_final) = output
+            .computed_engines
+            .get(&EngineConstraintKey::Node)
+            .cloned()
+        && let Ok(target) = derive_npm_floor(&node_final, cfg.data, input.precision)
+    {
+        let declared = output
+            .computed_engines
+            .get(&EngineConstraintKey::Npm)
+            .cloned();
+        let bump = maybe_bump_npm(declared.as_deref(), &target);
+        if bump.apply {
+            let new_npm = format!(">={}", bump.target_floor);
+            apply_npm_bump(&new_npm, &mut output, input);
+        }
+        lifecycle.npm_bump = Some(bump);
+    }
+
+    Ok((output, lifecycle))
+}
+
+fn apply_policy_result(
+    pr: &PolicyResult,
+    previous_node: &str,
+    output: &mut CheckEnginesOutput,
+    input: &CheckEnginesInput<'_>,
+) {
+    let Some(rewritten) = pr.rewritten.clone() else {
+        return;
+    };
+    if rewritten == previous_node {
+        return;
+    }
+    output
+        .computed_engines
+        .insert(EngineConstraintKey::Node, rewritten.clone());
+    upsert_change(
+        &mut output.engines_range_to_set,
+        EngineConstraintKey::Node,
+        original_from(input, EngineConstraintKey::Node),
+        rewritten,
+    );
+}
+
+fn apply_npm_bump(new_npm: &str, output: &mut CheckEnginesOutput, input: &CheckEnginesInput<'_>) {
+    output
+        .computed_engines
+        .insert(EngineConstraintKey::Npm, new_npm.to_string());
+    upsert_change(
+        &mut output.engines_range_to_set,
+        EngineConstraintKey::Npm,
+        original_from(input, EngineConstraintKey::Npm),
+        new_npm.to_string(),
+    );
+}
+
+fn original_from(input: &CheckEnginesInput<'_>, key: EngineConstraintKey) -> String {
+    input
+        .package_engines
+        .and_then(|pkg| pkg.get(&key.to_string()).cloned())
+        .unwrap_or_else(|| "*".to_string())
+}
+
+fn upsert_change(
+    list: &mut Vec<EngineRangeToSet>,
+    key: EngineConstraintKey,
+    from: String,
+    new_to: String,
+) {
+    if let Some(existing) = list.iter_mut().find(|e| e.engine == key) {
+        existing.range_to_set = new_to;
+    } else if from != new_to {
+        list.push(EngineRangeToSet {
+            engine: key,
+            range: from,
+            range_to_set: new_to,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use riri_semver_range::VersionPrecision;
+    use std::collections::HashMap;
+
+    fn fixture() -> LifecycleData {
+        let json = r#"{
+            "schema_version": 1,
+            "fetched_at": "2026-04-29T00:00:00Z",
+            "majors": {
+                "18": {
+                    "major": 18, "status": "end-of-life", "lts_codename": "Hydrogen",
+                    "start": "2022-04-19", "lts_start": "2022-10-25",
+                    "maintenance_start": "2023-10-18", "end": "2025-04-30",
+                    "lowest": "18.0.0", "highest": "18.20.5",
+                    "npm_at_lowest": "8.5.0", "npm_at_highest": "10.8.2",
+                    "npm_min_in_major": "8.5.0",
+                    "releases": [{"version": "18.0.0", "npm": "8.5.0", "date": "2022-04-19"}]
+                },
+                "20": {
+                    "major": 20, "status": "maintenance", "lts_codename": "Iron",
+                    "start": "2023-04-18", "lts_start": "2023-10-24",
+                    "maintenance_start": "2024-10-22", "end": "2026-04-30",
+                    "lowest": "20.0.0", "highest": "20.19.5",
+                    "npm_at_lowest": "9.6.4", "npm_at_highest": "10.8.2",
+                    "npm_min_in_major": "9.6.4",
+                    "releases": [{"version": "20.0.0", "npm": "9.6.4", "date": "2023-04-18"}]
+                },
+                "22": {
+                    "major": 22, "status": "active", "lts_codename": "Jod",
+                    "start": "2024-04-24", "lts_start": "2024-10-29",
+                    "maintenance_start": "2026-10-21", "end": "2027-04-30",
+                    "lowest": "22.0.0", "highest": "22.12.0",
+                    "npm_at_lowest": "10.5.1", "npm_at_highest": "10.9.1",
+                    "npm_min_in_major": "10.5.1",
+                    "releases": [{"version": "22.0.0", "npm": "10.5.1", "date": "2024-04-24"}]
+                }
+            }
+        }"#;
+        let mut data = LifecycleData::parse(json).expect("parse");
+        data.resolve_statuses(NaiveDate::from_ymd_opt(2026, 4, 29).expect("date"));
+        data
+    }
+
+    fn pkg_engines(node: Option<&str>, npm: Option<&str>) -> HashMap<String, String> {
+        let mut map = HashMap::new();
+        if let Some(n) = node {
+            map.insert("node".into(), n.to_string());
+        }
+        if let Some(n) = npm {
+            map.insert("npm".into(), n.to_string());
+        }
+        map
+    }
+
+    fn cfg(data: &LifecycleData, policy: Policy, bump_npm: bool) -> LifecycleConfig<'_> {
+        LifecycleConfig {
+            data,
+            policy,
+            today: NaiveDate::from_ymd_opt(2026, 4, 29).expect("date"),
+            allow_eol: false,
+            bump_npm,
+        }
+    }
+
+    #[test]
+    fn lifecycle_lifts_eol_node_lower_bound_under_supported() {
+        let data = fixture();
+        let pkg = pkg_engines(Some(">=18.0.0"), None);
+        let input = CheckEnginesInput {
+            lockfile_entries: Vec::new(),
+            package_engines: Some(&pkg),
+            filter_engines: vec![EngineConstraintKey::Node],
+            precision: VersionPrecision::Major,
+        };
+        let (output, lifecycle) =
+            check_engines_with_lifecycle(&input, &cfg(&data, Policy::Supported, false))
+                .expect("lifecycle");
+
+        assert_eq!(output.computed_engines[&EngineConstraintKey::Node], ">=20");
+        assert!(lifecycle.warnings.is_empty());
+        assert_eq!(
+            lifecycle.bumped_disjuncts,
+            vec![(">=18".to_string(), ">=20".to_string())]
+        );
+    }
+
+    #[test]
+    fn lifecycle_bumps_npm_floor_to_match_node_under_supported() {
+        let data = fixture();
+        let pkg = pkg_engines(Some(">=20.0.0"), Some(">=8.0.0"));
+        let input = CheckEnginesInput {
+            lockfile_entries: Vec::new(),
+            package_engines: Some(&pkg),
+            filter_engines: vec![EngineConstraintKey::Node, EngineConstraintKey::Npm],
+            precision: VersionPrecision::Major,
+        };
+        let (output, lifecycle) =
+            check_engines_with_lifecycle(&input, &cfg(&data, Policy::Supported, true))
+                .expect("lifecycle");
+
+        // node>=20 → npm floor = 9.6.4 (npm_min_in_major for 20). Declared 8.0.0 < 9.6.4 → bump.
+        assert_eq!(
+            output.computed_engines[&EngineConstraintKey::Npm],
+            ">=9.6.4"
+        );
+        let bump = lifecycle.npm_bump.expect("bump");
+        assert!(bump.apply);
+        assert_eq!(bump.target_floor.to_string(), "9.6.4");
+    }
+
+    #[test]
+    fn lifecycle_skips_npm_bump_when_disabled() {
+        let data = fixture();
+        let pkg = pkg_engines(Some(">=20.0.0"), Some(">=8.0.0"));
+        let input = CheckEnginesInput {
+            lockfile_entries: Vec::new(),
+            package_engines: Some(&pkg),
+            filter_engines: vec![EngineConstraintKey::Node, EngineConstraintKey::Npm],
+            precision: VersionPrecision::Major,
+        };
+        let (output, lifecycle) =
+            check_engines_with_lifecycle(&input, &cfg(&data, Policy::Supported, false))
+                .expect("lifecycle");
+
+        // bump_npm=false → npm should remain unchanged at the original ">=8.0.0".
+        assert_eq!(output.computed_engines[&EngineConstraintKey::Npm], ">=8");
+        assert!(lifecycle.npm_bump.is_none());
+    }
+
+    #[test]
+    fn lifecycle_emits_eol_warning_under_any() {
+        let data = fixture();
+        let pkg = pkg_engines(Some("^18.0.0"), None);
+        let input = CheckEnginesInput {
+            lockfile_entries: Vec::new(),
+            package_engines: Some(&pkg),
+            filter_engines: vec![EngineConstraintKey::Node],
+            precision: VersionPrecision::Major,
+        };
+        let (_output, lifecycle) =
+            check_engines_with_lifecycle(&input, &cfg(&data, Policy::Any, false))
+                .expect("lifecycle");
+
+        assert_eq!(lifecycle.warnings.len(), 1);
+        assert_eq!(lifecycle.warnings[0].major, 18);
+    }
+
+    #[test]
+    fn lifecycle_marks_unsatisfiable_when_all_disjuncts_dropped() {
+        let data = fixture();
+        let pkg = pkg_engines(Some("^18.0.0"), None);
+        let input = CheckEnginesInput {
+            lockfile_entries: Vec::new(),
+            package_engines: Some(&pkg),
+            filter_engines: vec![EngineConstraintKey::Node],
+            precision: VersionPrecision::Major,
+        };
+        let (_output, lifecycle) =
+            check_engines_with_lifecycle(&input, &cfg(&data, Policy::Lts, false))
+                .expect("lifecycle");
+
+        assert!(lifecycle.unsatisfiable);
+        assert_eq!(lifecycle.dropped_disjuncts, vec!["^18".to_string()]);
+    }
+
+    #[test]
+    fn lifecycle_passes_through_when_node_already_complies() {
+        let data = fixture();
+        let pkg = pkg_engines(Some("^22.0.0"), Some(">=11.0.0"));
+        let input = CheckEnginesInput {
+            lockfile_entries: Vec::new(),
+            package_engines: Some(&pkg),
+            filter_engines: vec![EngineConstraintKey::Node, EngineConstraintKey::Npm],
+            precision: VersionPrecision::Major,
+        };
+        let (output, lifecycle) =
+            check_engines_with_lifecycle(&input, &cfg(&data, Policy::Lts, true))
+                .expect("lifecycle");
+
+        // node ^22 already allowed under Lts → no rewrite. npm ^11 already above floor 10.5.1.
+        assert!(lifecycle.bumped_disjuncts.is_empty());
+        assert!(lifecycle.dropped_disjuncts.is_empty());
+        let bump = lifecycle.npm_bump.expect("bump");
+        assert!(!bump.apply);
+        // engines_range_to_set may still include normalization differences, but the node
+        // computed value should be the unchanged caret form.
+        assert_eq!(output.computed_engines[&EngineConstraintKey::Node], "^22");
+    }
+}

--- a/crates/riri-nce/src/npm_bump.rs
+++ b/crates/riri-nce/src/npm_bump.rs
@@ -1,0 +1,241 @@
+//! npm engine floor derivation from a node engine range.
+//!
+//! Derives the lowest npm version compatible with every OR-disjunct of an
+//! `engines.node` range, then decides whether the project's declared
+//! `engines.npm` constraint needs to be bumped.
+
+use riri_node_lifecycle::LifecycleData;
+use riri_semver_range::{ParsedRange, VersionPrecision};
+use semver::Version;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum NpmBumpError {
+    #[error("invalid node range: {0}")]
+    InvalidNodeRange(String),
+    #[error("no disjunct of node range maps to a known npm version")]
+    NoUsableDisjunct,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NpmBumpResult {
+    pub target_floor: Version,
+    pub apply: bool,
+    pub reason: String,
+}
+
+/// Computes the conservative npm floor for `node_range` under `data`.
+///
+/// For each OR-disjunct, the lower bound version `(M, m, p)` is mapped to npm:
+///   1. Exact release `M.m.p` known → its bundled npm.
+///   2. Else `data.majors[M].npm_min_in_major` (conservative).
+///
+/// The minimum across all disjuncts is the floor. `precision` is currently
+/// unused at the type level (the returned `Version` is always 3-component) and
+/// is reserved for future display-time trimming via the humanize layer.
+///
+/// # Errors
+///
+/// Returns [`NpmBumpError::InvalidNodeRange`] when `node_range` does not parse,
+/// and [`NpmBumpError::NoUsableDisjunct`] when no disjunct maps to known npm
+/// data (e.g. all majors absent from `data`).
+pub fn derive_npm_floor(
+    node_range: &str,
+    data: &LifecycleData,
+    _precision: VersionPrecision,
+) -> Result<Version, NpmBumpError> {
+    let parsed = ParsedRange::parse(node_range).map_err(NpmBumpError::InvalidNodeRange)?;
+
+    let mut floor: Option<Version> = None;
+    for part in &parsed.parts {
+        let Ok(major) = u32::try_from(part.min.major) else {
+            continue;
+        };
+        let Some(info) = data.majors.get(&major) else {
+            continue;
+        };
+        let candidate = info
+            .releases
+            .iter()
+            .find(|r| r.version == part.min)
+            .map_or_else(|| info.npm_min_in_major.clone(), |r| r.npm.clone());
+        floor = Some(match floor {
+            Some(f) if f < candidate => f,
+            _ => candidate,
+        });
+    }
+
+    floor.ok_or(NpmBumpError::NoUsableDisjunct)
+}
+
+/// Decides whether the declared npm range needs to be bumped to clear `target`.
+///
+/// `declared_npm` is the existing `engines.npm` range string from `package.json`,
+/// or `None` when absent. The comparison takes the parsed declared range's
+/// lowest lower bound and compares against `target`.
+///
+/// A `declared_npm` that fails to parse is treated as "no declared npm" — the
+/// caller will overwrite it with the bumped value.
+#[must_use]
+pub fn maybe_bump_npm(declared_npm: Option<&str>, target: &Version) -> NpmBumpResult {
+    let declared_lower = declared_npm.and_then(|s| {
+        ParsedRange::parse(s)
+            .ok()
+            .and_then(|p| p.parts.first().map(|first| first.min.clone()))
+    });
+
+    match declared_lower {
+        None => NpmBumpResult {
+            target_floor: target.clone(),
+            apply: true,
+            reason: format!("declared npm missing; setting floor to {target}"),
+        },
+        Some(declared) if declared < *target => NpmBumpResult {
+            target_floor: target.clone(),
+            apply: true,
+            reason: format!("declared npm {declared} below floor {target}"),
+        },
+        Some(declared) => NpmBumpResult {
+            target_floor: target.clone(),
+            apply: false,
+            reason: format!("declared npm {declared} already meets floor {target}"),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use riri_node_lifecycle::LifecycleData;
+
+    fn fixture() -> LifecycleData {
+        let json = r#"{
+            "schema_version": 1,
+            "fetched_at": "2026-04-29T00:00:00Z",
+            "majors": {
+                "20": {
+                    "major": 20, "status": "maintenance", "lts_codename": "Iron",
+                    "start": "2023-04-18", "lts_start": "2023-10-24",
+                    "maintenance_start": "2024-10-22", "end": "2026-04-30",
+                    "lowest": "20.0.0", "highest": "20.19.5",
+                    "npm_at_lowest": "9.6.4", "npm_at_highest": "10.8.2",
+                    "npm_min_in_major": "9.6.4",
+                    "releases": [
+                        {"version": "20.0.0", "npm": "9.6.4", "date": "2023-04-18"},
+                        {"version": "20.19.5", "npm": "10.8.2", "date": "2025-09-15"}
+                    ]
+                },
+                "22": {
+                    "major": 22, "status": "active", "lts_codename": "Jod",
+                    "start": "2024-04-24", "lts_start": "2024-10-29",
+                    "maintenance_start": "2026-10-21", "end": "2027-04-30",
+                    "lowest": "22.0.0", "highest": "22.12.0",
+                    "npm_at_lowest": "10.5.1", "npm_at_highest": "10.9.1",
+                    "npm_min_in_major": "10.5.1",
+                    "releases": [
+                        {"version": "22.0.0", "npm": "10.5.1", "date": "2024-04-24"},
+                        {"version": "22.12.0", "npm": "10.9.1", "date": "2024-12-03"}
+                    ]
+                }
+            }
+        }"#;
+        LifecycleData::parse(json).expect("parse fixture")
+    }
+
+    fn v(s: &str) -> Version {
+        Version::parse(s).expect("semver")
+    }
+
+    #[test]
+    fn floor_for_single_caret_uses_lowest_npm_in_major() {
+        let data = fixture();
+        let floor = derive_npm_floor("^20.0.0", &data, VersionPrecision::Major).expect("floor");
+        assert_eq!(floor, v("9.6.4"));
+    }
+
+    #[test]
+    fn floor_for_exact_match_uses_release_npm() {
+        let data = fixture();
+        let floor = derive_npm_floor(">=22.12.0", &data, VersionPrecision::Major).expect("floor");
+        assert_eq!(floor, v("10.9.1"));
+    }
+
+    #[test]
+    fn floor_for_unknown_release_falls_back_to_npm_min_in_major() {
+        let data = fixture();
+        // 22.5.0 is not in the releases list — fall back to npm_min_in_major (10.5.1).
+        let floor = derive_npm_floor(">=22.5.0", &data, VersionPrecision::Major).expect("floor");
+        assert_eq!(floor, v("10.5.1"));
+    }
+
+    #[test]
+    fn floor_across_disjuncts_takes_minimum() {
+        let data = fixture();
+        // ^20: 9.6.4 ; ^22: 10.5.1 → min = 9.6.4
+        let floor =
+            derive_npm_floor("^20.0.0 || ^22.0.0", &data, VersionPrecision::Major).expect("floor");
+        assert_eq!(floor, v("9.6.4"));
+    }
+
+    #[test]
+    fn floor_skips_unknown_majors_silently() {
+        let data = fixture();
+        // 18 is missing from fixture — skip; 20 contributes 9.6.4.
+        let floor =
+            derive_npm_floor("^18.0.0 || ^20.0.0", &data, VersionPrecision::Major).expect("floor");
+        assert_eq!(floor, v("9.6.4"));
+    }
+
+    #[test]
+    fn floor_errors_when_no_disjunct_has_data() {
+        let data = fixture();
+        let err = derive_npm_floor("^14.0.0 || ^16.0.0", &data, VersionPrecision::Major)
+            .expect_err("no usable disjunct");
+        assert!(matches!(err, NpmBumpError::NoUsableDisjunct));
+    }
+
+    #[test]
+    fn floor_errors_on_invalid_range() {
+        let data = fixture();
+        let err = derive_npm_floor("not a range", &data, VersionPrecision::Major)
+            .expect_err("invalid range");
+        assert!(matches!(err, NpmBumpError::InvalidNodeRange(_)));
+    }
+
+    #[test]
+    fn maybe_bump_returns_apply_when_declared_npm_missing() {
+        let target = v("10.5.1");
+        let result = maybe_bump_npm(None, &target);
+        assert!(result.apply);
+        assert_eq!(result.target_floor, target);
+    }
+
+    #[test]
+    fn maybe_bump_returns_apply_when_declared_below_target() {
+        let target = v("10.5.1");
+        let result = maybe_bump_npm(Some(">=9.0.0"), &target);
+        assert!(result.apply);
+        assert_eq!(result.target_floor, target);
+    }
+
+    #[test]
+    fn maybe_bump_returns_no_apply_when_declared_meets_target() {
+        let target = v("10.5.1");
+        let result = maybe_bump_npm(Some(">=10.5.1"), &target);
+        assert!(!result.apply);
+    }
+
+    #[test]
+    fn maybe_bump_returns_no_apply_when_declared_exceeds_target() {
+        let target = v("10.5.1");
+        let result = maybe_bump_npm(Some(">=11.0.0"), &target);
+        assert!(!result.apply);
+    }
+
+    #[test]
+    fn maybe_bump_with_unparseable_declared_npm_treats_as_missing() {
+        let target = v("10.5.1");
+        let result = maybe_bump_npm(Some("garbage"), &target);
+        assert!(result.apply);
+    }
+}

--- a/crates/riri-nce/src/policy.rs
+++ b/crates/riri-nce/src/policy.rs
@@ -1,0 +1,389 @@
+//! Lifecycle-policy rewrite of `engines.node` ranges.
+//!
+//! Given a parsed [`LifecycleData`] snapshot already resolved against `today`,
+//! [`rewrite_node_range`] applies a [`Policy`] gate to each `||`-separated
+//! disjunct of an input range and returns a rewritten range plus a structured
+//! breakdown of dropped, bumped, and EOL-flagged disjuncts.
+
+use chrono::NaiveDate;
+use riri_node_lifecycle::{LifecycleData, Policy, Status};
+use riri_semver_range::{Op, ParsedRange, RangePart, VersionPrecision, split_by_major};
+use semver::Version;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum RewriteError {
+    #[error("invalid semver range: {0}")]
+    Parse(String),
+}
+
+#[derive(Debug, Clone)]
+pub struct PolicyContext<'a> {
+    pub data: &'a LifecycleData,
+    pub policy: Policy,
+    pub today: NaiveDate,
+    pub allow_eol: bool,
+    pub precision: VersionPrecision,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EolWarning {
+    pub major: u32,
+    pub since: NaiveDate,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PolicyResult {
+    pub rewritten: Option<String>,
+    pub dropped_disjuncts: Vec<String>,
+    pub bumped_disjuncts: Vec<(String, String)>,
+    pub eol_warnings: Vec<EolWarning>,
+    pub unsatisfiable: bool,
+}
+
+/// Rewrites `range` under the given lifecycle policy.
+///
+/// `ctx.data` MUST have been resolved against `ctx.today` (e.g. via
+/// [`LifecycleData::resolve_statuses`] or [`LifecycleData::load_with_cache_override`]).
+///
+/// # Errors
+///
+/// Returns [`RewriteError::Parse`] when `range` is not a valid semver range.
+pub fn rewrite_node_range(
+    range: &str,
+    ctx: &PolicyContext<'_>,
+) -> Result<PolicyResult, RewriteError> {
+    let parsed = ParsedRange::parse(range).map_err(RewriteError::Parse)?;
+    let allowed = ctx.data.allowed_majors(ctx.policy);
+
+    let mut new_parts: Vec<RangePart> = Vec::new();
+    let mut dropped: Vec<String> = Vec::new();
+    let mut bumped: Vec<(String, String)> = Vec::new();
+
+    for input_part in &parsed.parts {
+        let original = humanize_part(input_part, ctx.precision);
+        let contributions = if is_wildcard(input_part) {
+            allowed.iter().copied().map(caret_from_major).collect()
+        } else {
+            filter_split(input_part, &allowed)
+        };
+
+        if contributions.is_empty() {
+            dropped.push(original);
+            continue;
+        }
+
+        let baseline = if is_wildcard(input_part) {
+            Vec::new()
+        } else {
+            split_by_major(input_part)
+        };
+        if contributions != baseline {
+            let rewritten_part = humanize_parts(&contributions, ctx.precision);
+            bumped.push((original, rewritten_part));
+        }
+        new_parts.extend(contributions);
+    }
+
+    if new_parts.is_empty() {
+        return Ok(PolicyResult {
+            rewritten: None,
+            dropped_disjuncts: dropped,
+            bumped_disjuncts: bumped,
+            eol_warnings: Vec::new(),
+            unsatisfiable: true,
+        });
+    }
+
+    let mut eol_warnings: Vec<EolWarning> = Vec::new();
+    if !ctx.allow_eol {
+        for part in &new_parts {
+            let Ok(major) = u32::try_from(part.min.major) else {
+                continue;
+            };
+            if let Some(info) = ctx.data.majors.get(&major)
+                && info.status == Status::EndOfLife
+                && !eol_warnings.iter().any(|w| w.major == major)
+            {
+                eol_warnings.push(EolWarning {
+                    major,
+                    since: info.end,
+                });
+            }
+        }
+    }
+
+    let rebuilt = ParsedRange { parts: new_parts };
+    let rewritten = rebuilt.humanize_with(ctx.precision);
+
+    Ok(PolicyResult {
+        rewritten: Some(rewritten),
+        dropped_disjuncts: dropped,
+        bumped_disjuncts: bumped,
+        eol_warnings,
+        unsatisfiable: false,
+    })
+}
+
+fn filter_split(input_part: &RangePart, allowed: &[u32]) -> Vec<RangePart> {
+    if input_part.max.is_none() {
+        let Ok(min_major) = u32::try_from(input_part.min.major) else {
+            return Vec::new();
+        };
+        let Some(smallest) = allowed.iter().copied().find(|&m| m >= min_major) else {
+            return Vec::new();
+        };
+        if smallest == min_major {
+            return vec![input_part.clone()];
+        }
+        return vec![RangePart {
+            min: Version::new(u64::from(smallest), 0, 0),
+            min_op: Op::Gte,
+            max: None,
+            max_op: None,
+        }];
+    }
+
+    split_by_major(input_part)
+        .into_iter()
+        .filter(|sub| {
+            u32::try_from(sub.min.major)
+                .ok()
+                .is_some_and(|m| allowed.contains(&m))
+        })
+        .collect()
+}
+
+fn is_wildcard(part: &RangePart) -> bool {
+    part.max.is_none()
+        && part.min_op == Op::Gte
+        && part.min.major == 0
+        && part.min.minor == 0
+        && part.min.patch == 0
+}
+
+fn caret_from_major(m: u32) -> RangePart {
+    RangePart {
+        min: Version::new(u64::from(m), 0, 0),
+        min_op: Op::Gte,
+        max: Some(Version::new(u64::from(m) + 1, 0, 0)),
+        max_op: Some(Op::Lt),
+    }
+}
+
+fn humanize_part(part: &RangePart, precision: VersionPrecision) -> String {
+    ParsedRange {
+        parts: vec![part.clone()],
+    }
+    .humanize_with(precision)
+}
+
+fn humanize_parts(parts: &[RangePart], precision: VersionPrecision) -> String {
+    ParsedRange {
+        parts: parts.to_vec(),
+    }
+    .humanize_with(precision)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use riri_node_lifecycle::LifecycleData;
+
+    fn fixture() -> LifecycleData {
+        let json = r#"{
+            "schema_version": 1,
+            "fetched_at": "2026-04-29T00:00:00Z",
+            "majors": {
+                "18": {
+                    "major": 18, "status": "end-of-life", "lts_codename": "Hydrogen",
+                    "start": "2022-04-19", "lts_start": "2022-10-25",
+                    "maintenance_start": "2023-10-18", "end": "2025-04-30",
+                    "lowest": "18.0.0", "highest": "18.20.5",
+                    "npm_at_lowest": "8.5.0", "npm_at_highest": "10.8.2",
+                    "npm_min_in_major": "8.5.0",
+                    "releases": [{"version": "18.0.0", "npm": "8.5.0", "date": "2022-04-19"}]
+                },
+                "20": {
+                    "major": 20, "status": "maintenance", "lts_codename": "Iron",
+                    "start": "2023-04-18", "lts_start": "2023-10-24",
+                    "maintenance_start": "2024-10-22", "end": "2026-04-30",
+                    "lowest": "20.0.0", "highest": "20.19.5",
+                    "npm_at_lowest": "9.6.4", "npm_at_highest": "10.8.2",
+                    "npm_min_in_major": "9.6.4",
+                    "releases": [{"version": "20.0.0", "npm": "9.6.4", "date": "2023-04-18"}]
+                },
+                "22": {
+                    "major": 22, "status": "active", "lts_codename": "Jod",
+                    "start": "2024-04-24", "lts_start": "2024-10-29",
+                    "maintenance_start": "2026-10-21", "end": "2027-04-30",
+                    "lowest": "22.0.0", "highest": "22.12.0",
+                    "npm_at_lowest": "10.5.1", "npm_at_highest": "10.9.1",
+                    "npm_min_in_major": "10.5.1",
+                    "releases": [{"version": "22.0.0", "npm": "10.5.1", "date": "2024-04-24"}]
+                },
+                "23": {
+                    "major": 23, "status": "end-of-life", "lts_codename": null,
+                    "start": "2024-10-15", "lts_start": null, "maintenance_start": null,
+                    "end": "2025-06-01", "lowest": "23.0.0", "highest": "23.11.1",
+                    "npm_at_lowest": "10.9.0", "npm_at_highest": "10.9.2",
+                    "npm_min_in_major": "10.9.0",
+                    "releases": [{"version": "23.0.0", "npm": "10.9.0", "date": "2024-10-15"}]
+                },
+                "24": {
+                    "major": 24, "status": "active", "lts_codename": "Krypton",
+                    "start": "2025-04-22", "lts_start": "2025-10-28",
+                    "maintenance_start": "2027-10-20", "end": "2028-04-30",
+                    "lowest": "24.0.0", "highest": "24.6.0",
+                    "npm_at_lowest": "11.0.0", "npm_at_highest": "11.5.1",
+                    "npm_min_in_major": "11.0.0",
+                    "releases": [{"version": "24.0.0", "npm": "11.0.0", "date": "2025-04-22"}]
+                },
+                "25": {
+                    "major": 25, "status": "current", "lts_codename": null,
+                    "start": "2025-10-21", "lts_start": null, "maintenance_start": null,
+                    "end": "2026-06-01", "lowest": "25.0.0", "highest": "25.2.0",
+                    "npm_at_lowest": "11.5.0", "npm_at_highest": "11.5.1",
+                    "npm_min_in_major": "11.5.0",
+                    "releases": [{"version": "25.0.0", "npm": "11.5.0", "date": "2025-10-21"}]
+                }
+            }
+        }"#;
+        let mut data = LifecycleData::parse(json).expect("parse fixture");
+        data.resolve_statuses(NaiveDate::from_ymd_opt(2026, 4, 29).expect("date"));
+        data
+    }
+
+    fn ctx(data: &LifecycleData, policy: Policy) -> PolicyContext<'_> {
+        PolicyContext {
+            data,
+            policy,
+            today: NaiveDate::from_ymd_opt(2026, 4, 29).expect("date"),
+            allow_eol: false,
+            precision: VersionPrecision::Major,
+        }
+    }
+
+    #[test]
+    fn fixture_resolves_expected_statuses() {
+        let data = fixture();
+        assert_eq!(data.majors[&18].status, Status::EndOfLife);
+        assert_eq!(data.majors[&20].status, Status::Maintenance);
+        assert_eq!(data.majors[&22].status, Status::Active);
+        assert_eq!(data.majors[&23].status, Status::EndOfLife);
+        assert_eq!(data.majors[&24].status, Status::Active);
+        assert_eq!(data.majors[&25].status, Status::Current);
+    }
+
+    #[test]
+    fn lts_keeps_caret_on_allowed_major_and_lifts_open_lower_bound() {
+        let data = fixture();
+        let result =
+            rewrite_node_range("^20.19.0 || ^22.12.0 || >=23.0.0", &ctx(&data, Policy::Lts))
+                .expect("rewrite");
+        assert_eq!(
+            result.rewritten.as_deref(),
+            Some("^20.19 || ^22.12 || >=24")
+        );
+        assert!(result.dropped_disjuncts.is_empty());
+        assert_eq!(result.bumped_disjuncts.len(), 1);
+        assert_eq!(result.bumped_disjuncts[0].0, ">=23");
+        assert_eq!(result.bumped_disjuncts[0].1, ">=24");
+        assert!(!result.unsatisfiable);
+        assert!(result.eol_warnings.is_empty());
+    }
+
+    #[test]
+    fn supported_drops_caret_on_eol_only_disjunct() {
+        let data = fixture();
+        let result =
+            rewrite_node_range("^18.0.0", &ctx(&data, Policy::Supported)).expect("rewrite");
+        assert!(result.unsatisfiable);
+        assert_eq!(result.rewritten, None);
+        assert_eq!(result.dropped_disjuncts, vec!["^18".to_string()]);
+    }
+
+    #[test]
+    fn any_keeps_eol_caret_and_emits_warning() {
+        let data = fixture();
+        let result = rewrite_node_range("^18.0.0", &ctx(&data, Policy::Any)).expect("rewrite");
+        assert_eq!(result.rewritten.as_deref(), Some("^18"));
+        assert_eq!(result.eol_warnings.len(), 1);
+        assert_eq!(result.eol_warnings[0].major, 18);
+        assert_eq!(
+            result.eol_warnings[0].since,
+            NaiveDate::from_ymd_opt(2025, 4, 30).expect("date")
+        );
+    }
+
+    #[test]
+    fn allow_eol_suppresses_warning_without_widening_policy() {
+        let data = fixture();
+        let mut c = ctx(&data, Policy::Any);
+        c.allow_eol = true;
+        let result = rewrite_node_range("^18.0.0", &c).expect("rewrite");
+        assert_eq!(result.rewritten.as_deref(), Some("^18"));
+        assert!(result.eol_warnings.is_empty());
+    }
+
+    #[test]
+    fn lts_lifts_open_eol_lower_bound() {
+        let data = fixture();
+        let result = rewrite_node_range(">=18.0.0", &ctx(&data, Policy::Lts)).expect("rewrite");
+        assert_eq!(result.rewritten.as_deref(), Some(">=20"));
+        assert_eq!(
+            result.bumped_disjuncts,
+            vec![(">=18".to_string(), ">=20".to_string())]
+        );
+    }
+
+    #[test]
+    fn lts_narrows_compound_bounded_dropping_disallowed_intermediate_majors() {
+        let data = fixture();
+        let result =
+            rewrite_node_range(">=20.0.0 <22.0.0", &ctx(&data, Policy::Lts)).expect("rewrite");
+        // Input spans 20 (Maintenance, allowed) and 21 (no data → not allowed).
+        // Result keeps only the 20 sub-clause.
+        assert_eq!(result.rewritten.as_deref(), Some("^20"));
+        assert!(result.dropped_disjuncts.is_empty());
+        // Humanizer always splits cross-major ranges, so the "from" side reflects
+        // the per-major decomposition rather than the literal input.
+        assert_eq!(
+            result.bumped_disjuncts,
+            vec![("^20 || ^21".to_string(), "^20".to_string())]
+        );
+    }
+
+    #[test]
+    fn lts_drops_compound_bounded_with_no_allowed_major_in_range() {
+        let data = fixture();
+        let result =
+            rewrite_node_range(">=23.0.0 <24.0.0", &ctx(&data, Policy::Lts)).expect("rewrite");
+        assert!(result.unsatisfiable);
+        assert_eq!(result.dropped_disjuncts, vec!["^23".to_string()]);
+    }
+
+    #[test]
+    fn lts_expands_wildcard_into_or_of_carets() {
+        let data = fixture();
+        let result = rewrite_node_range("*", &ctx(&data, Policy::Lts)).expect("rewrite");
+        assert_eq!(result.rewritten.as_deref(), Some("^20 || ^22 || ^24"));
+    }
+
+    #[test]
+    fn maintenance_keeps_only_maintenance_majors() {
+        let data = fixture();
+        let result = rewrite_node_range("^20.19.0 || ^22.12.0", &ctx(&data, Policy::Maintenance))
+            .expect("rewrite");
+        assert_eq!(result.rewritten.as_deref(), Some("^20.19"));
+        assert_eq!(result.dropped_disjuncts, vec!["^22.12".to_string()]);
+    }
+
+    #[test]
+    fn parse_error_propagates() {
+        let data = fixture();
+        let err =
+            rewrite_node_range("not a range", &ctx(&data, Policy::Lts)).expect_err("invalid range");
+        assert!(matches!(err, RewriteError::Parse(_)));
+    }
+}

--- a/crates/riri-semver-range/src/lib.rs
+++ b/crates/riri-semver-range/src/lib.rs
@@ -1,9 +1,10 @@
-pub(crate) mod helpers;
+pub mod helpers;
 mod humanize;
 mod intersection;
 mod parse;
 pub(crate) mod subset;
 
+pub use helpers::split_by_major;
 pub use intersection::restrictive_range;
 pub use parse::ParsedRange;
 pub use subset::{intersects, is_subset_of};


### PR DESCRIPTION
## Summary

- New `riri-nce::policy` module: `rewrite_node_range` rewrites a parsed `engines.node` range under a lifecycle `Policy` gate.
- Per-disjunct logic: keep pinned majors that are allowed; drop disjuncts when no allowed major is in range; lift open lower bounds (`>=18` → `>=20` under LTS); split bounded ranges per major and filter; expand wildcards into `^M` per allowed major.
- Returns structured `PolicyResult` with `rewritten`, `dropped_disjuncts`, `bumped_disjuncts`, `eol_warnings`, `unsatisfiable`.
- `riri-semver-range::split_by_major` now publicly re-exported (was crate-internal).

## Test plan

- [x] `cargo test -p riri-nce` — 11 new policy tests pass
- [x] Pre-commit fmt + clippy hooks pass
- [ ] CI verifies on push