### PR TITLE
fix(ci): quote release-please expression env value & add actionlint pre-commit hook

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,7 @@
+paths:
+  .github/workflows/pr-bench.yml:
+    # bench-compare is a JS action whose dist/ is built at runtime
+    # (npm ci && npm run bundle) in the workflow before invocation,
+    # so the static check for the bundle file is a false positive.
+    ignore:
+      - 'file "dist/index.js" does not exist'

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,34 @@
+name: actionlint
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+      - ".github/actionlint.yaml"
+  pull_request:
+    branches: ["**"]
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+      - ".github/actionlint.yaml"
+
+permissions: {}
+
+jobs:
+  actionlint:
+    name: Run actionlint
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run actionlint
+        uses: docker://rhysd/actionlint:1.7.12
+        with:
+          args: -color -shellcheck=

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Run actionlint
         uses: docker://rhysd/actionlint:1.7.12
         with:
-          args: -color -shellcheck=
+          args: -color

--- a/.github/workflows/bench-run.yml
+++ b/.github/workflows/bench-run.yml
@@ -113,7 +113,9 @@ jobs:
         env:
           BENCH_TARGETS: ${{ steps.discover.outputs.targets }}
           BASELINE_NAME: ${{ inputs.baseline-name }}
-        run: cargo bench $BENCH_TARGETS -- --save-baseline "$BASELINE_NAME"
+        run: |
+          read -ra targets <<< "$BENCH_TARGETS"
+          cargo bench "${targets[@]}" -- --save-baseline "$BASELINE_NAME"
 
       - name: Upload criterion baselines
         uses: actions/upload-artifact@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         run: cargo test --workspace --verbose
       - name: Set release-please variables
         env:
-          HAS_RELEASE_COMMIT: ${{ contains(toJson(github.event.commits.*.message), 'chore(main): release') }}
+          HAS_RELEASE_COMMIT: "${{ contains(toJson(github.event.commits.*.message), 'chore(main): release') }}"
         run: |
           if [ "$HAS_RELEASE_COMMIT" = "true" ]; then
             echo "skip_github_pull_request=true"  >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,11 +67,11 @@ jobs:
           HAS_RELEASE_COMMIT: "${{ contains(toJson(github.event.commits.*.message), 'chore(main): release') }}"
         run: |
           if [ "$HAS_RELEASE_COMMIT" = "true" ]; then
-            echo "skip_github_pull_request=true"  >> $GITHUB_ENV
-            echo "skip_github_release=false"      >> $GITHUB_ENV
+            echo "skip_github_pull_request=true"  >> "$GITHUB_ENV"
+            echo "skip_github_release=false"      >> "$GITHUB_ENV"
           else
-            echo "skip_github_pull_request=false" >> $GITHUB_ENV
-            echo "skip_github_release=true"       >> $GITHUB_ENV
+            echo "skip_github_pull_request=false" >> "$GITHUB_ENV"
+            echo "skip_github_release=true"       >> "$GITHUB_ENV"
           fi
       - name: Prepare release
         id: release

--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -246,8 +246,9 @@ jobs:
         id: tag
         run: |
           VERSION=$(node -p "require('./package.json').version")
-          if echo "$VERSION" | grep -q "-"; then
-            TAG=$(echo "$VERSION" | sed 's/.*-\([a-z]*\).*/\1/')
+          if [[ "$VERSION" == *-* ]]; then
+            TAG=${VERSION#*-}
+            TAG=${TAG%%.*}
             echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           else
             echo "tag=latest" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pr-action.yml
+++ b/.github/workflows/pr-action.yml
@@ -52,10 +52,10 @@ jobs:
         run: npm run typecheck
 
       - name: Lint
-        run: npx oxlint --config $GITHUB_WORKSPACE/oxlintrc.json
+        run: npx oxlint --config "$GITHUB_WORKSPACE/oxlintrc.json"
 
       - name: Format check
-        run: npx oxfmt --config $GITHUB_WORKSPACE/.oxfmtrc.json --check
+        run: npx oxfmt --config "$GITHUB_WORKSPACE/.oxfmtrc.json" --check
 
       - name: Bundle
         run: npm run bundle

--- a/.github/workflows/pr-bench.yml
+++ b/.github/workflows/pr-bench.yml
@@ -118,13 +118,17 @@ jobs:
           FALLBACK_RSS_KB: ${{ needs.bench-base.outputs.peak-rss-kb }}
         run: |
           if [ "$CACHE_HIT" = "true" ] && [ -d /tmp/bench-baseline ]; then
-            echo "sizes=$(cat /tmp/bench-baseline/binary-sizes.json)" >> "$GITHUB_OUTPUT"
-            echo "test_count=$(cat /tmp/bench-baseline/test-count.txt)" >> "$GITHUB_OUTPUT"
-            echo "rss_kb=$(cat /tmp/bench-baseline/peak-rss-kb.txt)" >> "$GITHUB_OUTPUT"
+            {
+              echo "sizes=$(cat /tmp/bench-baseline/binary-sizes.json)"
+              echo "test_count=$(cat /tmp/bench-baseline/test-count.txt)"
+              echo "rss_kb=$(cat /tmp/bench-baseline/peak-rss-kb.txt)"
+            } >> "$GITHUB_OUTPUT"
           else
-            echo "sizes=$FALLBACK_SIZES" >> "$GITHUB_OUTPUT"
-            echo "test_count=$FALLBACK_TEST_COUNT" >> "$GITHUB_OUTPUT"
-            echo "rss_kb=$FALLBACK_RSS_KB" >> "$GITHUB_OUTPUT"
+            {
+              echo "sizes=$FALLBACK_SIZES"
+              echo "test_count=$FALLBACK_TEST_COUNT"
+              echo "rss_kb=$FALLBACK_RSS_KB"
+            } >> "$GITHUB_OUTPUT"
           fi
 
       - name: Install action dependencies

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,11 @@ repos:
     hooks:
       - id: oxlint
 
+  - repo: https://github.com/rhysd/actionlint
+    rev: "v1.7.12"
+    hooks:
+      - id: actionlint
+
   - repo: local
     hooks:
       - id: fmt


### PR DESCRIPTION
## Summary
- `ci.yml`: wrap `HAS_RELEASE_COMMIT` env value in double quotes so YAML parser doesn't trip on the `: ` inside the `'chore(main): release'` literal embedded in the `${{ ... }}` expression
- `.pre-commit-config.yaml`: add `actionlint` hook so this class of GHA-specific YAML/expression bug fails locally instead of at workflow load time

## Context
After merging #156, GitHub Actions workflow loader rejected `ci.yml` with `Invalid workflow file: error in your yaml syntax on line 67`. PyYAML (used by `check-yaml` pre-commit hook) is more permissive than the GHA YAML parser, so the bug slipped through. `actionlint` reproduces the failure (`mapping values are not allowed in this context`).

The `-ignore 'file \"dist/index.js\" does not exist'` arg suppresses a pre-existing false positive on `.github/actions/bench-compare`, whose `dist/` is gitignored and built in CI.

## Test plan
- [ ] `pre-commit run actionlint --all-files` passes locally
- [ ] CI workflow loads & runs on this PR