### PR TITLE
feat(cli): decouple --sort from --update gate

### DIFF
--- a/crates/riri-napi-nce/README.md
+++ b/crates/riri-napi-nce/README.md
@@ -160,7 +160,7 @@ Options:
           Output results as JSON
 
       --sort
-          Sort package.json keys on write (uses sort-package-json conventions)
+          Sort package.json keys (sort-package-json conventions); writes the file even without --update or pending changes
 
       --precision <PRECISION>
           Version precision in output: major (e.g. >=24), minor (e.g. >=24.0), or patch (e.g. >=24.0.0). Trailing .0 components are trimmed accordingly. Non-zero components are never dropped

--- a/crates/riri-napi-npd/README.md
+++ b/crates/riri-napi-npd/README.md
@@ -124,7 +124,7 @@ Options:
   -d, --debug              Debug mode — detailed logging
   -u, --update             Update package.json with pinned versions
       --json               Output results as JSON
-      --sort               Sort package.json keys on write (uses sort-package-json conventions)
+      --sort               Sort package.json keys (sort-package-json conventions); writes the file even without --update or pending pins
       --enable-save-exact  Create or update .npmrc with save-exact=true
   -h, --help               Print help
   -V, --version            Print version

--- a/crates/riri-nce/src/cli.rs
+++ b/crates/riri-nce/src/cli.rs
@@ -61,7 +61,7 @@ pub struct Args {
     #[arg(long)]
     pub json: bool,
 
-    /// Sort package.json keys on write (uses sort-package-json conventions).
+    /// Sort package.json keys (sort-package-json conventions); writes the file even without --update or pending changes.
     #[arg(long)]
     pub sort: bool,
 
@@ -341,6 +341,13 @@ fn run(args: &Args) -> Result<i32> {
                 style(":)").green()
             );
         }
+        if args.sort {
+            let task = runner.task("Sorting package.json...");
+            pkg_file
+                .write_sorted()
+                .context("failed to write package.json")?;
+            task.complete("Sorted package.json");
+        }
         return Ok(EXIT_OK);
     }
 
@@ -383,12 +390,21 @@ fn run(args: &Args) -> Result<i32> {
                 .context("failed to write lockfile")?;
             task.complete("Updated lockfile");
         }
-    } else if !args.quiet {
-        let hint = generate_update_hint(args);
-        eprintln!(
-            "\n  Run {} to upgrade package.json.",
-            style(hint).bold().cyan()
-        );
+    } else {
+        if args.sort {
+            let task = runner.task("Sorting package.json...");
+            pkg_file
+                .write_sorted()
+                .context("failed to write package.json")?;
+            task.complete("Sorted package.json");
+        }
+        if !args.quiet {
+            let hint = generate_update_hint(args);
+            eprintln!(
+                "\n  Run {} to upgrade package.json.",
+                style(hint).bold().cyan()
+            );
+        }
     }
 
     Ok(EXIT_PINS_PENDING)

--- a/crates/riri-nce/tests/cli_snapshots.rs
+++ b/crates/riri-nce/tests/cli_snapshots.rs
@@ -366,6 +366,31 @@ fn cli_update_writes_lifecycle_rewrite() {
 }
 
 #[test]
