### PR TITLE
ci: address zizmor code-scanning notes

### DIFF
--- a/.github/workflows/bench-run.yml
+++ b/.github/workflows/bench-run.yml
@@ -51,6 +51,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
+          persist-credentials: false
 
       - name: Install Rust
         run: rustup update stable && rustup default stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,10 +118,14 @@ jobs:
           path: /tmp/bench-baseline/criterion
 
       - name: Save baseline metadata
+        env:
+          BINARY_SIZES: ${{ needs.bench-baseline.outputs.binary-sizes }}
+          TEST_COUNT: ${{ needs.bench-baseline.outputs.test-count }}
+          PEAK_RSS_KB: ${{ needs.bench-baseline.outputs.peak-rss-kb }}
         run: |
-          echo '${{ needs.bench-baseline.outputs.binary-sizes }}' > /tmp/bench-baseline/binary-sizes.json
-          echo '${{ needs.bench-baseline.outputs.test-count }}' > /tmp/bench-baseline/test-count.txt
-          echo '${{ needs.bench-baseline.outputs.peak-rss-kb }}' > /tmp/bench-baseline/peak-rss-kb.txt
+          printf '%s' "$BINARY_SIZES" > /tmp/bench-baseline/binary-sizes.json
+          printf '%s' "$TEST_COUNT" > /tmp/bench-baseline/test-count.txt
+          printf '%s' "$PEAK_RSS_KB" > /tmp/bench-baseline/peak-rss-kb.txt
 
       - name: Cache baseline results
         uses: actions/cache/save@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Detect changes
         id: filter
         uses: dorny/paths-filter@v4
@@ -46,6 +48,8 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Install Rust
         run: rustup update stable && rustup default stable
       - name: Rust cache
@@ -78,7 +82,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout release PR branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6 # zizmor: ignore[artipacked] needs persisted creds for git-auto-commit-action
         with:
           ref: ${{ needs.rust.outputs.pr_branch }}
       - name: Install Rust

--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -77,6 +77,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -143,6 +145,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -175,6 +179,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Download artifact
         uses: actions/download-artifact@v8

--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -196,22 +196,24 @@ jobs:
 
       - name: Test (glibc)
         if: contains(matrix.target, 'gnu')
-        uses: addnab/docker-run-action@v3
-        with:
-          image: node:lts-slim
-          options: >-
-            --platform ${{ contains(matrix.target, 'aarch64') && 'linux/arm64' || 'linux/amd64' }}
-            -v ${{ github.workspace }}:/work
-            -w /work/crates/riri-napi
-          run: node test.mjs
+        env:
+          DOCKER_PLATFORM: ${{ contains(matrix.target, 'aarch64') && 'linux/arm64' || 'linux/amd64' }}
+        run: |
+          docker run --rm \
+            --platform "$DOCKER_PLATFORM" \
+            -v "$GITHUB_WORKSPACE":/work \
+            -w /work/crates/riri-napi \
+            node:lts-slim \
+            node test.mjs
 
       - name: Test (musl)
         if: contains(matrix.target, 'musl')
-        uses: addnab/docker-run-action@v3
-        with:
-          image: node:lts-alpine
-          options: >-
-            --platform ${{ contains(matrix.target, 'aarch64') && 'linux/arm64' || 'linux/amd64' }}
-            -v ${{ github.workspace }}:/work
-            -w /work/crates/riri-napi
-          run: node test.mjs
+        env:
+          DOCKER_PLATFORM: ${{ contains(matrix.target, 'aarch64') && 'linux/arm64' || 'linux/amd64' }}
+        run: |
+          docker run --rm \
+            --platform "$DOCKER_PLATFORM" \
+            -v "$GITHUB_WORKSPACE":/work \
+            -w /work/crates/riri-napi \
+            node:lts-alpine \
+            node test.mjs

--- a/.github/workflows/pr-action.yml
+++ b/.github/workflows/pr-action.yml
@@ -35,6 +35,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/pr-bench.yml
+++ b/.github/workflows/pr-bench.yml
@@ -69,6 +69,8 @@ jobs:
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Install Rust
         run: rustup update stable && rustup default stable
       - name: Rust cache

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,6 +58,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -105,6 +107,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -141,4 +141,6 @@ jobs:
           fi
 
       - name: Publish
-        run: npm publish --access public --provenance --tag ${{ steps.tag.outputs.tag }}
+        env:
+          NPM_TAG: ${{ steps.tag.outputs.tag }}
+        run: npm publish --access public --provenance --tag "$NPM_TAG"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Install Rust
         run: rustup update stable && rustup default stable
       - name: Rust cache


### PR DESCRIPTION
Closes the 19 open zizmor notes on `main` (https://github.com/smarlhens/riri-node-tools/security/code-scanning?query=is%3Aopen+branch%3Amain+severity%3Anote).

- **artipacked** (14): set `persist-credentials: false` on every read-only `actions/checkout@v6`. The `update-lockfile` checkout in `ci.yml` keeps persisted creds (needed by `git-auto-commit-action`) and carries an inline `# zizmor: ignore[artipacked]` with rationale.
- **template-injection** (4): move `${{ … }}` expansions out of `run:` blocks into `env:` in `ci.yml` (bench baseline metadata) and `publish.yml` (npm tag).
- **superfluous-actions** (2): drop `addnab/docker-run-action@v3` in `napi.yml` and call `docker run` directly — Docker is preinstalled on Ubuntu runners.

Verified: 0 zizmor alerts open on this branch ref. CI green across all jobs (build, test, bench, zizmor).