### PR TITLE
feat(npd): pnpm catalog support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1635,9 +1635,11 @@ version = "0.1.0"
 dependencies = [
  "insta",
  "riri-common",
+ "riri-find-up",
  "rstest",
  "serde",
  "serde-saphyr",
+ "tempfile",
  "thiserror",
 ]
 

--- a/crates/riri-napi-npd/README.md
+++ b/crates/riri-napi-npd/README.md
@@ -126,6 +126,7 @@ Options:
       --json               Output results as JSON
       --sort               Sort package.json keys (sort-package-json conventions); writes the file even without --update or pending pins
       --enable-save-exact  Create or update .npmrc with save-exact=true
+      --pin-catalog        Resolve and report pnpm catalog entries from `pnpm-workspace.yaml`. On `-u`, rewrites the catalog entries in place. Requires a pnpm project
   -h, --help               Print help
   -V, --version            Print version
 ```

--- a/crates/riri-napi-npd/test.mjs
+++ b/crates/riri-napi-npd/test.mjs
@@ -97,6 +97,18 @@ test('runCli with --version exits 0', () => {
   assert.equal(code, 0);
 });
 
+test('runCli --pin-catalog --json on pnpm catalog fixture', () => {
+  const fixtureDir = resolve(fixturesDir, 'npd-pnpm-v9-catalog');
+  const original = process.cwd();
+  try {
+    process.chdir(fixtureDir);
+    const code = napi.runCli(['npd', '--pin-catalog', '--quiet', '--json']);
+    assert.equal(code, 1);
+  } finally {
+    process.chdir(original);
+  }
+});
+
 test('runCli with bogus flag exits 2', () => {
   const code = napi.runCli(['npd', '--definitely-not-a-flag']);
   assert.equal(code, 2);

--- a/crates/riri-nce/tests/check_engines_fixtures.rs
+++ b/crates/riri-nce/tests/check_engines_fixtures.rs
@@ -316,6 +316,12 @@ fn pnpm_or_ranges_node_npm_yarn() {
     insta::assert_snapshot!(result);
 }
 
+#[test]
+fn pnpm_catalog() {
+    let result = run_pnpm_fixture("pnpm-v9-catalog");
+    insta::assert_snapshot!(result);
+}
+
 // ── yarn fixtures ───────────────────────────────────────────────────
 
 fn run_yarn_fixture(fixture_dir: &str) -> String {

--- a/crates/riri-nce/tests/snapshots/check_engines_fixtures__pnpm_catalog.snap
+++ b/crates/riri-nce/tests/snapshots/check_engines_fixtures__pnpm_catalog.snap
@@ -1,0 +1,8 @@
+---
+source: crates/riri-nce/tests/check_engines_fixtures.rs
+expression: result
+---
+computed node: >=6.9.0
+computed npm: *
+computed yarn: *
+change node: * → >=6.9.0

--- a/crates/riri-npd/src/cli.rs
+++ b/crates/riri-npd/src/cli.rs
@@ -10,9 +10,22 @@ use riri_npm::NpmPackageLock;
 use riri_pnpm::PnpmLockfile;
 use riri_task_runner::{RendererMode, TaskRunner};
 use riri_yarn::YarnProject;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
-use crate::{DependencyKind, VersionToPin, pin_dependencies};
+use crate::{CatalogPin, DependencyKind, VersionToPin, pin_dependencies};
+
+/// Resolved catalog state for one `npd` invocation.
+struct CatalogPlan {
+    pins: Vec<CatalogPin>,
+    /// `None` when `--pin-catalog` is off, the project isn't pnpm, or there
+    /// is no `pnpm-workspace.yaml`. Required for write-back on `-u`.
+    source: Option<CatalogSource>,
+}
+
+struct CatalogSource {
+    path: PathBuf,
+    raw: String,
+}
 
 const EXIT_OK: i32 = 0;
 const EXIT_PINS_PENDING: i32 = 1;
@@ -51,6 +64,11 @@ pub struct Args {
     /// Create or update .npmrc with save-exact=true.
     #[arg(long)]
     pub enable_save_exact: bool,
+
+    /// Resolve and report pnpm catalog entries from `pnpm-workspace.yaml`.
+    /// On `-u`, rewrites the catalog entries in place. Requires a pnpm project.
+    #[arg(long)]
+    pub pin_catalog: bool,
 }
 
 fn renderer_mode(args: &Args) -> RendererMode {
@@ -153,24 +171,49 @@ fn run(args: &Args) -> Result<i32> {
         .map_err(|e| anyhow::anyhow!("pin_dependencies failed: {e}"))?;
     task.complete("Computed dependency pins");
 
+    let CatalogPlan {
+        pins: catalog_pins,
+        source: catalog_source,
+    } = if args.pin_catalog {
+        resolve_catalog_pins(args, &runner, &lockfile_result, &cwd, lockfile.as_ref())?
+    } else {
+        CatalogPlan {
+            pins: Vec::new(),
+            source: None,
+        }
+    };
+
     if args.json {
-        let json_output = serde_json::json!({
-            "pins": pins.iter().map(|p| serde_json::json!({
-                "name": p.name,
-                "kind": p.kind.as_str(),
-                "from": p.current_range,
-                "to": p.pinned_version,
-            })).collect::<Vec<_>>(),
-        });
+        let mut all_pins: Vec<serde_json::Value> = pins
+            .iter()
+            .map(|p| {
+                serde_json::json!({
+                    "name": p.name,
+                    "kind": p.kind.as_str(),
+                    "from": p.current_range,
+                    "to": p.pinned_version,
+                })
+            })
+            .collect();
+        for cp in &catalog_pins {
+            all_pins.push(serde_json::json!({
+                "name": cp.dep_name,
+                "kind": "catalog",
+                "catalog": cp.catalog_name,
+                "from": cp.from,
+                "to": cp.to,
+            }));
+        }
+        let json_output = serde_json::json!({ "pins": all_pins });
         println!("{}", serde_json::to_string_pretty(&json_output)?);
-        return Ok(if pins.is_empty() {
+        return Ok(if pins.is_empty() && catalog_pins.is_empty() {
             EXIT_OK
         } else {
             EXIT_PINS_PENDING
         });
     }
 
-    if pins.is_empty() {
+    if pins.is_empty() && catalog_pins.is_empty() {
         if !args.quiet {
             eprintln!(
                 "\n  All dependencies are already pinned {}",
@@ -196,6 +239,20 @@ fn run(args: &Args) -> Result<i32> {
                 pin.current_range.clone(),
                 "\u{2192}".to_string(),
                 pin.pinned_version.clone(),
+                String::new(),
+            ]);
+        }
+        for cp in &catalog_pins {
+            let origin = match &cp.catalog_name {
+                None => "(catalog)".to_string(),
+                Some(name) => format!("(catalog:{name})"),
+            };
+            table.add_row(vec![
+                cp.dep_name.clone(),
+                cp.from.clone(),
+                "\u{2192}".to_string(),
+                cp.to.clone(),
+                origin,
             ]);
         }
         for line in table.lines() {
@@ -204,16 +261,36 @@ fn run(args: &Args) -> Result<i32> {
     }
 
     if args.update {
-        let task = runner.task("Updating package.json...");
-        apply_pins(&mut pkg_file, &pins);
-        if args.sort {
+        if !pins.is_empty() {
+            let task = runner.task("Updating package.json...");
+            apply_pins(&mut pkg_file, &pins);
+            if args.sort {
+                pkg_file
+                    .write_sorted()
+                    .context("failed to write package.json")?;
+            } else {
+                pkg_file.write().context("failed to write package.json")?;
+            }
+            task.complete("Updated package.json");
+        } else if args.sort {
+            let task = runner.task("Sorting package.json...");
             pkg_file
                 .write_sorted()
                 .context("failed to write package.json")?;
-        } else {
-            pkg_file.write().context("failed to write package.json")?;
+            task.complete("Sorted package.json");
         }
-        task.complete("Updated package.json");
+        if let Some(source) = catalog_source.as_ref()
+            && !catalog_pins.is_empty()
+        {
+            let task = runner.task("Updating pnpm-workspace.yaml...");
+            match apply_catalog_pins(source, &catalog_pins) {
+                Ok(()) => task.complete("Updated pnpm-workspace.yaml"),
+                Err(e) => {
+                    task.fail("Updating pnpm-workspace.yaml");
+                    return Err(e);
+                }
+            }
+        }
     } else {
         if args.sort {
             let task = runner.task("Sorting package.json...");
@@ -225,8 +302,13 @@ fn run(args: &Args) -> Result<i32> {
         if !args.quiet {
             let hint = generate_update_hint(args);
             eprintln!(
-                "\n  Run {} to upgrade package.json.",
-                style(hint).bold().cyan()
+                "\n  Run {} to upgrade package.json{}.",
+                style(hint).bold().cyan(),
+                if args.pin_catalog {
+                    " and pnpm-workspace.yaml"
+                } else {
+                    ""
+                },
             );
         }
     }
@@ -314,6 +396,38 @@ fn apply_pins(pkg_file: &mut PackageJsonFile, pins: &[VersionToPin]) {
     }
 }
 
+/// Rewrites each catalog pin into the original `pnpm-workspace.yaml` raw
+/// content and atomically writes it back to disk.
+fn apply_catalog_pins(source: &CatalogSource, pins: &[CatalogPin]) -> Result<()> {
+    let mut content = source.raw.clone();
+    for pin in pins {
+        content = riri_pnpm::catalog::PnpmCatalog::edit_line(
+            &content,
+            pin.catalog_name.as_deref(),
+            &pin.dep_name,
+            &pin.to,
+        )
+        .with_context(|| {
+            format!(
+                "failed to rewrite catalog entry `{}`{}",
+                pin.dep_name,
+                pin.catalog_name
+                    .as_ref()
+                    .map(|c| format!(" in catalog `{c}`"))
+                    .unwrap_or_default()
+            )
+        })?;
+    }
+
+    let parent = source.path.parent().unwrap_or_else(|| Path::new("."));
+    let tmp_path = parent.join(".pnpm-workspace.yaml.tmp");
+    std::fs::write(&tmp_path, &content)
+        .with_context(|| format!("failed to write {}", tmp_path.display()))?;
+    std::fs::rename(&tmp_path, &source.path)
+        .with_context(|| format!("failed to rename into {}", source.path.display()))?;
+    Ok(())
+}
+
 fn sync_typed(
     target: &mut std::collections::HashMap<String, String>,
     pins: &[VersionToPin],
@@ -336,7 +450,80 @@ fn generate_update_hint(args: &Args) -> String {
         parts.push("-d".to_string());
     }
     parts.push("-u".to_string());
+    if args.pin_catalog {
+        parts.push("--pin-catalog".to_string());
+    }
     parts.join(" ")
+}
+
+fn resolve_catalog_pins(
+    args: &Args,
+    runner: &TaskRunner,
+    lockfile_result: &riri_common::LockFileResult,
+    cwd: &Path,
+    lockfile: &dyn LockfileVersions,
+) -> Result<CatalogPlan> {
+    if lockfile_result.package_manager != PackageManager::Pnpm {
+        if !args.quiet {
+            eprintln!(
+                "  {} --pin-catalog is pnpm-only, ignoring",
+                style("warning:").yellow().bold(),
+            );
+        }
+        return Ok(CatalogPlan {
+            pins: Vec::new(),
+            source: None,
+        });
+    }
+
+    let Some(yaml_path) = riri_pnpm::catalog::find_workspace_yaml(cwd) else {
+        if !args.quiet {
+            eprintln!(
+                "  {} pnpm-workspace.yaml not found, no catalog entries to pin",
+                style("warning:").yellow().bold(),
+            );
+        }
+        return Ok(CatalogPlan {
+            pins: Vec::new(),
+            source: None,
+        });
+    };
+
+    let task = runner.task("Reading pnpm-workspace.yaml...");
+    let raw = match std::fs::read_to_string(&yaml_path) {
+        Ok(content) => {
+            task.complete("Read pnpm-workspace.yaml");
+            content
+        }
+        Err(e) => {
+            task.fail("Reading pnpm-workspace.yaml");
+            return Err(anyhow::anyhow!(
+                "failed to read {}: {e}",
+                yaml_path.display()
+            ));
+        }
+    };
+
+    let task = runner.task("Parsing catalog entries...");
+    let catalog = match riri_pnpm::catalog::PnpmCatalog::parse(&raw) {
+        Ok(c) => {
+            task.complete("Parsed catalog entries");
+            c
+        }
+        Err(e) => {
+            task.fail("Parsing catalog entries");
+            return Err(anyhow::anyhow!(e));
+        }
+    };
+
+    let pins = crate::pin_catalog_entries(&catalog, lockfile);
+    Ok(CatalogPlan {
+        pins,
+        source: Some(CatalogSource {
+            path: yaml_path,
+            raw,
+        }),
+    })
 }
 
 /// Entry point shared by the standalone binary and the JS bin shim.

--- a/crates/riri-npd/src/lib.rs
+++ b/crates/riri-npd/src/lib.rs
@@ -25,6 +25,19 @@ pub struct VersionToPin {
     pub pinned_version: String,
 }
 
+/// A catalog dependency pin, emitted in parallel with regular pins.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CatalogPin {
+    /// The dependency name as it appears in the catalog map.
+    pub dep_name: String,
+    /// `None` for the default catalog, `Some(name)` for a named catalog.
+    pub catalog_name: Option<String>,
+    /// The current value in `pnpm-workspace.yaml`.
+    pub from: String,
+    /// The version the lockfile resolved.
+    pub to: String,
+}
+
 /// The `package.json` dependency category a [`VersionToPin`] originated from.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DependencyKind {
@@ -145,11 +158,70 @@ pub fn pin_dependencies(
 }
 
 fn is_local_specifier(spec: &str) -> bool {
-    spec.starts_with("file:") || spec.starts_with("link:") || spec.starts_with("workspace:")
+    spec.starts_with("file:")
+        || spec.starts_with("link:")
+        || spec.starts_with("workspace:")
+        || spec.starts_with("catalog:")
+        || spec == "catalog"
 }
 
 fn is_already_pinned(spec: &str, locked: &str) -> bool {
     Version::parse(spec).is_ok_and(|parsed| parsed.to_string() == locked)
+}
+
+/// Compute catalog pins by iterating both the default and named catalogs
+/// and resolving each entry against the lockfile.
+///
+/// Skip rules:
+///   - Entries already at the lockfile version.
+///   - Entries with no matching lockfile entry.
+#[must_use]
+pub fn pin_catalog_entries(
+    catalog: &riri_pnpm::catalog::PnpmCatalog,
+    lockfile: &dyn LockfileVersions,
+) -> Vec<CatalogPin> {
+    let mut result = Vec::new();
+
+    for (dep_name, from) in &catalog.default {
+        if let Some(to) = resolved_pin(lockfile, dep_name, from) {
+            result.push(CatalogPin {
+                dep_name: dep_name.clone(),
+                catalog_name: None,
+                from: from.clone(),
+                to,
+            });
+        }
+    }
+
+    for (name, entries) in &catalog.named {
+        for (dep_name, from) in entries {
+            if let Some(to) = resolved_pin(lockfile, dep_name, from) {
+                result.push(CatalogPin {
+                    dep_name: dep_name.clone(),
+                    catalog_name: Some(name.clone()),
+                    from: from.clone(),
+                    to,
+                });
+            }
+        }
+    }
+
+    result.sort_by(|a, b| {
+        a.catalog_name
+            .as_deref()
+            .unwrap_or("")
+            .cmp(b.catalog_name.as_deref().unwrap_or(""))
+            .then(a.dep_name.cmp(&b.dep_name))
+    });
+    result
+}
+
+fn resolved_pin(lockfile: &dyn LockfileVersions, dep_name: &str, from: &str) -> Option<String> {
+    let locked = lockfile.version_for(dep_name)?;
+    if is_already_pinned(from, locked) {
+        return None;
+    }
+    Some(locked.to_string())
 }
 
 #[cfg(test)]
@@ -235,6 +307,13 @@ mod tests {
     }
 
     #[test]
+    fn skips_catalog_specifiers() {
+        let pkg = pkg(&[("react", "catalog:"), ("vue", "catalog:vue3")]);
+        let lock = locked(&[("react", "18.2.0"), ("vue", "3.4.21")]);
+        assert!(pin_dependencies(&pkg, &lock).expect("ok").is_empty());
+    }
+
+    #[test]
     fn skips_dependency_absent_from_lockfile() {
         let pkg = pkg(&[("missing", "^1.0.0")]);
         let lock = locked(&[]);
@@ -261,5 +340,72 @@ mod tests {
         assert!(kinds.contains(&DependencyKind::Dependencies));
         assert!(kinds.contains(&DependencyKind::DevDependencies));
         assert!(kinds.contains(&DependencyKind::OptionalDependencies));
+    }
+
+    #[test]
+    fn pin_catalog_entries_default() {
+        use riri_pnpm::catalog::PnpmCatalog;
+        let yaml = "catalog:\n  react: ^18.0.0\n  lodash: ^4.17.21\n";
+        let catalog = PnpmCatalog::parse(yaml).expect("parse");
+        let lock = locked(&[("react", "18.2.0"), ("lodash", "4.17.21")]);
+        let pins = pin_catalog_entries(&catalog, &lock);
+        assert_eq!(pins.len(), 2);
+
+        let by_name: std::collections::HashMap<_, _> =
+            pins.iter().map(|p| (p.dep_name.as_str(), p)).collect();
+
+        let react = by_name.get("react").expect("react pin");
+        assert!(react.catalog_name.is_none());
+        assert_eq!(react.from, "^18.0.0");
+        assert_eq!(react.to, "18.2.0");
+
+        let lodash = by_name.get("lodash").expect("lodash pin");
+        assert!(lodash.catalog_name.is_none());
+        assert_eq!(lodash.from, "^4.17.21");
+        assert_eq!(lodash.to, "4.17.21");
+    }
+
+    #[test]
+    fn pin_catalog_entries_skips_already_pinned_exact() {
+        use riri_pnpm::catalog::PnpmCatalog;
+        let yaml = "catalog:\n  react: 18.2.0\n";
+        let catalog = PnpmCatalog::parse(yaml).expect("parse");
+        let lock = locked(&[("react", "18.2.0")]);
+        assert!(pin_catalog_entries(&catalog, &lock).is_empty());
+    }
+
+    #[test]
+    fn pin_catalog_entries_named() {
+        use riri_pnpm::catalog::PnpmCatalog;
+        let yaml = "catalogs:\n  vue3:\n    vue: ^3.4.0\n";
+        let catalog = PnpmCatalog::parse(yaml).expect("parse");
+        let lock = locked(&[("vue", "3.4.21")]);
+        let pins = pin_catalog_entries(&catalog, &lock);
+        assert_eq!(pins.len(), 1);
+        assert_eq!(pins[0].dep_name, "vue");
+        assert_eq!(pins[0].catalog_name.as_deref(), Some("vue3"));
+        assert_eq!(pins[0].from, "^3.4.0");
+        assert_eq!(pins[0].to, "3.4.21");
+    }
+
+    #[test]
+    fn pin_catalog_entries_skips_absent_lockfile_entry() {
+        use riri_pnpm::catalog::PnpmCatalog;
+        let yaml = "catalog:\n  react: ^18.0.0\n";
+        let catalog = PnpmCatalog::parse(yaml).expect("parse");
+        let lock = locked(&[]);
+        assert!(pin_catalog_entries(&catalog, &lock).is_empty());
+    }
+
+    #[test]
+    fn pin_catalog_entries_sorted_default_then_named() {
+        use riri_pnpm::catalog::PnpmCatalog;
+        let yaml = "catalog:\n  react: ^18.0.0\ncatalogs:\n  vue3:\n    vue: ^3.4.0\n";
+        let catalog = PnpmCatalog::parse(yaml).expect("parse");
+        let lock = locked(&[("react", "18.2.0"), ("vue", "3.4.21")]);
+        let pins = pin_catalog_entries(&catalog, &lock);
+        assert_eq!(pins.len(), 2);
+        assert!(pins[0].catalog_name.is_none()); // default first
+        assert_eq!(pins[1].catalog_name.as_deref(), Some("vue3"));
     }
 }

--- a/crates/riri-npd/tests/cli_snapshots.rs
+++ b/crates/riri-npd/tests/cli_snapshots.rs
@@ -182,6 +182,86 @@ fn cli_enable_save_exact_skips_when_already_set() {
 }
 
 #[test]
+fn cli_pin_catalog_reports_default_and_named() {
+    let (stdout, _stderr, code) =
+        run_in_fixture("npd-pnpm-v9-catalog", &["--pin-catalog", "--json"]);
+    assert_eq!(code, 1);
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    insta::assert_snapshot!(
+        "pin_catalog_json",
+        serde_json::to_string_pretty(&json).unwrap()
+    );
+}
+
+fn copy_fixture_dir_to_tmp(fixture: &str) -> tempfile::TempDir {
+    let src = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../fixtures")
+        .join(fixture);
+    let tmp = tempfile::TempDir::new().unwrap();
+    for entry in std::fs::read_dir(&src).unwrap() {
+        let entry = entry.unwrap();
+        let to = tmp.path().join(entry.file_name());
+        std::fs::copy(entry.path(), to).unwrap();
+    }
+    tmp
+}
+
+#[test]
+fn cli_pin_catalog_update_rewrites_workspace_yaml() {
+    let tmp = copy_fixture_dir_to_tmp("npd-pnpm-v9-catalog");
+    let output = npd_binary()
+        .current_dir(tmp.path())
+        .args(["-u", "--pin-catalog"])
+        .output()
+        .unwrap();
+    let code = output.status.code().unwrap_or(-1);
+    assert_eq!(code, 1);
+
+    let pkg = std::fs::read_to_string(tmp.path().join("package.json")).unwrap();
+    assert!(pkg.contains("\"foo\": \"1.0.5\""), "{pkg}");
+    // catalog refs must stay intact in package.json.
+    assert!(pkg.contains("\"fizz\": \"catalog:\""), "{pkg}");
+    assert!(pkg.contains("\"quux\": \"catalog:set1\""), "{pkg}");
+
+    let yaml = std::fs::read_to_string(tmp.path().join("pnpm-workspace.yaml")).unwrap();
+    assert!(yaml.contains("fizz: 18.2.0"), "{yaml}");
+    assert!(yaml.contains("quux: 3.4.21"), "{yaml}");
+    // already-pinned entry must be left untouched.
+    assert!(yaml.contains("buzz: 4.17.21"), "{yaml}");
+    // and the unpinned range must be gone.
+    assert!(!yaml.contains("^18.0.0"), "{yaml}");
+    assert!(!yaml.contains("^3.4.0"), "{yaml}");
+}
+
+#[test]
+fn cli_pin_catalog_without_update_does_not_touch_yaml() {
+    let tmp = copy_fixture_dir_to_tmp("npd-pnpm-v9-catalog");
+    let before = std::fs::read_to_string(tmp.path().join("pnpm-workspace.yaml")).unwrap();
+    let output = npd_binary()
+        .current_dir(tmp.path())
+        .args(["--pin-catalog"])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code().unwrap_or(-1), 1);
+    let after = std::fs::read_to_string(tmp.path().join("pnpm-workspace.yaml")).unwrap();
+    assert_eq!(before, after);
+}
+
+#[test]
+fn cli_pin_catalog_on_non_pnpm_project_warns_and_ignores() {
+    let tmp = copy_fixture_to_tmp("npd-npm-v3-unpinned-deps");
+    let output = npd_binary()
+        .current_dir(tmp.path())
+        .args(["--pin-catalog", "--json"])
+        .output()
+        .unwrap();
+    let code = output.status.code().unwrap_or(-1);
+    assert_eq!(code, 1);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("pnpm-only"), "stderr: {stderr}");
+}
+
+#[test]
 fn cli_help_lists_core_flags() {
     let output = npd_binary().arg("--help").output().unwrap();
     let stdout = String::from_utf8_lossy(&output.stdout);

--- a/crates/riri-npd/tests/snapshots/cli_snapshots__cli_npd_fixture@npd-pnpm-v9-catalog.snap
+++ b/crates/riri-npd/tests/snapshots/cli_snapshots__cli_npd_fixture@npd-pnpm-v9-catalog.snap
@@ -1,0 +1,17 @@
+---
+source: crates/riri-npd/tests/cli_snapshots.rs
+expression: snapshot
+---
+exit: 1
+---
+  Detecting lockfile...
+  Detected pnpm-lock.yaml
+  Reading package.json...
+  Read package.json
+  Parsing lockfile...
+  Parsed lockfile
+  Computing dependency pins...
+  Computed dependency pins
+    foo  ^1.0.0  →  1.0.5
+
+  Run npd -v -u to upgrade package.json.

--- a/crates/riri-npd/tests/snapshots/cli_snapshots__pin_catalog_json.snap
+++ b/crates/riri-npd/tests/snapshots/cli_snapshots__pin_catalog_json.snap
@@ -1,0 +1,28 @@
+---
+source: crates/riri-npd/tests/cli_snapshots.rs
+expression: serde_json::to_string_pretty(&json).unwrap()
+---
+{
+  "pins": [
+    {
+      "name": "foo",
+      "kind": "dependencies",
+      "from": "^1.0.0",
+      "to": "1.0.5"
+    },
+    {
+      "name": "fizz",
+      "kind": "catalog",
+      "catalog": null,
+      "from": "^18.0.0",
+      "to": "18.2.0"
+    },
+    {
+      "name": "quux",
+      "kind": "catalog",
+      "catalog": "set1",
+      "from": "^3.4.0",
+      "to": "3.4.21"
+    }
+  ]
+}

--- a/crates/riri-pnpm/Cargo.toml
+++ b/crates/riri-pnpm/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 
 [dependencies]
 riri-common = { workspace = true }
+riri-find-up = { workspace = true }
 serde = { workspace = true }
 serde-saphyr = "0.0.26"
 thiserror = { workspace = true }
@@ -14,6 +15,7 @@ thiserror = { workspace = true }
 [dev-dependencies]
 insta = { workspace = true }
 rstest = { workspace = true }
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/riri-pnpm/src/catalog.rs
+++ b/crates/riri-pnpm/src/catalog.rs
@@ -1,0 +1,574 @@
+//! pnpm catalog support (pnpm-workspace.yaml).
+//!
+//! Reads the `catalog:` (default) and `catalogs:<name>:` (named) maps
+//! from `pnpm-workspace.yaml`, and provides targeted line-edit for
+//! rewriting a single entry while preserving comments + key order.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use riri_find_up::find_up;
+
+#[derive(Debug, thiserror::Error)]
+pub enum CatalogError {
+    #[error("invalid YAML: {0}")]
+    Yaml(#[from] serde_saphyr::Error),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum CatalogEditError {
+    #[error("catalog block not found in pnpm-workspace.yaml")]
+    BlockNotFound,
+    #[error("key `{0}` not found in catalog block")]
+    KeyNotFound(String),
+    #[error("entry `{0}` uses an unsupported multiline yaml value")]
+    Multiline(String),
+}
+
+#[derive(Debug, Clone)]
+pub struct PnpmCatalog {
+    pub default: BTreeMap<String, String>,
+    pub named: BTreeMap<String, BTreeMap<String, String>>,
+    pub raw: String,
+}
+
+/// Walks up from `start` looking for `pnpm-workspace.yaml`. Returns the path
+/// if found.
+#[must_use]
+pub fn find_workspace_yaml(start: &Path) -> Option<PathBuf> {
+    find_up(start, &["pnpm-workspace.yaml"]).into_iter().next()
+}
+
+fn line_indent(line: &str) -> usize {
+    line.chars().take_while(|c| *c == ' ').count()
+}
+
+fn unquote_key(raw: &str) -> &str {
+    let bytes = raw.as_bytes();
+    if bytes.len() >= 2
+        && ((bytes[0] == b'\'' && bytes[bytes.len() - 1] == b'\'')
+            || (bytes[0] == b'"' && bytes[bytes.len() - 1] == b'"'))
+    {
+        &raw[1..raw.len() - 1]
+    } else {
+        raw
+    }
+}
+
+/// Returns `(key_raw, value_start, value_end)` byte offsets into `line` for
+/// a `<indent><key>: <value>[<trailing>]` line, or `None` if it does not match.
+fn split_kv(line: &str) -> Option<(&str, usize, usize)> {
+    let trimmed = line.trim_start();
+    if trimmed.is_empty() || trimmed.starts_with('#') {
+        return None;
+    }
+    let indent = line.len() - trimmed.len();
+
+    // Find the key terminator `:`.
+    let mut chars = trimmed.char_indices();
+    let mut key_end = None;
+    let mut in_single = false;
+    let mut in_double = false;
+    for (offset, ch) in &mut chars {
+        match ch {
+            '\'' if !in_double => in_single = !in_single,
+            '"' if !in_single => in_double = !in_double,
+            ':' if !in_single && !in_double => {
+                key_end = Some(offset);
+                break;
+            }
+            _ => {}
+        }
+    }
+    let key_end = key_end?;
+    let key = trimmed[..key_end].trim_end();
+
+    let after_colon = key_end + ':'.len_utf8();
+    let value_part = &trimmed[after_colon..];
+    let value_offset_in_trimmed = after_colon + (value_part.len() - value_part.trim_start().len());
+    let value_start_in_trimmed = value_offset_in_trimmed;
+
+    // Find value end: stop before unescaped `#` (after at least one space) or EOL.
+    // `prev_space = true` initially because `value_str` starts after `trim_start`
+    // of the value section: either at least one space was consumed (so the char
+    // before `value_str[0]` is a space), or the value section is empty.
+    let value_str = &trimmed[value_start_in_trimmed..];
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut value_end_in_value = value_str.len();
+    let mut prev_space = true;
+    for (offset, ch) in value_str.char_indices() {
+        match ch {
+            '\'' if !in_double => in_single = !in_single,
+            '"' if !in_single => in_double = !in_double,
+            '#' if !in_single && !in_double && prev_space => {
+                value_end_in_value = offset;
+                break;
+            }
+            _ => {}
+        }
+        prev_space = ch == ' ' || ch == '\t';
+    }
+    let value_end_in_trimmed =
+        value_start_in_trimmed + value_str[..value_end_in_value].trim_end().len();
+
+    Some((
+        key,
+        indent + value_start_in_trimmed,
+        indent + value_end_in_trimmed,
+    ))
+}
+
+fn value_needs_quoting(value: &str) -> bool {
+    value.is_empty()
+        || value.chars().any(|c| {
+            matches!(
+                c,
+                ':' | '#'
+                    | '?'
+                    | ','
+                    | '['
+                    | ']'
+                    | '{'
+                    | '}'
+                    | '&'
+                    | '*'
+                    | '!'
+                    | '|'
+                    | '>'
+                    | '\''
+                    | '"'
+                    | '%'
+                    | '@'
+                    | '`'
+            )
+        })
+        || value.starts_with('-')
+        || value.starts_with(char::is_whitespace)
+}
+
+fn quote_value(value: &str) -> String {
+    let escaped = value.replace('\\', "\\\\").replace('"', "\\\"");
+    format!("\"{escaped}\"")
+}
+
+/// Locates the body indent + line range `[start_line_idx, end_line_idx)` for a
+/// catalog block.
+fn locate_block(lines: &[&str], catalog_name: Option<&str>) -> Option<(usize, usize, usize)> {
+    let header = match catalog_name {
+        None => "catalog:",
+        Some(_) => "catalogs:",
+    };
+
+    let header_line = lines.iter().position(|l| l.trim_end() == header)?;
+
+    if let Some(name) = catalog_name {
+        // Find `<indent>name:` under `catalogs:`.
+        let catalogs_indent = line_indent(lines[header_line]);
+        let mut name_line = None;
+        for (idx, line) in lines.iter().enumerate().skip(header_line + 1) {
+            let trimmed = line.trim_end();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let indent = line_indent(line);
+            if indent <= catalogs_indent {
+                break;
+            }
+            if trimmed.trim_start() == format!("{name}:") {
+                name_line = Some(idx);
+                break;
+            }
+        }
+        let name_line = name_line?;
+        let name_indent = line_indent(lines[name_line]);
+        let body_start = name_line + 1;
+        let mut body_indent = None;
+        let mut body_end = lines.len();
+        for (idx, line) in lines.iter().enumerate().skip(body_start) {
+            if line.trim().is_empty() {
+                continue;
+            }
+            let indent = line_indent(line);
+            if indent <= name_indent {
+                body_end = idx;
+                break;
+            }
+            if body_indent.is_none() {
+                body_indent = Some(indent);
+            }
+        }
+        Some((body_indent?, body_start, body_end))
+    } else {
+        let header_indent = line_indent(lines[header_line]);
+        let body_start = header_line + 1;
+        let mut body_indent = None;
+        let mut body_end = lines.len();
+        for (idx, line) in lines.iter().enumerate().skip(body_start) {
+            if line.trim().is_empty() {
+                continue;
+            }
+            let indent = line_indent(line);
+            if indent <= header_indent {
+                body_end = idx;
+                break;
+            }
+            if body_indent.is_none() {
+                body_indent = Some(indent);
+            }
+        }
+        Some((body_indent?, body_start, body_end))
+    }
+}
+
+impl PnpmCatalog {
+    /// Parse a `pnpm-workspace.yaml` content string.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CatalogError::Yaml`] if the YAML is invalid.
+    pub fn parse(yaml: &str) -> Result<Self, CatalogError> {
+        #[derive(Debug, serde::Deserialize, Default)]
+        struct Root {
+            #[serde(default)]
+            catalog: BTreeMap<String, String>,
+            #[serde(default)]
+            catalogs: BTreeMap<String, BTreeMap<String, String>>,
+        }
+
+        if yaml.trim().is_empty() {
+            return Ok(Self {
+                default: BTreeMap::new(),
+                named: BTreeMap::new(),
+                raw: yaml.to_string(),
+            });
+        }
+
+        let root: Root = serde_saphyr::from_str(yaml)?;
+        Ok(Self {
+            default: root.catalog,
+            named: root.catalogs,
+            raw: yaml.to_string(),
+        })
+    }
+
+    /// Resolves a `catalog:` (when `catalog_name` is `None`) or
+    /// `catalog:<name>` reference to the entry value.
+    #[must_use]
+    pub fn find_entry(&self, dep: &str, catalog_name: Option<&str>) -> Option<&str> {
+        match catalog_name {
+            None => self.default.get(dep).map(String::as_str),
+            Some(name) => self
+                .named
+                .get(name)
+                .and_then(|m| m.get(dep))
+                .map(String::as_str),
+        }
+    }
+
+    /// Rewrite a single catalog entry in `raw` and return the new content.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CatalogEditError`] if the catalog block or the key cannot
+    /// be located, or if the existing entry uses an unsupported multiline
+    /// YAML form.
+    pub fn edit_line(
+        raw: &str,
+        catalog_name: Option<&str>,
+        dep: &str,
+        new_value: &str,
+    ) -> Result<String, CatalogEditError> {
+        let lines: Vec<&str> = raw.split_inclusive('\n').collect();
+        let line_refs: Vec<&str> = lines.iter().map(|l| l.trim_end_matches('\n')).collect();
+
+        let (body_indent, body_start, body_end) =
+            locate_block(&line_refs, catalog_name).ok_or(CatalogEditError::BlockNotFound)?;
+
+        for idx in body_start..body_end {
+            let line = line_refs[idx];
+            if line_indent(line) != body_indent {
+                continue;
+            }
+            let Some((raw_key, val_start, val_end)) = split_kv(line) else {
+                continue;
+            };
+            if unquote_key(raw_key) != dep {
+                continue;
+            }
+
+            let value_slice = &line[val_start..val_end];
+            if matches!(value_slice, ">" | "|" | ">-" | "|-" | ">+" | "|+")
+                || value_slice.starts_with('[')
+                || value_slice.starts_with('{')
+            {
+                return Err(CatalogEditError::Multiline(dep.to_string()));
+            }
+
+            let new_token = if value_needs_quoting(new_value) {
+                quote_value(new_value)
+            } else {
+                new_value.to_string()
+            };
+
+            // When the existing value is empty and the trailing region begins
+            // with `#`, the leading space that separated the (empty) value from
+            // the comment was consumed by `trim_start` in `split_kv`. Inject a
+            // space so the new value is not glued to the comment marker.
+            let trailing = &line[val_end..];
+            let separator = if value_slice.is_empty() && trailing.starts_with('#') {
+                " "
+            } else {
+                ""
+            };
+            let new_line = format!(
+                "{}{}{}{}",
+                &line[..val_start],
+                new_token,
+                separator,
+                trailing,
+            );
+            let mut out = String::with_capacity(raw.len() + new_token.len());
+            for (i, original) in lines.iter().enumerate() {
+                if i == idx {
+                    out.push_str(&new_line);
+                    let original_with_newline = lines[idx];
+                    let newline_len = original_with_newline.len() - line.len();
+                    out.push_str(
+                        &original_with_newline[original_with_newline.len() - newline_len..],
+                    );
+                } else {
+                    out.push_str(original);
+                }
+            }
+            return Ok(out);
+        }
+
+        Err(CatalogEditError::KeyNotFound(dep.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod parse_tests {
+    use super::*;
+
+    #[test]
+    fn parses_default_catalog() {
+        let yaml = r#"
+catalog:
+  react: ^18.0.0
+  lodash: "^4.17.21"
+"#;
+        let catalog = PnpmCatalog::parse(yaml).expect("parse");
+        assert_eq!(
+            catalog.default.get("react").map(String::as_str),
+            Some("^18.0.0")
+        );
+        assert_eq!(
+            catalog.default.get("lodash").map(String::as_str),
+            Some("^4.17.21")
+        );
+        assert!(catalog.named.is_empty());
+    }
+
+    #[test]
+    fn parses_named_catalogs() {
+        let yaml = r"
+catalogs:
+  vue3:
+    vue: ^3.4.0
+    pinia: ^2.1.0
+  react17:
+    react: ^17.0.2
+";
+        let catalog = PnpmCatalog::parse(yaml).expect("parse");
+        assert_eq!(
+            catalog.named["vue3"].get("vue").map(String::as_str),
+            Some("^3.4.0")
+        );
+        assert_eq!(
+            catalog.named["vue3"].get("pinia").map(String::as_str),
+            Some("^2.1.0")
+        );
+        assert_eq!(
+            catalog.named["react17"].get("react").map(String::as_str),
+            Some("^17.0.2")
+        );
+        assert!(catalog.default.is_empty());
+    }
+
+    #[test]
+    fn parses_both_default_and_named() {
+        let yaml = r"
+catalog:
+  react: ^18.0.0
+catalogs:
+  vue3:
+    vue: ^3.4.0
+";
+        let catalog = PnpmCatalog::parse(yaml).expect("parse");
+        assert_eq!(
+            catalog.default.get("react").map(String::as_str),
+            Some("^18.0.0")
+        );
+        assert_eq!(
+            catalog.named["vue3"].get("vue").map(String::as_str),
+            Some("^3.4.0")
+        );
+    }
+
+    #[test]
+    fn parses_scoped_package_names() {
+        let yaml = r#"
+catalog:
+  '@scope/pkg': ^1.0.0
+  "@other/pkg": ^2.0.0
+"#;
+        let catalog = PnpmCatalog::parse(yaml).expect("parse");
+        assert_eq!(
+            catalog.default.get("@scope/pkg").map(String::as_str),
+            Some("^1.0.0")
+        );
+        assert_eq!(
+            catalog.default.get("@other/pkg").map(String::as_str),
+            Some("^2.0.0")
+        );
+    }
+
+    #[test]
+    fn find_entry_default_vs_named() {
+        let yaml = r"
+catalog:
+  react: ^18.0.0
+catalogs:
+  vue3:
+    vue: ^3.4.0
+";
+        let catalog = PnpmCatalog::parse(yaml).expect("parse");
+        assert_eq!(catalog.find_entry("react", None), Some("^18.0.0"));
+        assert_eq!(catalog.find_entry("vue", Some("vue3")), Some("^3.4.0"));
+        assert_eq!(catalog.find_entry("missing", None), None);
+        assert_eq!(catalog.find_entry("react", Some("vue3")), None);
+    }
+
+    #[test]
+    fn preserves_raw_content() {
+        let yaml = "catalog:\n  react: ^18.0.0\n";
+        let catalog = PnpmCatalog::parse(yaml).expect("parse");
+        assert_eq!(catalog.raw, yaml);
+    }
+}
+
+#[cfg(test)]
+mod edit_tests {
+    use super::*;
+
+    #[test]
+    fn edits_unquoted_value_in_default_catalog() {
+        let yaml = "catalog:\n  react: ^18.0.0\n  lodash: ^4.17.21\n";
+        let out = PnpmCatalog::edit_line(yaml, None, "react", "18.2.0").expect("edit");
+        assert_eq!(out, "catalog:\n  react: 18.2.0\n  lodash: ^4.17.21\n");
+    }
+
+    #[test]
+    fn edits_double_quoted_value_preserving_trailing_comment() {
+        let yaml = "catalog:\n  lodash: \"^4.17.21\" # pinned for security\n";
+        let out = PnpmCatalog::edit_line(yaml, None, "lodash", "4.17.25").expect("edit");
+        assert_eq!(out, "catalog:\n  lodash: 4.17.25 # pinned for security\n");
+    }
+
+    #[test]
+    fn edits_single_quoted_scoped_key() {
+        let yaml = "catalog:\n  '@scope/pkg': ^1.0.0\n";
+        let out = PnpmCatalog::edit_line(yaml, None, "@scope/pkg", "1.1.0").expect("edit");
+        assert_eq!(out, "catalog:\n  '@scope/pkg': 1.1.0\n");
+    }
+
+    #[test]
+    fn edits_entry_in_named_catalog() {
+        let yaml = "catalogs:\n  vue3:\n    vue: ^3.4.0\n    pinia: ^2.1.0\n";
+        let out = PnpmCatalog::edit_line(yaml, Some("vue3"), "pinia", "2.1.7").expect("edit");
+        assert_eq!(
+            out,
+            "catalogs:\n  vue3:\n    vue: ^3.4.0\n    pinia: 2.1.7\n"
+        );
+    }
+
+    #[test]
+    fn quotes_new_value_when_it_contains_special_chars() {
+        let yaml = "catalog:\n  react: ^18.0.0\n";
+        let out = PnpmCatalog::edit_line(yaml, None, "react", ">=18.0.0").expect("edit");
+        assert_eq!(out, "catalog:\n  react: \">=18.0.0\"\n");
+    }
+
+    #[test]
+    fn errors_when_catalog_block_missing() {
+        let yaml = "packages:\n  - apps/*\n";
+        let err = PnpmCatalog::edit_line(yaml, None, "react", "18.2.0").expect_err("err");
+        assert!(matches!(err, CatalogEditError::BlockNotFound));
+    }
+
+    #[test]
+    fn errors_when_named_catalog_missing() {
+        let yaml = "catalogs:\n  vue3:\n    vue: ^3.4.0\n";
+        let err =
+            PnpmCatalog::edit_line(yaml, Some("react17"), "react", "17.0.2").expect_err("err");
+        assert!(matches!(err, CatalogEditError::BlockNotFound));
+    }
+
+    #[test]
+    fn errors_when_key_missing() {
+        let yaml = "catalog:\n  react: ^18.0.0\n";
+        let err = PnpmCatalog::edit_line(yaml, None, "lodash", "4.17.21").expect_err("err");
+        match err {
+            CatalogEditError::KeyNotFound(name) => assert_eq!(name, "lodash"),
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn errors_on_multiline_value() {
+        let yaml = "catalog:\n  react: >\n    ^18.0.0\n";
+        let err = PnpmCatalog::edit_line(yaml, None, "react", "18.2.0").expect_err("err");
+        assert!(matches!(err, CatalogEditError::Multiline(_)));
+    }
+
+    #[test]
+    fn preserves_trailing_comment_when_value_is_empty() {
+        // Currently this yaml is unusual (empty value = null), but if we are asked
+        // to overwrite it, the trailing comment must survive.
+        let yaml = "catalog:\n  react: # pinned\n";
+        let out = PnpmCatalog::edit_line(yaml, None, "react", "18.2.0").expect("edit");
+        assert_eq!(out, "catalog:\n  react: 18.2.0 # pinned\n");
+    }
+}
+
+#[cfg(test)]
+mod find_tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn finds_yaml_in_start_dir() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        fs::write(tmp.path().join("pnpm-workspace.yaml"), "catalog: {}\n").expect("write");
+        let found = find_workspace_yaml(tmp.path()).expect("found");
+        assert_eq!(found, tmp.path().join("pnpm-workspace.yaml"));
+    }
+
+    #[test]
+    fn finds_yaml_in_parent_dir() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        fs::write(tmp.path().join("pnpm-workspace.yaml"), "catalog: {}\n").expect("write");
+        let nested = tmp.path().join("apps/web");
+        fs::create_dir_all(&nested).expect("nested");
+        let found = find_workspace_yaml(&nested).expect("found");
+        assert_eq!(found, tmp.path().join("pnpm-workspace.yaml"));
+    }
+
+    #[test]
+    fn returns_none_when_absent() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        assert!(find_workspace_yaml(tmp.path()).is_none());
+    }
+}

--- a/crates/riri-pnpm/src/lib.rs
+++ b/crates/riri-pnpm/src/lib.rs
@@ -3,6 +3,8 @@
 //! Parses the lockfile and exposes engine constraints per dependency
 //! via the [`LockfileEngines`] trait.
 
+pub mod catalog;
+
 use riri_common::{Engines, LockfileEngines, LockfileVersions};
 use serde::Deserialize;
 use std::collections::HashMap;

--- a/crates/riri-pnpm/tests/snapshots/parse_fixtures__parse_pnpm_fixture@pnpm-v9-catalog.snap
+++ b/crates/riri-pnpm/tests/snapshots/parse_fixtures__parse_pnpm_fixture@pnpm-v9-catalog.snap
@@ -1,0 +1,5 @@
+---
+source: crates/riri-pnpm/tests/parse_fixtures.rs
+expression: snapshot
+---
+fake-lib-a@4.17.21: {node: >=6.9.0}

--- a/fixtures/npd-pnpm-v9-catalog/package.json
+++ b/fixtures/npd-pnpm-v9-catalog/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "fake-catalog",
+  "private": true,
+  "dependencies": {
+    "fizz": "catalog:",
+    "foo": "^1.0.0",
+    "quux": "catalog:set1"
+  }
+}

--- a/fixtures/npd-pnpm-v9-catalog/pnpm-lock.yaml
+++ b/fixtures/npd-pnpm-v9-catalog/pnpm-lock.yaml
@@ -1,0 +1,36 @@
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    dependencies:
+      foo:
+        specifier: ^1.0.0
+        version: 1.0.5
+      fizz:
+        specifier: ^18.0.0
+        version: 18.2.0
+      quux:
+        specifier: ^3.4.0
+        version: 3.4.21
+      buzz:
+        specifier: 4.17.21
+        version: 4.17.21
+
+packages:
+
+  foo@1.0.5:
+    resolution:
+      integrity: sha512-placeholder
+
+  fizz@18.2.0:
+    resolution:
+      integrity: sha512-placeholder
+
+  quux@3.4.21:
+    resolution:
+      integrity: sha512-placeholder
+
+  buzz@4.17.21:
+    resolution:
+      integrity: sha512-placeholder

--- a/fixtures/npd-pnpm-v9-catalog/pnpm-workspace.yaml
+++ b/fixtures/npd-pnpm-v9-catalog/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+catalog:
+  fizz: ^18.0.0
+  buzz: 4.17.21
+catalogs:
+  set1:
+    quux: ^3.4.0

--- a/fixtures/pnpm-v9-catalog/package.json
+++ b/fixtures/pnpm-v9-catalog/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "fake",
+  "private": true,
+  "dependencies": {
+    "fake-lib-a": "catalog:"
+  }
+}

