### PR TITLE
chore(zizmor): bump action v0.5.4 → v0.5.6 & shorten workflow/job names

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,4 +1,4 @@
-name: GitHub Actions Security Analysis with zizmor
+name: zizmor
 
 on:
   push:
@@ -14,7 +14,7 @@ permissions: {}
 
 jobs:
   zizmor:
-    name: Run zizmor
+    name: zizmor
     runs-on: ubuntu-24.04
     permissions:
       security-events: write
@@ -27,7 +27,7 @@ jobs:
           persist-credentials: false
 
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@v0.5.4
+        uses: zizmorcore/zizmor-action@v0.5.6
         with:
           inputs: |
             .github/workflows/


### PR DESCRIPTION
## Summary
- Bump `zizmorcore/zizmor-action` from v0.5.4 to v0.5.6
- Rename workflow `name:` to `zizmor` and job `name:` to `zizmor` for consistency with the new `actionlint` workflow naming pattern

## Test plan
- [ ] zizmor workflow runs green on this PR