### PR TITLE
chore(deps): bump oxfmt v0.47.0 → v0.49.0 & oxlint v1.62.0 → v1.64.0 in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,13 +18,13 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/oxc-project/mirrors-oxfmt
-    rev: "v0.47.0"
+    rev: "v0.49.0"
     hooks:
       - id: oxfmt
         types_or: [javascript, jsx, ts, tsx, json, yaml, markdown, css]
 
   - repo: https://github.com/oxc-project/mirrors-oxlint
-    rev: "v1.62.0"
+    rev: "v1.64.0"
     hooks:
       - id: oxlint
 


### PR DESCRIPTION
## Summary
- `oxc-project/mirrors-oxfmt` v0.47.0 → v0.49.0
- `oxc-project/mirrors-oxlint` v1.62.0 → v1.64.0

Matches versions already bumped in `bench-compare-action` devDeps in #151.

## Test plan
- [x] `pre-commit run --all-files` green