--- a/fixtures/pnpm-v9-catalog/pnpm-lock.yaml
+++ b/fixtures/pnpm-v9-catalog/pnpm-lock.yaml
@@ -1,0 +1,20 @@
+lockfileVersion: '9.0'
+
+importers:
+  .:
+    dependencies:
+      fake-lib-a:
+        specifier: 'catalog:'
+        version: 4.17.21
+
+packages:
+
+  fake-lib-a@4.17.21:
+    resolution:
+      integrity: sha512-placeholder
+    engines:
+      node: '>=6.9.0'
+
+snapshots:
+
+  fake-lib-a@4.17.21: {}

--- a/fixtures/pnpm-v9-catalog/pnpm-workspace.yaml
+++ b/fixtures/pnpm-v9-catalog/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+catalog:
+  fake-lib-a: ^4.17.21


### PR DESCRIPTION
Adds pnpm v9+ catalog awareness to `riri-npd`.

## Summary
1. **Baseline bug fix** (always on): `catalog:` and `catalog:<name>` specifiers in package.json deps are now skipped (alongside `file:`, `link:`, `workspace:`). Without this, npd silently proposes pinning the concrete lockfile version into package.json, breaking pnpm catalog projects.
2. **`--pin-catalog` flag**: resolves catalog entries in `pnpm-workspace.yaml` against the lockfile and, on `-u`, rewrites the yaml in place via targeted line-edit (comments + ordering preserved).
3. **Warnings** (non-fatal) when `--pin-catalog` runs against a non-pnpm project or when `pnpm-workspace.yaml` is absent.
4. **New JSON shape**: catalog pins emitted with `kind: "catalog"` and `catalog: "<name>" | null`.

## Test plan
- [x] Skip rules cover `catalog:` and `catalog:<name>`
- [x] `riri-pnpm::catalog::parse` covers default + named + scoped keys
- [x] `riri-pnpm::catalog::edit_line` preserves comments + ordering across quoted variants
- [x] CLI snapshot tests via `cli_npd_fixture` glob auto-discover new fixtures
- [x] `-u --pin-catalog` rewrites pnpm-workspace.yaml atomically
- [x] NAPI `runCli` smoke test for `--pin-catalog`