### PR TITLE
feat(common): shared .npmrc upsert helper

### DIFF
--- a/crates/riri-common/src/lib.rs
+++ b/crates/riri-common/src/lib.rs
@@ -1,7 +1,9 @@
 mod detect;
+mod npmrc;
 mod package_json_file;
 
 pub use detect::{DetectError, detect_lockfile, find_package_json};
+pub use npmrc::{NpmrcOutcome, upsert_npmrc_flag};
 pub use package_json_file::PackageJsonFile;
 
 use serde::Deserialize;

--- a/crates/riri-common/src/npmrc.rs
+++ b/crates/riri-common/src/npmrc.rs
@@ -1,0 +1,84 @@
+//! `.npmrc` upsert helper shared by `nce` (`engine-strict=true`) and
+//! `npd` (`save-exact=true`).
+
+use std::path::Path;
+
+/// Outcome of a [`upsert_npmrc_flag`] call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NpmrcOutcome {
+    /// File already contained the line; nothing was written.
+    AlreadySet,
+    /// File was created or appended with the line.
+    Added,
+}
+
+/// Ensures `dir/.npmrc` contains the literal `flag` line.
+///
+/// Behaviour:
+///   - missing file → create with `flag\n`
+///   - existing content already contains `flag` (substring) → no-op
+///   - else → append `flag\n` (with a leading newline if the file did not end with one)
+///
+/// # Errors
+///
+/// Returns the underlying [`std::io::Error`] when reading or writing fails.
+pub fn upsert_npmrc_flag(dir: &Path, flag: &str) -> std::io::Result<NpmrcOutcome> {
+    let path = dir.join(".npmrc");
+    let existing = std::fs::read_to_string(&path).unwrap_or_default();
+    if existing.contains(flag) {
+        return Ok(NpmrcOutcome::AlreadySet);
+    }
+    let new_content = if existing.is_empty() {
+        format!("{flag}\n")
+    } else if existing.ends_with('\n') {
+        format!("{existing}{flag}\n")
+    } else {
+        format!("{existing}\n{flag}\n")
+    };
+    std::fs::write(&path, new_content)?;
+    Ok(NpmrcOutcome::Added)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn creates_file_when_missing() {
+        let tmp = TempDir::new().unwrap();
+        let outcome = upsert_npmrc_flag(tmp.path(), "engine-strict=true").unwrap();
+        assert_eq!(outcome, NpmrcOutcome::Added);
+        let content = std::fs::read_to_string(tmp.path().join(".npmrc")).unwrap();
+        assert_eq!(content, "engine-strict=true\n");
+    }
+
+    #[test]
+    fn no_op_when_flag_already_present() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join(".npmrc"), "engine-strict=true\n").unwrap();
+        let outcome = upsert_npmrc_flag(tmp.path(), "engine-strict=true").unwrap();
+        assert_eq!(outcome, NpmrcOutcome::AlreadySet);
+    }
+
+    #[test]
+    fn appends_when_other_lines_present() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join(".npmrc"), "registry=https://example.com\n").unwrap();
+        let outcome = upsert_npmrc_flag(tmp.path(), "save-exact=true").unwrap();
+        assert_eq!(outcome, NpmrcOutcome::Added);
+        let content = std::fs::read_to_string(tmp.path().join(".npmrc")).unwrap();
+        assert_eq!(content, "registry=https://example.com\nsave-exact=true\n");
+    }
+
+    #[test]
+    fn appends_with_newline_when_existing_lacks_trailing_newline() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join(".npmrc"), "registry=https://example.com").unwrap();
+        let outcome = upsert_npmrc_flag(tmp.path(), "save-exact=true").unwrap();
+        assert_eq!(outcome, NpmrcOutcome::Added);
+        let content = std::fs::read_to_string(tmp.path().join(".npmrc")).unwrap();
+        assert_eq!(content, "registry=https://example.com\nsave-exact=true\n");
+    }
+}

