### PR TITLE
fix(napi): include js loader, readme, license in published tarball

### DIFF
--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -259,8 +259,8 @@ jobs:
           name: js-loader-${{ inputs.app-name }}
           path: ${{ inputs.crate-dir }}
 
-      - name: Copy README and LICENSE
-        run: cp ../../README.md ../../LICENSE.md .
+      - name: Copy LICENSE
+        run: cp ../../LICENSE.md .
 
       - name: Determine npm tag
         id: tag

--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -105,6 +105,17 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+      - name: Upload JS loader (target-agnostic)
+        if: matrix.settings.target == 'x86_64-unknown-linux-gnu'
+        uses: actions/upload-artifact@v7
+        with:
+          name: js-loader-${{ inputs.app-name }}
+          path: |
+            ${{ inputs.crate-dir }}/index.js
+            ${{ inputs.crate-dir }}/index.d.ts
+          if-no-files-found: error
+          retention-days: 1
+
   test-native:
     if: ${{ !inputs.run-publish }}
     name: test - ${{ matrix.settings.target }}
@@ -241,6 +252,15 @@ jobs:
 
       - name: Move artifacts
         run: npx napi artifacts --output-dir artifacts
+
+      - name: Download JS loader
+        uses: actions/download-artifact@v8
+        with:
+          name: js-loader-${{ inputs.app-name }}
+          path: ${{ inputs.crate-dir }}
+
+      - name: Copy README and LICENSE
+        run: cp ../../README.md ../../LICENSE.md .
 
       - name: Determine npm tag
         id: tag

