### PR TITLE
feat(release-please): update Cargo.lock via extra-files & drop update-lockfile job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,6 @@ jobs:
 
   rust:
     runs-on: ubuntu-24.04
-    outputs:
-      prs_created: ${{ steps.release.outputs.prs_created }}
-      pr_branch: ${{ steps.release.outputs.prs_created == 'true' && fromJson(steps.release.outputs.prs)[0].headBranchName || '' }}
     steps:
       - name: Checkout source code
         uses: actions/checkout@v6
@@ -80,27 +77,6 @@ jobs:
           skip-github-pull-request: ${{ env.skip_github_pull_request }}
           skip-github-release: ${{ env.skip_github_release }}
           token: ${{ secrets.PAT }}
-
-  update-lockfile:
-    needs: rust
-    if: needs.rust.outputs.prs_created == 'true'
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout release PR branch
-        uses: actions/checkout@v6 # zizmor: ignore[artipacked] needs persisted creds for git-auto-commit-action
-        with:
-          ref: ${{ needs.rust.outputs.pr_branch }}
-      - name: Install Rust
-        run: rustup update stable && rustup default stable
-      - name: Update Cargo.lock
-        run: cargo update --workspace
-      - name: Commit Cargo.lock
-        uses: stefanzweifel/git-auto-commit-action@v7
-        with:
-          commit_message: "chore: update Cargo.lock"
-          file_pattern: Cargo.lock
 
   bench-baseline:
     needs: changes

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -24,6 +24,11 @@
           "type": "json",
           "path": "package.json",
           "jsonpath": "$.version"
+        },
+        {
+          "type": "toml",
+          "path": "/Cargo.lock",
+          "jsonpath": "$.package[?(@.name.value=='riri-napi-nce')].version"
         }
       ]
     },
@@ -34,6 +39,11 @@
           "type": "json",
           "path": "package.json",
           "jsonpath": "$.version"
+        },
+        {
+          "type": "toml",
+          "path": "/Cargo.lock",
+          "jsonpath": "$.package[?(@.name.value=='riri-napi-npd')].version"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- Add Cargo.lock as a TOML `extra-files` entry in `release-please-config.json` for both packages, using a JSONPath filter on the workspace-member version line
- Remove the `update-lockfile` job from `ci.yml` — Cargo.lock is now bumped as part of release-please's own commit, producing a single bot-signed commit on the release PR

## Why
Previously the `update-lockfile` job pushed a separate `chore: update Cargo.lock` commit on top of the release-please PR branch. On rebase-merge that became HEAD on main, which:
- caused the release tag (created by manual `release.yml` dispatch) to land on the lockfile commit instead of the release commit, confusing release-please's state and triggering a no-op same-version PR regeneration (see PR #158)
- couldn't be solved by amending the release-please commit because that breaks the bot signature

By piggybacking the Cargo.lock update on release-please's own commit (via `extra-files`), there's no extra commit, the signature stays intact, and the release boundary is unambiguous.

## Implementation detail / gotcha
release-please's TOML updater (`GenericToml` + `parseWith` in `src/util/toml-edit.ts`) parses each TOML value into a tagged `{ start, end, value }` object so byte-offset replacements can be made without reformatting. Consequently, JSONPath filters must access `.value` instead of comparing the raw field:

```jsonc
// Doesn't match (raw comparison fails against tagged object):
"$.package[?(@.name=='riri-napi-nce')].version"
// Works:
"$.package[?(@.name.value=='riri-napi-nce')].version"
```

Verified locally that this produces a single-line update in Cargo.lock for each package (L1367 for nce, L1384 for npd) with the existing file content otherwise untouched.

## Trade-off
release-please only bumps the workspace-member `version` line in Cargo.lock. It does NOT run `cargo update --workspace`, so transitive dep refreshes no longer ride along with release PRs. That cadence now needs to live in a separate scheduled / dep-bot flow (Dependabot / Renovate already cover this).

## Test plan
- [ ] Trigger a release-please PR (e.g. land a `feat:` commit on `crates/riri-napi-*`) and verify the PR contains a single commit including both the version bump and the Cargo.lock entry update
- [ ] Verify rebase-merge of that PR results in a single commit on main and a tag pointing at it