### PR TITLE
chore(release-please): drop RC prerelease config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -24,9 +24,7 @@
           "path": "package.json",
           "jsonpath": "$.version"
         }
-      ],
-      "prerelease": true,
-      "prerelease-type": "rc"
+      ]
     }
   }
 }


### PR DESCRIPTION
Removes `prerelease: true` and `prerelease-type: rc` from the release-please config so the next release-please PR proposes `1.0.0` (stable) instead of `1.0.0-rc.X`.