--- a/crates/riri-napi-nce/README.md
+++ b/crates/riri-napi-nce/README.md
@@ -1,0 +1,190 @@
+# NPM check engines
+
+[![CI](https://github.com/smarlhens/riri-node-tools/actions/workflows/ci.yml/badge.svg)](https://github.com/smarlhens/riri-node-tools/actions/workflows/ci.yml)
+[![napi-nce](https://github.com/smarlhens/riri-node-tools/actions/workflows/napi-nce.yml/badge.svg)](https://github.com/smarlhens/riri-node-tools/actions/workflows/napi-nce.yml)
+![node-current (scoped)](https://img.shields.io/node/v/@smarlhens/npm-check-engines)
+[![license](https://img.shields.io/github/license/smarlhens/riri-node-tools)](https://github.com/smarlhens/riri-node-tools/blob/main/LICENSE.md)
+[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
+
+**npm-check-engines upgrades your package.json node engines constraint to the most restrictive used by your dependencies.**
+
+This package ships a native Rust core via [NAPI-RS](https://napi.rs/) as part of the [riri-node-tools](https://github.com/smarlhens/riri-node-tools) monorepo.
+
+---
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Installation](#installation)
+- [Usage](#usage)
+  - [CLI](#cli)
+  - [Node API](#node-api)
+- [CLI Options](#cli-options)
+- [Debug](#debug)
+- [Thanks](#thanks)
+
+---
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org/en/download/) **version `^20.17.0 || ^22.13.0 || >=23.5.0`**
+
+Supported platforms:
+
+| OS      | Arch                      |
+|---------|---------------------------|
+| Linux   | x64 (glibc/musl), arm64 (glibc/musl) |
+| macOS   | x64, arm64                |
+| Windows | x64                       |
+
+---
+
+## Installation
+
+Install globally:
+
+```sh
+npm install -g @smarlhens/npm-check-engines
+```
+
+Or run with [npx](https://docs.npmjs.com/cli/v8/commands/npx):
+
+```sh
+npx @smarlhens/npm-check-engines
+```
+
+---
+
+## Usage
+
+### CLI
+
+Compute the most restrictive `engines.node` constraint for the project in the current directory based on the lockfile (`package-lock.json`, `yarn.lock`, or `pnpm-lock.yaml`):
+
+```sh
+nce
+```
+
+Update `package.json` (and lockfile, when relevant) with the computed ranges:
+
+```sh
+nce -u
+```
+
+Emit machine-readable JSON:
+
+```sh
+nce --json
+```
+
+### Node API
+
+```typescript
+import { checkEngines } from '@smarlhens/npm-check-engines';
+
+const packageJson = '...'; // stringified package.json
+const lockfileContent = '...'; // stringified lockfile
+
+const { computedEngines, changes } = checkEngines({
+  packageJson,
+  lockfileContent,
+  lockfileType: 'npm', // optional: 'npm' | 'yarn' | 'pnpm' — auto-detected when omitted
+  filterEngines: ['node'], // optional: restrict which engines to compute
+  precision: 'patch', // optional: 'major' | 'minor' | 'patch'
+});
+
+console.log(computedEngines); // { node: '^20.17.0 || ^22.13.0 || >=23.5.0', ... }
+for (const { engine, from, to } of changes) {
+  console.log(`${engine}: "${from}" → "${to}"`);
+}
+```
+
+Additional helpers exported by the package:
+
+```typescript
+import {
+  humanizeRange,
+  intersects,
+  isSubsetOf,
+  restrictiveRange,
+  satisfies,
+  runCli,
+} from '@smarlhens/npm-check-engines';
+```
+
+- `humanizeRange(input, precision?)` — trim trailing zero components per precision rule
+- `intersects(a, b)` — do two ranges overlap
+- `isSubsetOf(a, b)` — is `a` fully contained in `b`
+- `restrictiveRange(a, b)` — return the most restrictive of two ranges
+- `satisfies(range, version)` — does a concrete version satisfy a range
+- `runCli(argv)` — run the `nce` CLI in-process; `argv[0]` must be the program name. Returns exit code.
+
+---
+
+## CLI Options
+
+```text
+Usage: nce [OPTIONS]
+
+Options:
+  -q, --quiet
+          Silent mode — no output
+  -v, --verbose
+          Verbose output
+  -d, --debug
+          Debug mode — detailed logging
+  -e, --engines <ENGINES>
+          Engine keys to check (e.g. node, npm, yarn). Defaults to all
+  -u, --update
+          Update package.json (and lockfile) with computed ranges
+      --enable-engine-strict
+          Create or update .npmrc with engine-strict=true
+      --json
+          Output results as JSON
+      --sort
+          Sort package.json keys on write (uses sort-package-json conventions)
+      --precision <PRECISION>
+          Version precision in output: major (e.g. >=24), minor (e.g. >=24.0),
+          or patch (e.g. >=24.0.0). Trailing .0 components are trimmed
+          accordingly. Non-zero components are never dropped.
+          [default: patch]
+          Possible values: major, minor, patch
+      --node-policy <NODE_POLICY>
+          Node.js lifecycle policy gate for engines.node
+          [default: supported]
+          Possible values: any, stable, supported, lts, maintenance
+      --allow-eol
+          Suppress EOL warnings (does not widen the policy)
+      --bump-npm
+          Bump engines.npm floor to match the lowest node major in range
+      --no-bump-npm
+          Disable the npm coupling pass
+      --npm-precision <NPM_PRECISION>
+          Precision applied to the npm bump floor
+          [default: major]
+          Possible values: major, minor, patch
+      --refresh
+          Fetch fresh lifecycle data from upstream and update the user cache
+  -h, --help
+          Print help
+  -V, --version
+          Print version
+```
+
+---
+
+## Debug
+
+```sh
+nce -d
+```
+
+The `-d/--debug` flag enables detailed logging to stderr. No environment variable is required.
+
+---
+
+## Thanks
+
+Originally inspired by [npm-check-updates](https://github.com/raineorshine/npm-check-updates).
+
+---

--- a/crates/riri-napi-npd/README.md
+++ b/crates/riri-napi-npd/README.md
@@ -1,0 +1,131 @@
+# NPM pin dependencies
+
+[![CI](https://github.com/smarlhens/riri-node-tools/actions/workflows/ci.yml/badge.svg)](https://github.com/smarlhens/riri-node-tools/actions/workflows/ci.yml)
+[![napi-npd](https://github.com/smarlhens/riri-node-tools/actions/workflows/napi-npd.yml/badge.svg)](https://github.com/smarlhens/riri-node-tools/actions/workflows/napi-npd.yml)
+![node-current (scoped)](https://img.shields.io/node/v/@smarlhens/npm-pin-dependencies)
+[![license](https://img.shields.io/github/license/smarlhens/riri-node-tools)](https://github.com/smarlhens/riri-node-tools/blob/main/LICENSE.md)
+[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
+
+**npm-pin-dependencies pins your `package.json` dependency ranges to the exact versions resolved by the lockfile.**
+
+This package ships a native Rust core via [NAPI-RS](https://napi.rs/) as part of the [riri-node-tools](https://github.com/smarlhens/riri-node-tools) monorepo.
+
+---
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Installation](#installation)
+- [Usage](#usage)
+  - [CLI](#cli)
+  - [Node API](#node-api)
+- [Options](#options)
+- [Debug](#debug)
+
+---
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org/en/download/) **version `^20.17.0 || ^22.13.0 || >=23.5.0`**
+
+Supported platforms:
+
+| OS      | Arch                                 |
+|---------|--------------------------------------|
+| Linux   | x64 (glibc/musl), arm64 (glibc/musl) |
+| macOS   | x64, arm64                           |
+| Windows | x64                                  |
+
+---
+
+## Installation
+
+Install globally:
+
+```sh
+npm install -g @smarlhens/npm-pin-dependencies
+```
+
+Or run with [npx](https://docs.npmjs.com/cli/v8/commands/npx):
+
+```sh
+npx @smarlhens/npm-pin-dependencies
+```
+
+---
+
+## Usage
+
+### CLI
+
+Show which `package.json` dependency ranges would be pinned to lockfile-resolved versions:
+
+```sh
+npd
+```
+
+Apply the pins to `package.json`:
+
+```sh
+npd -u
+```
+
+Emit machine-readable JSON:
+
+```sh
+npd --json
+```
+
+Supports `package-lock.json`, `yarn.lock`, and `pnpm-lock.yaml` (auto-detected).
+
+### Node API
+
+```typescript
+import { pinDependencies } from '@smarlhens/npm-pin-dependencies';
+
+const packageJson = '...'; // stringified package.json
+const lockfileContent = '...'; // stringified lockfile
+
+const { pins } = pinDependencies({
+  packageJson,
+  lockfileContent,
+  lockfileType: 'npm', // optional: 'npm' | 'yarn' | 'pnpm' — auto-detected when omitted
+});
+
+for (const { name, kind, from, to } of pins) {
+  console.log(`${kind} ${name}: "${from}" → "${to}"`);
+}
+```
+
+`runCli(argv)` is also exported to run the `npd` CLI in-process; `argv[0]` must be the program name. Returns exit code.
+
+---
+
+## Options
+
+```text
+Usage: npd [OPTIONS]
+
+Options:
+  -q, --quiet              Silent mode — no output
+  -v, --verbose            Verbose output
+  -d, --debug              Debug mode — detailed logging
+  -u, --update             Update package.json with pinned versions
+      --json               Output results as JSON
+      --sort               Sort package.json keys on write (uses sort-package-json conventions)
+      --enable-save-exact  Create or update .npmrc with save-exact=true
+  -h, --help               Print help
+  -V, --version            Print version
+```
+
+---
+
+## Debug
+
+```sh
+npd -d
+```
+
+The `-d/--debug` flag enables detailed logging to stderr. No environment variable is required.
+
+---


### PR DESCRIPTION
## summary
- upload `index.js` + `index.d.ts` once from `x86_64-unknown-linux-gnu` build (target-agnostic loader)
- publish job downloads loader artifact into crate-dir before `npm publish`
- publish job copies repo-root `README.md` + `LICENSE.md` into crate-dir (npm auto-includes only if present in package dir)

fixes broken `@smarlhens/npm-check-engines@1.0.0` tarball: shipped only `bin/nce.js` + `package.json`, missing loader stub + readme/license → `MODULE_NOT_FOUND` on `npx`.

shared `napi.yml` covers both `publish-nce` + `publish-npd`.

## test plan
- [x] `napi build --platform --release` locally emits `index.js` (25k) + `index.d.ts` for nce + npd
- [x] `npm pack --dry-run` tarball = 6 files: LICENSE.md, README.md, bin/*, index.d.ts, index.js, package.json
- [x] `node bin/nce.js --version` via `require('..')` exits 0
- [x] `napi prepublish -t npm --no-gh-release --dry-run` exits 0
- [ ] dispatch `publish-nce` workflow on bumped version, verify published tarball contents