--- a/crates/riri-nce/src/main.rs
+++ b/crates/riri-nce/src/main.rs
@@ -178,6 +178,8 @@ fn run(args: &Args) -> Result<ExitCode> {
     let runner = TaskRunner::new(mode);
     let cwd = std::env::current_dir().context("failed to get current directory")?;
 
+    maybe_enable_engine_strict(args, &runner, &cwd)?;
+
     // Detect lockfile
     let task = runner.task("Detecting lockfile...");
     match detect_lockfile(&cwd) {
@@ -383,25 +385,29 @@ fn run(args: &Args) -> Result<ExitCode> {
         );
     }
 
-    // Enable engine-strict in .npmrc
-    if args.enable_engine_strict {
-        let task = runner.task("Enabling engine-strict in .npmrc...");
-        let npmrc_path = cwd.join(".npmrc");
-        let content = std::fs::read_to_string(&npmrc_path).unwrap_or_default();
-        if content.contains("engine-strict=true") {
+    Ok(ExitCode::from(1))
+}
+
+fn maybe_enable_engine_strict(
+    args: &Args,
+    runner: &TaskRunner,
+    cwd: &std::path::Path,
+) -> Result<()> {
+    if !args.enable_engine_strict {
+        return Ok(());
+    }
+    let task = runner.task("Enabling engine-strict in .npmrc...");
+    match riri_common::upsert_npmrc_flag(cwd, "engine-strict=true")
+        .context("failed to write .npmrc")?
+    {
+        riri_common::NpmrcOutcome::AlreadySet => {
             task.skip("Enabling engine-strict in .npmrc", "already enabled");
-        } else {
-            let new_content = if content.is_empty() {
-                "engine-strict=true\n".to_string()
-            } else {
-                format!("{content}engine-strict=true\n")
-            };
-            std::fs::write(&npmrc_path, new_content).context("failed to write .npmrc")?;
+        }
+        riri_common::NpmrcOutcome::Added => {
             task.complete("Enabled engine-strict in .npmrc");
         }
     }
-
-    Ok(ExitCode::from(1))
+    Ok(())
 }
 
 const DEFAULT_MAX_DATA_AGE_DAYS: i64 = 180;

--- a/crates/riri-npd/src/main.rs
+++ b/crates/riri-npd/src/main.rs
@@ -42,6 +42,10 @@ struct Args {
     /// Sort package.json keys on write (uses sort-package-json conventions).
     #[arg(long)]
     sort: bool,
+
+    /// Create or update .npmrc with save-exact=true.
+    #[arg(long)]
+    enable_save_exact: bool,
 }
 
 fn renderer_mode(args: &Args) -> RendererMode {
@@ -89,6 +93,8 @@ fn run(args: &Args) -> Result<ExitCode> {
     let mode = renderer_mode(args);
     let runner = TaskRunner::new(mode);
     let cwd = std::env::current_dir().context("failed to get current directory")?;
+
+    maybe_enable_save_exact(args, &runner, &cwd)?;
 
     let task = runner.task("Detecting lockfile...");
     let lockfile_result = match detect_lockfile(&cwd) {
@@ -202,6 +208,24 @@ fn run(args: &Args) -> Result<ExitCode> {
     }
 
     Ok(ExitCode::from(1))
+}
+
+fn maybe_enable_save_exact(args: &Args, runner: &TaskRunner, cwd: &Path) -> Result<()> {
+    if !args.enable_save_exact {
+        return Ok(());
+    }
+    let task = runner.task("Enabling save-exact in .npmrc...");
+    match riri_common::upsert_npmrc_flag(cwd, "save-exact=true")
+        .context("failed to write .npmrc")?
+    {
+        riri_common::NpmrcOutcome::AlreadySet => {
+            task.skip("Enabling save-exact in .npmrc", "already enabled");
+        }
+        riri_common::NpmrcOutcome::Added => {
+            task.complete("Enabled save-exact in .npmrc");
+        }
+    }
+    Ok(())
 }
 
 fn apply_pins(pkg_file: &mut PackageJsonFile, pins: &[VersionToPin]) {

--- a/crates/riri-npd/tests/cli_snapshots.rs
+++ b/crates/riri-npd/tests/cli_snapshots.rs
@@ -139,9 +139,40 @@ fn cli_yarn_no_node_modules_errors() {
 }
 
 #[test]
+fn cli_enable_save_exact_creates_npmrc() {
+    let tmp = copy_fixture_to_tmp("npd-npm-v3-already-pinned");
+    let output = npd_binary()
+        .current_dir(tmp.path())
+        .args(["--enable-save-exact"])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code().unwrap_or(-1), 0);
+    let npmrc = std::fs::read_to_string(tmp.path().join(".npmrc")).unwrap();
+    assert_eq!(npmrc, "save-exact=true\n");
+}
+
+#[test]
+fn cli_enable_save_exact_skips_when_already_set() {
+    let tmp = copy_fixture_to_tmp("npd-npm-v3-already-pinned");
+    std::fs::write(tmp.path().join(".npmrc"), "save-exact=true\n").unwrap();
+    let output = npd_binary()
+        .current_dir(tmp.path())
+        .args(["--enable-save-exact"])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code().unwrap_or(-1), 0);
+    let npmrc = std::fs::read_to_string(tmp.path().join(".npmrc")).unwrap();
+    assert_eq!(npmrc, "save-exact=true\n");
+}
+
+#[test]
 fn cli_help_lists_core_flags() {
     let output = npd_binary().arg("--help").output().unwrap();
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("--update"), "should show --update");
     assert!(stdout.contains("--json"), "should show --json");
+    assert!(
+        stdout.contains("--enable-save-exact"),
+        "should show --enable-save-exact"
+    );
 }


### PR DESCRIPTION
## Summary
Slice 4 of Phase 9: extracts the `.npmrc` upsert into `riri-common` so `nce` (`engine-strict=true`) and `npd` (`save-exact=true`) share one helper.

- New `riri_common::upsert_npmrc_flag(dir, flag) -> NpmrcOutcome`: idempotent, creates the file when missing, appends with a leading newline when the existing file lacks one
- `nce` now calls `maybe_enable_engine_strict()` early in `run()` so it always fires on `--enable-engine-strict`, even on the up-to-date / unsatisfiable / json early-return paths (previous bug)
- `npd` gains `--enable-save-exact` flag wired to the same helper, hoisted before lockfile detection for the same reason
- 4 unit tests on the helper (create, no-op, append-after-line, append-after-no-newline)
- 2 npd CLI tests (creates `.npmrc`, idempotent on re-run) + help-flag check

## Test plan
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`

Follow-up: NAPI binding for npd, migration / cutover.