### PR TITLE
feat(nce): tighten open lower bound under restrictive policies

### DIFF
--- a/crates/riri-nce/src/lifecycle.rs
+++ b/crates/riri-nce/src/lifecycle.rs
@@ -242,11 +242,14 @@ mod tests {
             check_engines_with_lifecycle(&input, &cfg(&data, Policy::Supported, false))
                 .expect("lifecycle");
 
-        assert_eq!(output.computed_engines[&EngineConstraintKey::Node], ">=20");
+        assert_eq!(
+            output.computed_engines[&EngineConstraintKey::Node],
+            "^20 || >=22"
+        );
         assert!(lifecycle.warnings.is_empty());
         assert_eq!(
             lifecycle.bumped_disjuncts,
-            vec![(">=18".to_string(), ">=20".to_string())]
+            vec![(">=18".to_string(), "^20 || >=22".to_string())]
         );
     }
 

--- a/crates/riri-nce/src/policy.rs
+++ b/crates/riri-nce/src/policy.rs
@@ -63,9 +63,9 @@ pub fn rewrite_node_range(
     for input_part in &parsed.parts {
         let original = humanize_part(input_part, ctx.precision);
         let contributions = if is_wildcard(input_part) {
-            allowed.iter().copied().map(caret_from_major).collect()
+            expand_from_major(0, &allowed, ctx.policy)
         } else {
-            filter_split(input_part, &allowed)
+            filter_split(input_part, &allowed, ctx.policy)
         };
 
         if contributions.is_empty() {
@@ -125,23 +125,26 @@ pub fn rewrite_node_range(
     })
 }
 
-fn filter_split(input_part: &RangePart, allowed: &[u32]) -> Vec<RangePart> {
+fn filter_split(input_part: &RangePart, allowed: &[u32], policy: Policy) -> Vec<RangePart> {
     if input_part.max.is_none() {
         let Ok(min_major) = u32::try_from(input_part.min.major) else {
             return Vec::new();
         };
-        let Some(smallest) = allowed.iter().copied().find(|&m| m >= min_major) else {
-            return Vec::new();
-        };
-        if smallest == min_major {
-            return vec![input_part.clone()];
+        if matches!(policy, Policy::Any | Policy::Stable) {
+            let Some(smallest) = allowed.iter().copied().find(|&m| m >= min_major) else {
+                return Vec::new();
+            };
+            if smallest == min_major {
+                return vec![input_part.clone()];
+            }
+            return vec![RangePart {
+                min: Version::new(u64::from(smallest), 0, 0),
+                min_op: Op::Gte,
+                max: None,
+                max_op: None,
+            }];
         }
-        return vec![RangePart {
-            min: Version::new(u64::from(smallest), 0, 0),
-            min_op: Op::Gte,
-            max: None,
-            max_op: None,
-        }];
+        return expand_from_major(min_major, allowed, policy);
     }
 
     split_by_major(input_part)
@@ -152,6 +155,36 @@ fn filter_split(input_part: &RangePart, allowed: &[u32]) -> Vec<RangePart> {
                 .is_some_and(|m| allowed.contains(&m))
         })
         .collect()
+}
+
+/// Expands `>=min_major.0.0` into the allowed-major caret list under `policy`.
+///
+/// Under `Supported`, the highest allowed caret is replaced with an open `>=M.0.0`
+/// to keep the range forward-compatible with the next current major. Under `Lts` and
+/// `Maintenance`, every contribution stays caret-bounded.
+fn expand_from_major(min_major: u32, allowed: &[u32], policy: Policy) -> Vec<RangePart> {
+    let mut filtered: Vec<u32> = allowed
+        .iter()
+        .copied()
+        .filter(|m| *m >= min_major)
+        .collect();
+    if filtered.is_empty() {
+        return Vec::new();
+    }
+    let keep_open_tail = matches!(policy, Policy::Supported);
+    let last = filtered.pop().expect("non-empty after is_empty check");
+    let mut parts: Vec<RangePart> = filtered.into_iter().map(caret_from_major).collect();
+    if keep_open_tail {
+        parts.push(RangePart {
+            min: Version::new(u64::from(last), 0, 0),
+            min_op: Op::Gte,
+            max: None,
+            max_op: None,
+        });
+    } else {
+        parts.push(caret_from_major(last));
+    }
+    parts
 }
 
 fn is_wildcard(part: &RangePart) -> bool {
@@ -281,14 +314,11 @@ mod tests {
         let result =
             rewrite_node_range("^20.19.0 || ^22.12.0 || >=23.0.0", &ctx(&data, Policy::Lts))
                 .expect("rewrite");
-        assert_eq!(
-            result.rewritten.as_deref(),
-            Some("^20.19 || ^22.12 || >=24")
-        );
+        assert_eq!(result.rewritten.as_deref(), Some("^20.19 || ^22.12 || ^24"));
         assert!(result.dropped_disjuncts.is_empty());
         assert_eq!(result.bumped_disjuncts.len(), 1);
         assert_eq!(result.bumped_disjuncts[0].0, ">=23");
-        assert_eq!(result.bumped_disjuncts[0].1, ">=24");
+        assert_eq!(result.bumped_disjuncts[0].1, "^24");
         assert!(!result.unsatisfiable);
         assert!(result.eol_warnings.is_empty());
     }
@@ -330,10 +360,10 @@ mod tests {
     fn lts_lifts_open_eol_lower_bound() {
         let data = fixture();
         let result = rewrite_node_range(">=18.0.0", &ctx(&data, Policy::Lts)).expect("rewrite");
-        assert_eq!(result.rewritten.as_deref(), Some(">=20"));
+        assert_eq!(result.rewritten.as_deref(), Some("^20 || ^22 || ^24"));
         assert_eq!(
             result.bumped_disjuncts,
-            vec![(">=18".to_string(), ">=20".to_string())]
+            vec![(">=18".to_string(), "^20 || ^22 || ^24".to_string())]
         );
     }
 

--- a/crates/riri-nce/tests/cli_snapshots.rs
+++ b/crates/riri-nce/tests/cli_snapshots.rs
@@ -246,7 +246,10 @@ fn cli_npm_bump_floor() {
 
 #[test]
 fn cli_no_bump_npm_flag() {
-    let (stdout, stderr, code) = run_in_fixture("nce-no-bump-npm-flag", &["-v", "--no-bump-npm"]);
+    let (stdout, stderr, code) = run_in_fixture(
+        "nce-no-bump-npm-flag",
+        &["-v", "--node-policy=any", "--no-bump-npm"],
+    );
     assert_eq!(code, 0);
     assert!(stdout.is_empty());
     insta::assert_snapshot!("no_bump_npm_flag_stderr", stderr);
@@ -357,7 +360,8 @@ fn cli_update_writes_lifecycle_rewrite() {
     let code = output.status.code().unwrap_or(-1);
     assert_eq!(code, 1);
     let written = std::fs::read_to_string(tmp.path().join("package.json")).unwrap();
-    assert!(written.contains("\">=20.0.0\""), "package.json: {written}");
+    assert!(written.contains("^20.0.0"), "package.json: {written}");
+    assert!(written.contains(">=25.0.0"), "package.json: {written}");
     assert!(!written.contains("\">=18.0.0\""), "package.json: {written}");
 }
 
@@ -473,7 +477,8 @@ fn cli_cache_override_takes_precedence_over_bundled() {
     let code = output.status.code().unwrap_or(-1);
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert_eq!(code, 1, "stderr: {stderr}");
-    assert!(stderr.contains(">=20.0.0"), "stderr: {stderr}");
+    assert!(stderr.contains("^20.0.0"), "stderr: {stderr}");
+    assert!(stderr.contains(">=25.0.0"), "stderr: {stderr}");
 }
 
 #[test]

--- a/crates/riri-nce/tests/snapshots/cli_snapshots__bump_npm_overrides_no_bump_stderr.snap
+++ b/crates/riri-nce/tests/snapshots/cli_snapshots__bump_npm_overrides_no_bump_stderr.snap
@@ -10,6 +10,7 @@ expression: stderr
   Parsed lockfile
   Computing engine constraints...
   Computed engine constraints
-  npm  >=8.0.0  →  >=9.6.4
+  node  >=20.0.0  →  ^20.0.0 || ^22.0.0 || ^24.0.0 || >=25.0.0
+  npm   >=8.0.0   →  >=9.6.4
 
   Run nce -v -u to upgrade package.json.

--- a/crates/riri-nce/tests/snapshots/cli_snapshots__npm_bump_floor_stderr.snap
+++ b/crates/riri-nce/tests/snapshots/cli_snapshots__npm_bump_floor_stderr.snap
@@ -10,6 +10,7 @@ expression: stderr
   Parsed lockfile
   Computing engine constraints...
   Computed engine constraints
-  npm  >=8.0.0  →  >=9.6.4
+  node  >=20.0.0  →  ^20.0.0 || ^22.0.0 || ^24.0.0 || >=25.0.0
+  npm   >=8.0.0   →  >=9.6.4
 
   Run nce -v -u to upgrade package.json.

--- a/crates/riri-nce/tests/snapshots/cli_snapshots__npm_engine_filter_verbose_stderr.snap
+++ b/crates/riri-nce/tests/snapshots/cli_snapshots__npm_engine_filter_verbose_stderr.snap
@@ -10,6 +10,6 @@ expression: stderr
   Parsed lockfile
   Computing engine constraints...
   Computed engine constraints
-  node  *  →  >=20.0.0
+  node  *  →  ^20.0.0 || ^22.0.0 || ^24.0.0 || >=25.0.0
 
   Run nce -v -e node -u to upgrade package.json.

--- a/crates/riri-nce/tests/snapshots/cli_snapshots__npm_json_output.snap
+++ b/crates/riri-nce/tests/snapshots/cli_snapshots__npm_json_output.snap
@@ -4,7 +4,7 @@ expression: "serde_json::to_string_pretty(&json).unwrap()"
 ---
 {
   "computed": {
-    "node": ">=20.0.0",
+    "node": "^20.0.0 || ^22.0.0 || ^24.0.0 || >=25.0.0",
     "npm": ">=9.6.4",
     "yarn": "*"
   },
@@ -12,7 +12,7 @@ expression: "serde_json::to_string_pretty(&json).unwrap()"
     {
       "engine": "node",
       "from": "*",
-      "to": ">=20.0.0"
+      "to": "^20.0.0 || ^22.0.0 || ^24.0.0 || >=25.0.0"
     },
     {
       "engine": "npm",
@@ -31,7 +31,7 @@ expression: "serde_json::to_string_pretty(&json).unwrap()"
     "bumped_disjuncts": [
       {
         "from": ">=17.0.0",
-        "to": ">=20.0.0"
+        "to": "^20.0.0 || ^22.0.0 || ^24.0.0 || >=25.0.0"
       }
     ],
     "unsatisfiable": false

--- a/crates/riri-nce/tests/snapshots/cli_snapshots__npm_or_ranges_node_npm_yarn_verbose_stderr.snap
+++ b/crates/riri-nce/tests/snapshots/cli_snapshots__npm_or_ranges_node_npm_yarn_verbose_stderr.snap
@@ -10,7 +10,7 @@ expression: stderr
   Parsed lockfile
   Computing engine constraints...
   Computed engine constraints
-  node  *  →  >=20.0.0
+  node  *  →  ^20.0.0 || ^22.0.0 || ^24.0.0 || >=25.0.0
   npm   *  →  >=9.6.4
   yarn  *  →  ^1.22.4
 

--- a/crates/riri-nce/tests/snapshots/cli_snapshots__npm_or_ranges_node_only_verbose_stderr.snap
+++ b/crates/riri-nce/tests/snapshots/cli_snapshots__npm_or_ranges_node_only_verbose_stderr.snap
@@ -10,7 +10,7 @@ expression: stderr
   Parsed lockfile
   Computing engine constraints...
   Computed engine constraints
-  node  *  →  >=20.0.0
+  node  *  →  ^20.0.0 || ^22.0.0 || ^24.0.0 || >=25.0.0
   npm   *  →  >=9.6.4
 
   Run nce -v -u to upgrade package.json.

--- a/crates/riri-nce/tests/snapshots/cli_snapshots__npm_precision_minor_stderr.snap
+++ b/crates/riri-nce/tests/snapshots/cli_snapshots__npm_precision_minor_stderr.snap
@@ -10,6 +10,7 @@ expression: stderr
   Parsed lockfile
   Computing engine constraints...
   Computed engine constraints
-  npm  *  →  >=11.0
+  node  >=24.0.0  →  ^24.0.0 || >=25.0.0
+  npm   *         →  >=11.0
 
   Run nce -v -u to upgrade package.json.

--- a/crates/riri-nce/tests/snapshots/cli_snapshots__npm_precision_patch_explicit_stderr.snap
+++ b/crates/riri-nce/tests/snapshots/cli_snapshots__npm_precision_patch_explicit_stderr.snap
@@ -10,6 +10,7 @@ expression: stderr
   Parsed lockfile
   Computing engine constraints...
   Computed engine constraints
-  npm  *  →  >=11.0.0
+  node  >=24.0.0  →  ^24.0.0 || >=25.0.0
+  npm   *         →  >=11.0.0
 
   Run nce -v -u to upgrade package.json.

--- a/crates/riri-nce/tests/snapshots/cli_snapshots__pnpm_json_output.snap
+++ b/crates/riri-nce/tests/snapshots/cli_snapshots__pnpm_json_output.snap
@@ -4,7 +4,7 @@ expression: "serde_json::to_string_pretty(&json).unwrap()"
 ---
 {
   "computed": {
-    "node": ">=20.0.0",
+    "node": "^20.0.0 || ^22.0.0 || ^24.0.0 || >=25.0.0",
     "npm": ">=9.6.4",
     "yarn": "*"
   },
@@ -12,7 +12,7 @@ expression: "serde_json::to_string_pretty(&json).unwrap()"
     {
       "engine": "node",
       "from": "*",
-      "to": ">=20.0.0"
+      "to": "^20.0.0 || ^22.0.0 || ^24.0.0 || >=25.0.0"
     },
     {
       "engine": "npm",
@@ -31,7 +31,7 @@ expression: "serde_json::to_string_pretty(&json).unwrap()"
     "bumped_disjuncts": [
       {
         "from": ">=17.0.0",
-        "to": ">=20.0.0"
+        "to": "^20.0.0 || ^22.0.0 || ^24.0.0 || >=25.0.0"
       }
     ],
     "unsatisfiable": false

--- a/crates/riri-nce/tests/snapshots/cli_snapshots__pnpm_or_ranges_node_npm_yarn_verbose_stderr.snap
+++ b/crates/riri-nce/tests/snapshots/cli_snapshots__pnpm_or_ranges_node_npm_yarn_verbose_stderr.snap
@@ -10,7 +10,7 @@ expression: stderr
   Parsed lockfile
   Computing engine constraints...
   Computed engine constraints
-  node  *  →  >=20.0.0
+  node  *  →  ^20.0.0 || ^22.0.0 || ^24.0.0 || >=25.0.0
   npm   *  →  >=9.6.4
   yarn  *  →  ^1.22.4
 

--- a/crates/riri-nce/tests/snapshots/cli_snapshots__pnpm_or_ranges_node_only_verbose_stderr.snap
+++ b/crates/riri-nce/tests/snapshots/cli_snapshots__pnpm_or_ranges_node_only_verbose_stderr.snap
@@ -10,7 +10,7 @@ expression: stderr
   Parsed lockfile
   Computing engine constraints...
   Computed engine constraints
-  node  *  →  >=20.0.0
+  node  *  →  ^20.0.0 || ^22.0.0 || ^24.0.0 || >=25.0.0
   npm   *  →  >=9.6.4
 
   Run nce -v -u to upgrade package.json.

--- a/crates/riri-nce/tests/snapshots/cli_snapshots__policy_lts_eol_bump_stderr.snap
+++ b/crates/riri-nce/tests/snapshots/cli_snapshots__policy_lts_eol_bump_stderr.snap
@@ -10,7 +10,7 @@ expression: stderr
   Parsed lockfile
   Computing engine constraints...
   Computed engine constraints
-  node  ^20.19.0 || ^22.12.0 || >=23.0.0  →  ^20.19.0 || ^22.12.0 || >=24.0.0
+  node  ^20.19.0 || ^22.12.0 || >=23.0.0  →  ^20.19.0 || ^22.12.0 || ^24.0.0
   npm   *                                 →  >=9.6.4
 
   Run nce -v -u to upgrade package.json.

--- a/crates/riri-nce/tests/snapshots/cli_snapshots__policy_supported_eol_bump_stderr.snap
+++ b/crates/riri-nce/tests/snapshots/cli_snapshots__policy_supported_eol_bump_stderr.snap
@@ -10,7 +10,7 @@ expression: stderr
   Parsed lockfile
   Computing engine constraints...
   Computed engine constraints
-  node  >=18.0.0  →  >=20.0.0
+  node  >=18.0.0  →  ^20.0.0 || ^22.0.0 || ^24.0.0 || >=25.0.0
   npm   *         →  >=9.6.4
 
   Run nce -v -u to upgrade package.json.

--- a/crates/riri-nce/tests/snapshots/cli_snapshots__supported_eol_bump_json.snap
+++ b/crates/riri-nce/tests/snapshots/cli_snapshots__supported_eol_bump_json.snap
@@ -4,7 +4,7 @@ expression: "serde_json::to_string_pretty(&json).unwrap()"
 ---
 {
   "computed": {
-    "node": ">=20.0.0",
+    "node": "^20.0.0 || ^22.0.0 || ^24.0.0 || >=25.0.0",
     "npm": ">=9.6.4",
     "yarn": "*"
   },
@@ -12,7 +12,7 @@ expression: "serde_json::to_string_pretty(&json).unwrap()"
     {
       "engine": "node",
       "from": ">=18.0.0",
-      "to": ">=20.0.0"
+      "to": "^20.0.0 || ^22.0.0 || ^24.0.0 || >=25.0.0"
     },
     {
       "engine": "npm",
@@ -28,7 +28,7 @@ expression: "serde_json::to_string_pretty(&json).unwrap()"
     "bumped_disjuncts": [
       {
         "from": ">=18.0.0",
-        "to": ">=20.0.0"
+        "to": "^20.0.0 || ^22.0.0 || ^24.0.0 || >=25.0.0"
       }
     ],
     "unsatisfiable": false

--- a/crates/riri-nce/tests/snapshots/cli_snapshots__yarn_json_output.snap
+++ b/crates/riri-nce/tests/snapshots/cli_snapshots__yarn_json_output.snap
@@ -4,7 +4,7 @@ expression: "serde_json::to_string_pretty(&json).unwrap()"
 ---
 {
   "computed": {
-    "node": ">=20.0.0",
+    "node": "^20.0.0 || ^22.0.0 || ^24.0.0 || >=25.0.0",
     "npm": ">=9.6.4",
     "yarn": "*"
   },
@@ -12,7 +12,7 @@ expression: "serde_json::to_string_pretty(&json).unwrap()"
     {
       "engine": "node",
       "from": "*",
-      "to": ">=20.0.0"
+      "to": "^20.0.0 || ^22.0.0 || ^24.0.0 || >=25.0.0"
     },
     {
       "engine": "npm",
@@ -31,7 +31,7 @@ expression: "serde_json::to_string_pretty(&json).unwrap()"
     "bumped_disjuncts": [
       {
         "from": ">=17.0.0",
-        "to": ">=20.0.0"
+        "to": "^20.0.0 || ^22.0.0 || ^24.0.0 || >=25.0.0"
       }
     ],
     "unsatisfiable": false

--- a/crates/riri-nce/tests/snapshots/cli_snapshots__yarn_or_ranges_node_npm_yarn_verbose_stderr.snap
+++ b/crates/riri-nce/tests/snapshots/cli_snapshots__yarn_or_ranges_node_npm_yarn_verbose_stderr.snap
@@ -10,7 +10,7 @@ expression: stderr
   Scanned node_modules
   Computing engine constraints...
   Computed engine constraints
-  node  *  →  >=20.0.0
+  node  *  →  ^20.0.0 || ^22.0.0 || ^24.0.0 || >=25.0.0
   npm   *  →  >=9.6.4
   yarn  *  →  ^1.22.4
 

--- a/crates/riri-nce/tests/snapshots/cli_snapshots__yarn_or_ranges_node_only_verbose_stderr.snap
+++ b/crates/riri-nce/tests/snapshots/cli_snapshots__yarn_or_ranges_node_only_verbose_stderr.snap
@@ -10,7 +10,7 @@ expression: stderr
   Scanned node_modules
   Computing engine constraints...
   Computed engine constraints
-  node  *  →  >=20.0.0
+  node  *  →  ^20.0.0 || ^22.0.0 || ^24.0.0 || >=25.0.0
   npm   *  →  >=9.6.4
 
   Run nce -v -u to upgrade package.json.


### PR DESCRIPTION
## Summary
Open lower bounds (`>=X.Y.Z`) under restrictive policies (Supported/Lts/Maintenance) now expand to OR-of-allowed-carets instead of a single lifted lower bound. This closes the EOL leak from intermediate odd majors (21, 23) that were silently allowed by the old `>=20.0.0` form.

| Policy | Old | New |
|--------|-----|-----|
| Any / Stable | `>=18.0.0` | unchanged |
| Supported | `>=18.0.0` → `>=20.0.0` | `>=18.0.0` → `^20.0.0 \|\| ^22.0.0 \|\| ^24.0.0 \|\| >=25.0.0` |
| Lts | `>=18.0.0` → `>=20.0.0` | `>=18.0.0` → `^20.0.0 \|\| ^22.0.0 \|\| ^24.0.0` |
| Maintenance | `>=18.0.0` → `>=20.0.0` | `>=18.0.0` → `^20.0.0` |

Supported keeps an open tail (`>=Mhighest.0.0`) at the highest allowed major to stay forward-compatible with the next current. Lts/Maintenance close every contribution since future LTS/Maintenance majors aren't predictable.

## Test plan
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`