### PR TITLE
ci: suppress zizmor cache-poisoning + replace dependabot-flagged fixture packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Install Rust
         run: rustup update stable && rustup default stable
       - name: Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@v2 # zizmor: ignore[cache-poisoning] release-please-action ships no build artifacts
       - name: Check formatting
         run: cargo fmt --all -- --check
       - name: Check errors

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Rust
         run: rustup update stable && rustup default stable
       - name: Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@v2 # zizmor: ignore[cache-poisoning] release-please-action ships no build artifacts
       - name: Check formatting
         run: cargo fmt --all -- --check
       - name: Check errors


### PR DESCRIPTION
## zizmor cache-poisoning (2 errors)

`Swatinem/rust-cache@v2` flagged in `release.yml` and `ci.yml`'s `rust` job because both call `googleapis/release-please-action@v5` in the same job. release-please only opens release PRs / creates GitHub release entries from commit history — it does not build or upload binaries. Actual artifact build/publish lives in `publish.yml` (no rust-cache there) and `napi.yml` (separate cache prefix, separate workflow).

Fix: inline `# zizmor: ignore[cache-poisoning]` with rationale on both cache steps.

## Dependabot fixture replacements

Follow-up commit replaces flagged fixture packages with fake equivalents (matching the pattern used in earlier fixture cleanups).