### PR TITLE
fix(ci): scan all push commits for release marker & match scoped npm tag prefix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,16 @@ jobs:
       - name: Test
         run: cargo test --workspace --verbose
       - name: Set release-please variables
+        env:
+          HAS_RELEASE_COMMIT: ${{ contains(toJson(github.event.commits.*.message), 'chore(main): release') }}
         run: |
-          echo "skip_github_pull_request=${{ startsWith(github.event.head_commit.message, 'chore(main): release') }}" >> $GITHUB_ENV
-          echo "skip_github_release=${{ !startsWith(github.event.head_commit.message, 'chore(main): release') }}" >> $GITHUB_ENV
+          if [ "$HAS_RELEASE_COMMIT" = "true" ]; then
+            echo "skip_github_pull_request=true"  >> $GITHUB_ENV
+            echo "skip_github_release=false"      >> $GITHUB_ENV
+          else
+            echo "skip_github_pull_request=false" >> $GITHUB_ENV
+            echo "skip_github_release=true"       >> $GITHUB_ENV
+          fi
       - name: Prepare release
         id: release
         uses: googleapis/release-please-action@v5

--- a/.github/workflows/publish-nce.yml
+++ b/.github/workflows/publish-nce.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   napi:
-    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'npm-check-engines-') }}
+    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, '@smarlhens/npm-check-engines-') }}
     uses: ./.github/workflows/napi.yml
     permissions:
       contents: read

--- a/.github/workflows/publish-npd.yml
+++ b/.github/workflows/publish-npd.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   napi:
-    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'npm-pin-dependencies-') }}
+    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, '@smarlhens/npm-pin-dependencies-') }}
     uses: ./.github/workflows/napi.yml
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- `ci.yml`: scan all commits in push (not just HEAD) for `chore(main): release` so the lockfile-update commit added by `update-lockfile` job no longer hides the release commit
- `publish-nce.yml` / `publish-npd.yml`: tag prefix filter updated to `@smarlhens/npm-check-engines-` / `@smarlhens/npm-pin-dependencies-` to match scoped npm package names produced by release-please

## Context
After merging #149, no GitHub release / npm publish fired:
1. `update-lockfile` pushed `chore: update Cargo.lock` on top of the release-please branch. On rebase-merge it became HEAD on main, so `startsWith(github.event.head_commit.message, 'chore(main): release')` was false → `skip-github-release=true`.
2. After manual `release.yml` dispatch produced tag `@smarlhens/npm-check-engines-v1.0.0`, both publish workflows were skipped because their `if:` checked `startsWith(..., 'npm-check-engines-')`, missing the `@smarlhens/` scope.

## Test plan
- [ ] Next release-please PR merge produces a GitHub release tag automatically
- [ ] `publish-nce` / `publish-npd` jobs run (not skipped) when matching tag is created