### PR TITLE
fix(napi): disable gh-release creation in prepublish to skip wrong-tag lookup

### DIFF
--- a/crates/riri-napi-nce/package.json
+++ b/crates/riri-napi-nce/package.json
@@ -27,7 +27,7 @@
     "artifacts": "napi artifacts",
     "build": "napi build --platform --release",
     "build:debug": "napi build --platform",
-    "prepublishOnly": "napi prepublish -t npm",
+    "prepublishOnly": "napi prepublish -t npm --no-gh-release",
     "version": "napi version"
   },
   "devDependencies": {

--- a/crates/riri-napi-npd/package.json
+++ b/crates/riri-napi-npd/package.json
@@ -27,7 +27,7 @@
     "artifacts": "napi artifacts",
     "build": "napi build --platform --release",
     "build:debug": "napi build --platform",
-    "prepublishOnly": "napi prepublish -t npm",
+    "prepublishOnly": "napi prepublish -t npm --no-gh-release",
     "version": "napi version"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
Pass `--no-gh-release` to `napi prepublish` in both packages' `prepublishOnly` script.

## Why
`@napi-rs/cli` defaults to `--gh-release true`, which makes `napi prepublish` try to:
1. `POST /repos/<repo>/releases` — fails with **401 Unauthorized** because no GH token is wired into the publish env
2. `GET /repos/<repo>/releases/tags/v<version>` as fallback — fails with **404** because release-please uses scoped tags (`@smarlhens/npm-check-engines-v1.0.0`, not `v1.0.0`)

These errors are logged per per-platform sub-package publish in a loud loop. npm publish itself still succeeds (the errors are post-publish artifact-upload attempts), but the noise is misleading.

Since release-please already publishes a properly-scoped GitHub release with changelog + source archive, having napi also try to attach `.node` binaries to a GH release is redundant for npm-distributed packages — users install via npm and get the right binary per platform.

## Test plan
- [ ] Dispatch `publish-nce.yml` after merge; verify the publish job log has no 401/404 errors and no "Creating GitHub release v<version>" attempts