+fn cli_sort_writes_without_update_flag() {
+    let tmp = copy_fixture_to_tmp("nce-policy-supported-eol-bump");
+    let unsorted = "{\n  \"engines\": {\n    \"node\": \">=18.0.0\"\n  },\n  \"private\": true,\n  \"name\": \"fake\"\n}\n";
+    std::fs::write(tmp.path().join("package.json"), unsorted).unwrap();
+    let pinned = pin_lifecycle(&["--sort", "--no-bump-npm"]);
+    let output = nce_binary()
+        .current_dir(tmp.path())
+        .args(&pinned)
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code().unwrap_or(-1), 1);
+    let written = std::fs::read_to_string(tmp.path().join("package.json")).unwrap();
+    assert!(
+        written.contains("\">=18.0.0\""),
+        "engines.node should be unchanged without --update: {written}"
+    );
+    let name_pos = written.find("\"name\"").unwrap();
+    let engines_pos = written.find("\"engines\"").unwrap();
+    assert!(
+        name_pos < engines_pos,
+        "sort-package-json should place name before engines: {written}"
+    );
+}
+
+#[test]
 fn cli_policy_unsatisfiable() {
     let (stdout, stderr, code) = run_in_fixture(
         "nce-policy-unsatisfiable",

--- a/crates/riri-npd/src/cli.rs
+++ b/crates/riri-npd/src/cli.rs
@@ -44,7 +44,7 @@ pub struct Args {
     #[arg(long)]
     pub json: bool,
 
-    /// Sort package.json keys on write (uses sort-package-json conventions).
+    /// Sort package.json keys (sort-package-json conventions); writes the file even without --update or pending pins.
     #[arg(long)]
     pub sort: bool,
 
@@ -174,6 +174,13 @@ fn run(args: &Args) -> Result<i32> {
                 style(":)").green()
             );
         }
+        if args.sort {
+            let task = runner.task("Sorting package.json...");
+            pkg_file
+                .write_sorted()
+                .context("failed to write package.json")?;
+            task.complete("Sorted package.json");
+        }
         return Ok(EXIT_OK);
     }
 
@@ -204,12 +211,21 @@ fn run(args: &Args) -> Result<i32> {
             pkg_file.write().context("failed to write package.json")?;
         }
         task.complete("Updated package.json");
-    } else if !args.quiet {
-        let hint = generate_update_hint(args);
-        eprintln!(
-            "\n  Run {} to upgrade package.json.",
-            style(hint).bold().cyan()
-        );
+    } else {
+        if args.sort {
+            let task = runner.task("Sorting package.json...");
+            pkg_file
+                .write_sorted()
+                .context("failed to write package.json")?;
+            task.complete("Sorted package.json");
+        }
+        if !args.quiet {
+            let hint = generate_update_hint(args);
+            eprintln!(
+                "\n  Run {} to upgrade package.json.",
+                style(hint).bold().cyan()
+            );
+        }
     }
 
     Ok(EXIT_PINS_PENDING)

--- a/crates/riri-npd/tests/cli_snapshots.rs
+++ b/crates/riri-npd/tests/cli_snapshots.rs
@@ -135,6 +135,26 @@ fn cli_yarn_no_node_modules_errors() {
 }
 
 #[test]
+fn cli_sort_writes_when_all_pinned() {
+    let tmp = copy_fixture_to_tmp("npd-npm-v3-already-pinned");
+    let unsorted = "{\n  \"dependencies\": {\n    \"foo\": \"4.17.21\"\n  },\n  \"private\": true,\n  \"name\": \"fake\"\n}\n";
+    std::fs::write(tmp.path().join("package.json"), unsorted).unwrap();
+    let output = npd_binary()
+        .current_dir(tmp.path())
+        .args(["--sort"])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code().unwrap_or(-1), 0);
+    let written = std::fs::read_to_string(tmp.path().join("package.json")).unwrap();
+    let name_pos = written.find("\"name\"").unwrap();
+    let deps_pos = written.find("\"dependencies\"").unwrap();
+    assert!(
+        name_pos < deps_pos,
+        "sort-package-json should place name before dependencies: {written}"
+    );
+}
+
+#[test]
 fn cli_enable_save_exact_creates_npmrc() {
     let tmp = copy_fixture_to_tmp("npd-npm-v3-already-pinned");
     let output = npd_binary()


### PR DESCRIPTION
## summary
- `--sort` now writes a sorted `package.json` regardless of whether `--update` was passed or whether engine ranges / pins are pending
- previously `--sort` was a modifier on `--update` and silently no-op'd when no engine changes (nce) or no pins pending (npd)
- applies to both `nce` and `npd`

## why
- running `nce --sort` or `npd --sort` on a project with already-correct ranges/pins did nothing — confusing UX
- `--sort` now reads as a standalone intent: "sort the file, full stop"

## changes
- `crates/riri-nce/src/cli.rs`: sort write path added to the empty-changes early-return and to the non-update branch
- `crates/riri-npd/src/cli.rs`: same pattern for the empty-pins early-return and non-update branch
- help text on `--sort` updated to spell out the decoupled behavior
- napi README help blocks regenerated via `cargo xtask regen-readme`

## test plan
- [x] `cli_sort_writes_without_update_flag` (nce): unsorted pkg + `--sort` (no `-u`) → file is sorted, engines.node unchanged
- [x] `cli_sort_writes_when_all_pinned` (npd): unsorted pkg with all deps already pinned + `--sort` → file is sorted
- [x] `cargo test -p riri-nce -p riri-npd` — nce 39 pass, npd 16 pass
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy -p riri-nce -p riri-npd -- -D warnings` clean
- [x] `cargo xtask regen-readme --check` clean
- [x] CI passes