### PR TITLE
fix(ci): drop reusable napi.yml permissions to fix startup_failure

### DIFF
--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -17,9 +17,6 @@ on:
         type: boolean
         default: false
 
-permissions:
-  contents: read
-
 env:
   MACOSX_DEPLOYMENT_TARGET: "10.13"
 
@@ -219,8 +216,6 @@ jobs:
     defaults:
       run:
         working-directory: ${{ inputs.crate-dir }}
-    permissions:
-      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
The reusable `napi.yml` workflow added in #139 declared root-level `permissions: contents: read` and a `publish` job with `permissions: id-token: write`. Both `napi-nce` and `napi-npd` callers fail with `startup_failure` because GitHub statically validates the called workflow's job permissions against the caller — the publish job's `id-token: write` is rejected when the caller (PR/push trigger) only grants `contents: read`, regardless of the job's `if:` gate.

Fix: drop both permission declarations from the reusable. Callers grant whatever each context needs:
- `napi-nce.yml` / `napi-npd.yml` → workflow-level `contents: read` (publish job is gated off, no id-token needed)
- `publish-nce.yml` / `publish-npd.yml` → job-level `contents: read` + `id-token: write` (publish runs)

## Test plan
- [x] CI must show `napi-nce` + `napi-npd` running build/test jobs (not startup_failure)