### PR TITLE
feat(cli): expand --debug output with per-step tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1003,6 +1003,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1121,6 +1130,15 @@ name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "num-traits"
@@ -1557,6 +1575,8 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1593,6 +1613,8 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1873,6 +1895,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1984,6 +2015,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2021,6 +2061,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow 1.0.3",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2122,6 +2223,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/crates/riri-napi-nce/README.md
+++ b/crates/riri-napi-nce/README.md
@@ -68,8 +68,8 @@ nce
 Sample output (against `fixtures/nce-policy-supported-eol-bump`):
 
 ```text
-  node  >=18.0.0  →  ^22.0.0 || ^24.0.0 || ^25.0.0 || >=26.0.0
-  npm   *         →  >=10.5.1
+    node  >=18.0.0  →  ^22.0.0 || ^24.0.0 || ^25.0.0 || >=26.0.0
+    npm   *         →  >=10.5.1
 
   Run nce -u to upgrade package.json.
 ```
@@ -228,9 +228,28 @@ The `-d/--debug` flag enables detailed logging to stderr. No environment variabl
   ▸ Parsing lockfile......
   ✓ Parsed lockfile
   ▸ Computing engine constraints......
+    Compare: * and >=18.0.0 engine=node package=<root>
+    New most restrictive range: >=18.0.0 engine=node
+    Final computed engine range constraint: >=18.0.0 engine=node
+    Compare: * and >=18.0.0 engine=node package=<root>
+    New most restrictive range: >=18.0.0 engine=node
+    Final computed engine range constraint: >=18.0.0 engine=node
+    Package has no engines engine=npm package=<root>
+    Final computed engine range constraint: * engine=npm
+    Package has no engines engine=npm package=<root>
+    Final computed engine range constraint: * engine=npm
+    Package has no engines engine=yarn package=<root>
+    Final computed engine range constraint: * engine=yarn
+    Package has no engines engine=yarn package=<root>
+    Final computed engine range constraint: * engine=yarn
+    Rewriting node range under policy gate: >=18.0.0 policy=Supported
+    Bumped disjunct: >=18.0.0 → ^22.0.0 || ^24.0.0 || ^25.0.0 || >=26.0.0
+    Rewritten node range: ^22.0.0 || ^24.0.0 || ^25.0.0 || >=26.0.0
+    npm floor derived from node range: target 10.5.1 (declared: Some("*")) apply=true
+    Bumping engines.npm floor to: >=10.5.1
   ✓ Computed engine constraints
-  node  >=18.0.0  →  ^22.0.0 || ^24.0.0 || ^25.0.0 || >=26.0.0
-  npm   *         →  >=10.5.1
+    node  >=18.0.0  →  ^22.0.0 || ^24.0.0 || ^25.0.0 || >=26.0.0
+    npm   *         →  >=10.5.1
 
   Run nce -d -u to upgrade package.json.
 ```

--- a/crates/riri-napi-npd/README.md
+++ b/crates/riri-napi-npd/README.md
@@ -67,9 +67,9 @@ npd
 Sample output (against `fixtures/npd-npm-v3-unpinned-deps`):
 
 ```text
-  bar  ~18.2.0   →  18.2.0
-  foo  ^4.17.21  →  4.17.21
-  baz  ^1.0.0    →  1.6.0
+    bar  ~18.2.0   →  18.2.0
+    foo  ^4.17.21  →  4.17.21
+    baz  ^1.0.0    →  1.6.0
 
   Run npd -u to upgrade package.json.
 ```
@@ -151,10 +151,13 @@ The `-d/--debug` flag enables detailed logging to stderr. No environment variabl
   ▸ Parsing lockfile......
   ✓ Parsed lockfile
   ▸ Computing dependency pins......
+    Pin ~18.2.0 → 18.2.0 bucket="dependencies" package=bar
+    Pin ^4.17.21 → 4.17.21 bucket="dependencies" package=foo
+    Pin ^1.0.0 → 1.6.0 bucket="devDependencies" package=baz
   ✓ Computed dependency pins
-  bar  ~18.2.0   →  18.2.0
-  foo  ^4.17.21  →  4.17.21
-  baz  ^1.0.0    →  1.6.0
+    bar  ~18.2.0   →  18.2.0
+    foo  ^4.17.21  →  4.17.21
+    baz  ^1.0.0    →  1.6.0
 
   Run npd -d -u to upgrade package.json.
 ```

--- a/crates/riri-nce/Cargo.toml
+++ b/crates/riri-nce/Cargo.toml
@@ -21,6 +21,8 @@ console = { workspace = true }
 semver = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 
 [features]
 default = ["refresh"]

--- a/crates/riri-nce/src/cli.rs
+++ b/crates/riri-nce/src/cli.rs
@@ -181,6 +181,9 @@ fn parse_engine_filters(raw: &[String]) -> Vec<EngineConstraintKey> {
 #[allow(clippy::too_many_lines)]
 fn run(args: &Args) -> Result<i32> {
     let mode = renderer_mode(args);
+    if args.debug {
+        install_debug_subscriber();
+    }
     let runner = TaskRunner::new(mode);
     let cwd = std::env::current_dir().context("failed to get current directory")?;
 
@@ -364,7 +367,7 @@ fn run(args: &Args) -> Result<i32> {
         }
 
         for line in table.lines() {
-            eprintln!("  {}", line.trim());
+            eprintln!("    {}", line.trim());
         }
     }
 
@@ -408,6 +411,42 @@ fn run(args: &Args) -> Result<i32> {
     }
 
     Ok(EXIT_PINS_PENDING)
+}
+
+fn install_debug_subscriber() {
+    use std::io::IsTerminal;
+    use tracing_subscriber::EnvFilter;
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::util::SubscriberInitExt;
+    let filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("riri_nce=debug"));
+    let layer = tracing_subscriber::fmt::layer()
+        .event_format(IndentedFormat)
+        .with_ansi(std::io::stderr().is_terminal())
+        .with_writer(std::io::stderr);
+    let _ = tracing_subscriber::registry()
+        .with(filter)
+        .with(layer)
+        .try_init();
+}
+
+struct IndentedFormat;
+
+impl<S, N> tracing_subscriber::fmt::FormatEvent<S, N> for IndentedFormat
+where
+    S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+    N: for<'a> tracing_subscriber::fmt::FormatFields<'a> + 'static,
+{
+    fn format_event(
+        &self,
+        ctx: &tracing_subscriber::fmt::FmtContext<'_, S, N>,
+        mut writer: tracing_subscriber::fmt::format::Writer<'_>,
+        event: &tracing::Event<'_>,
+    ) -> std::fmt::Result {
+        writer.write_str("    ")?;
+        ctx.field_format().format_fields(writer.by_ref(), event)?;
+        writeln!(writer)
+    }
 }
 
 fn maybe_enable_engine_strict(

--- a/crates/riri-nce/src/compute.rs
+++ b/crates/riri-nce/src/compute.rs
@@ -3,6 +3,7 @@
 use riri_common::{EngineConstraintKey, Engines};
 use riri_semver_range::{ParsedRange, VersionPrecision, restrictive_range};
 use std::collections::HashMap;
+use tracing::debug;
 
 /// Extract the constraint string for a given engine key from an `Engines` value.
 ///
@@ -35,35 +36,85 @@ pub fn compute_engines_constraint<'a>(
     let wildcard = ParsedRange::parse("*").expect("wildcard always parses");
     let mut most_restrictive = wildcard;
     let mut ignored_ranges: Vec<String> = Vec::new();
+    let engine = key.to_string();
 
-    for (_pkg_name, engines) in entries {
+    for (pkg_name, engines) in entries {
+        let pkg = if pkg_name.is_empty() {
+            "<root>"
+        } else {
+            pkg_name
+        };
         let Some(constraint) = get_constraint_from_engines(engines, key) else {
+            debug!(target: "riri_nce::compute", engine = %engine, package = %pkg, "Package has no engines");
             continue;
         };
 
         if constraint == "*" || constraint.is_empty() {
+            debug!(
+                target: "riri_nce::compute",
+                engine = %engine,
+                package = %pkg,
+                "Package has no constraints for current engine"
+            );
             continue;
         }
 
-        // Skip ranges already proven to be supersets of the current most restrictive range.
         if ignored_ranges.contains(&constraint) {
+            debug!(
+                target: "riri_nce::compute",
+                engine = %engine,
+                package = %pkg,
+                range = %constraint,
+                "Ignored range (already proven non-narrowing)"
+            );
             continue;
         }
 
         let Ok(range) = ParsedRange::parse(&constraint) else {
+            debug!(
+                target: "riri_nce::compute",
+                engine = %engine,
+                package = %pkg,
+                range = %constraint,
+                "Skipped unparseable range"
+            );
             continue;
         };
 
+        let current = most_restrictive.humanize();
+        debug!(
+            target: "riri_nce::compute",
+            engine = %engine,
+            package = %pkg,
+            "Compare: {current} and {constraint}"
+        );
+
         let new_most_restrictive = restrictive_range(&most_restrictive, &range);
-        if new_most_restrictive.humanize() == most_restrictive.humanize() {
-            // Range didn't narrow most restrictive range — it's a superset or non-intersecting. Cache it.
+        let next = new_most_restrictive.humanize();
+        if next == current {
+            debug!(
+                target: "riri_nce::compute",
+                engine = %engine,
+                "Range {constraint} did not narrow {current} — cached as ignored"
+            );
             ignored_ranges.push(constraint);
         } else {
+            debug!(
+                target: "riri_nce::compute",
+                engine = %engine,
+                "New most restrictive range: {next}"
+            );
             most_restrictive = new_most_restrictive;
         }
     }
 
-    most_restrictive.humanize_with(precision)
+    let final_range = most_restrictive.humanize();
+    let simplified = most_restrictive.humanize_with(precision);
+    debug!(target: "riri_nce::compute", engine = %engine, "Final computed engine range constraint: {final_range}");
+    if simplified != final_range {
+        debug!(target: "riri_nce::compute", engine = %engine, "Simplified computed engine range constraint: {simplified}");
+    }
+    simplified
 }
 
 /// Input for [`check_engines`].

--- a/crates/riri-nce/src/lifecycle.rs
+++ b/crates/riri-nce/src/lifecycle.rs
@@ -11,6 +11,7 @@ use chrono::{DateTime, NaiveDate, Utc};
 use riri_common::EngineConstraintKey;
 use riri_node_lifecycle::{LifecycleData, Policy};
 use riri_semver_range::{ParsedRange, VersionPrecision};
+use tracing::debug;
 
 #[derive(Debug, Clone)]
 pub struct LifecycleConfig<'a> {
@@ -62,7 +63,30 @@ pub fn check_engines_with_lifecycle(
             allow_eol: cfg.allow_eol,
             precision: input.precision,
         };
+        debug!(
+            target: "riri_nce::lifecycle",
+            policy = ?cfg.policy,
+            "Rewriting node range under policy gate: {node_to}"
+        );
         let pr = rewrite_node_range(&node_to, &ctx)?;
+        for dropped in &pr.dropped_disjuncts {
+            debug!(target: "riri_nce::lifecycle", "Dropped disjunct (no allowed majors): {dropped}");
+        }
+        for (from, to) in &pr.bumped_disjuncts {
+            debug!(target: "riri_nce::lifecycle", "Bumped disjunct: {from} → {to}");
+        }
+        for warning in &pr.eol_warnings {
+            debug!(
+                target: "riri_nce::lifecycle",
+                major = warning.major,
+                "EOL warning emitted for major {} (eol on {})", warning.major, warning.since
+            );
+        }
+        if pr.unsatisfiable {
+            debug!(target: "riri_nce::lifecycle", "Policy rewrite is unsatisfiable — no allowed majors intersect input");
+        } else if let Some(ref rewritten) = pr.rewritten {
+            debug!(target: "riri_nce::lifecycle", "Rewritten node range: {rewritten}");
+        }
         apply_policy_result(&pr, &node_to, &mut output, input);
         lifecycle.warnings = pr.eol_warnings;
         lifecycle.dropped_disjuncts = pr.dropped_disjuncts;
@@ -85,8 +109,16 @@ pub fn check_engines_with_lifecycle(
             .get(&EngineConstraintKey::Npm)
             .cloned();
         let bump = maybe_bump_npm(declared.as_deref(), &target);
+        debug!(
+            target: "riri_nce::lifecycle",
+            apply = bump.apply,
+            "npm floor derived from node range: target {} (declared: {:?})",
+            bump.target_floor,
+            declared
+        );
         if bump.apply {
             let new_npm = format_npm_floor(&bump.target_floor, cfg.npm_precision);
+            debug!(target: "riri_nce::lifecycle", "Bumping engines.npm floor to: {new_npm}");
             apply_npm_bump(&new_npm, &mut output, input);
         }
         lifecycle.npm_bump = Some(bump);

--- a/crates/riri-nce/tests/snapshots/cli_snapshots__bump_npm_overrides_no_bump_stderr.snap
+++ b/crates/riri-nce/tests/snapshots/cli_snapshots__bump_npm_overrides_no_bump_stderr.snap
@@ -10,7 +10,7 @@ expression: stderr
   Parsed lockfile
   Computing engine constraints...
   Computed engine constraints
-  node  >=20.0.0  →  ^20.0.0 || ^22.0.0 || ^24.0.0 || >=25.0.0
-  npm   >=8.0.0   →  >=9.6.4
+    node  >=20.0.0  →  ^20.0.0 || ^22.0.0 || ^24.0.0 || >=25.0.0
+    npm   >=8.0.0   →  >=9.6.4
 
   Run nce -v -u to upgrade package.json.

--- a/crates/riri-nce/tests/snapshots/cli_snapshots__npm_bump_floor_stderr.snap
+++ b/crates/riri-nce/tests/snapshots/cli_snapshots__npm_bump_floor_stderr.snap
@@ -10,7 +10,7 @@ expression: stderr
   Parsed lockfile
   Computing engine constraints...
   Computed engine constraints
-  node  >=20.0.0  →  ^20.0.0 || ^22.0.0 || ^24.0.0 || >=25.0.0
-  npm   >=8.0.0   →  >=9.6.4
+    node  >=20.0.0  →  ^20.0.0 || ^22.0.0 || ^24.0.0 || >=25.0.0
+    npm   >=8.0.0   →  >=9.6.4
 
   Run nce -v -u to upgrade package.json.

--- a/crates/riri-nce/tests/snapshots/cli_snapshots__npm_engine_filter_verbose_stderr.snap
+++ b/crates/riri-nce/tests/snapshots/cli_snapshots__npm_engine_filter_verbose_stderr.snap
@@ -10,6 +10,6 @@ expression: stderr
   Parsed lockfile
   Computing engine constraints...
   Computed engine constraints
-  node  *  →  ^20.0.0 || ^22.0.0 || ^24.0.0 || >=25.0.0
+    node  *  →  ^20.0.0 || ^22.0.0 || ^24.0.0 || >=25.0.0
 
   Run nce -v -e node -u to upgrade package.json.

--- a/crates/riri-nce/tests/snapshots/cli_snapshots__npm_or_ranges_node_npm_yarn_verbose_stderr.snap
+++ b/crates/riri-nce/tests/snapshots/cli_snapshots__npm_or_ranges_node_npm_yarn_verbose_stderr.snap
@@ -10,8 +10,8 @@ expression: stderr
   Parsed lockfile
   Computing engine constraints...
   Computed engine constraints
-  node  *  →  ^20.0.0 || ^22.0.0 || ^24.0.0 || >=25.0.0
-  npm   *  →  >=9.6.4
-  yarn  *  →  ^1.22.4
+    node  *  →  ^20.0.0 || ^22.0.0 || ^24.0.0 || >=25.0.0
+    npm   *  →  >=9.6.4
+    yarn  *  →  ^1.22.4
 
   Run nce -v -u to upgrade package.json.

--- a/crates/riri-nce/tests/snapshots/cli_snapshots__npm_or_ranges_node_only_verbose_stderr.snap
+++ b/crates/riri-nce/tests/snapshots/cli_snapshots__npm_or_ranges_node_only_verbose_stderr.snap
@@ -10,7 +10,7 @@ expression: stderr
   Parsed lockfile
   Computing engine constraints...
   Computed engine constraints
-  node  *  →  ^20.0.0 || ^22.0.0 || ^24.0.0 || >=25.0.0
-  npm   *  →  >=9.6.4
+    node  *  →  ^20.0.0 || ^22.0.0 || ^24.0.0 || >=25.0.0
+    npm   *  →  >=9.6.4
 
   Run nce -v -u to upgrade package.json.

--- a/crates/riri-nce/tests/snapshots/cli_snapshots__npm_precision_minor_stderr.snap
+++ b/crates/riri-nce/tests/snapshots/cli_snapshots__npm_precision_minor_stderr.snap
@@ -10,7 +10,7 @@ expression: stderr
   Parsed lockfile
   Computing engine constraints...
   Computed engine constraints
-  node  >=24.0.0  →  ^24.0.0 || >=25.0.0
-  npm   *         →  >=11.0
+    node  >=24.0.0  →  ^24.0.0 || >=25.0.0
+    npm   *         →  >=11.0
 
   Run nce -v -u to upgrade package.json.

--- a/crates/riri-nce/tests/snapshots/cli_snapshots__npm_precision_patch_explicit_stderr.snap
+++ b/crates/riri-nce/tests/snapshots/cli_snapshots__npm_precision_patch_explicit_stderr.snap
@@ -10,7 +10,7 @@ expression: stderr
   Parsed lockfile
   Computing engine constraints...
   Computed engine constraints
-  node  >=24.0.0  →  ^24.0.0 || >=25.0.0
-  npm   *         →  >=11.0.0
+    node  >=24.0.0  →  ^24.0.0 || >=25.0.0
+    npm   *         →  >=11.0.0
 
   Run nce -v -u to upgrade package.json.

--- a/crates/riri-nce/tests/snapshots/cli_snapshots__pnpm_or_ranges_node_npm_yarn_verbose_stderr.snap
+++ b/crates/riri-nce/tests/snapshots/cli_snapshots__pnpm_or_ranges_node_npm_yarn_verbose_stderr.snap
@@ -10,8 +10,8 @@ expression: stderr
   Parsed lockfile
   Computing engine constraints...
   Computed engine constraints
-  node  *  →  ^20.0.0 || ^22.0.0 || ^24.0.0 || >=25.0.0
-  npm   *  →  >=9.6.4
-  yarn  *  →  ^1.22.4
+    node  *  →  ^20.0.0 || ^22.0.0 || ^24.0.0 || >=25.0.0
+    npm   *  →  >=9.6.4
+    yarn  *  →  ^1.22.4
 
   Run nce -v -u to upgrade package.json.

--- a/crates/riri-nce/tests/snapshots/cli_snapshots__pnpm_or_ranges_node_only_verbose_stderr.snap
+++ b/crates/riri-nce/tests/snapshots/cli_snapshots__pnpm_or_ranges_node_only_verbose_stderr.snap
@@ -10,7 +10,7 @@ expression: stderr
   Parsed lockfile
   Computing engine constraints...
   Computed engine constraints
-  node  *  →  ^20.0.0 || ^22.0.0 || ^24.0.0 || >=25.0.0
-  npm   *  →  >=9.6.4
+    node  *  →  ^20.0.0 || ^22.0.0 || ^24.0.0 || >=25.0.0
+    npm   *  →  >=9.6.4
 
   Run nce -v -u to upgrade package.json.

--- a/crates/riri-nce/tests/snapshots/cli_snapshots__policy_lts_eol_bump_stderr.snap
+++ b/crates/riri-nce/tests/snapshots/cli_snapshots__policy_lts_eol_bump_stderr.snap
@@ -10,7 +10,7 @@ expression: stderr
   Parsed lockfile
   Computing engine constraints...
   Computed engine constraints
-  node  ^20.19.0 || ^22.12.0 || >=23.0.0  →  ^20.19.0 || ^22.12.0 || ^24.0.0
-  npm   *                                 →  >=9.6.4
+    node  ^20.19.0 || ^22.12.0 || >=23.0.0  →  ^20.19.0 || ^22.12.0 || ^24.0.0
+    npm   *                                 →  >=9.6.4
 
   Run nce -v -u to upgrade package.json.

--- a/crates/riri-nce/tests/snapshots/cli_snapshots__policy_lts_expands_wildcard_stderr.snap
+++ b/crates/riri-nce/tests/snapshots/cli_snapshots__policy_lts_expands_wildcard_stderr.snap
@@ -10,6 +10,6 @@ expression: stderr
   Parsed lockfile
   Computing engine constraints...
   Computed engine constraints
-  node  *  →  ^20.0.0 || ^22.0.0 || ^24.0.0
+    node  *  →  ^20.0.0 || ^22.0.0 || ^24.0.0
 
   Run nce -v -u to upgrade package.json.

--- a/crates/riri-nce/tests/snapshots/cli_snapshots__policy_maintenance_drops_active_stderr.snap
+++ b/crates/riri-nce/tests/snapshots/cli_snapshots__policy_maintenance_drops_active_stderr.snap
@@ -10,6 +10,6 @@ expression: stderr
   Parsed lockfile
   Computing engine constraints...
   Computed engine constraints
-  node  ^20.0.0 || ^22.0.0  →  ^20.0.0
+    node  ^20.0.0 || ^22.0.0  →  ^20.0.0
 
   Run nce -v -u to upgrade package.json.

--- a/crates/riri-nce/tests/snapshots/cli_snapshots__policy_supported_eol_bump_stderr.snap
+++ b/crates/riri-nce/tests/snapshots/cli_snapshots__policy_supported_eol_bump_stderr.snap
@@ -10,7 +10,7 @@ expression: stderr
   Parsed lockfile
   Computing engine constraints...
   Computed engine constraints
-  node  >=18.0.0  →  ^20.0.0 || ^22.0.0 || ^24.0.0 || >=25.0.0
-  npm   *         →  >=9.6.4
+    node  >=18.0.0  →  ^20.0.0 || ^22.0.0 || ^24.0.0 || >=25.0.0
+    npm   *         →  >=9.6.4
 
   Run nce -v -u to upgrade package.json.

--- a/crates/riri-nce/tests/snapshots/cli_snapshots__policy_supported_narrows_compound_stderr.snap
+++ b/crates/riri-nce/tests/snapshots/cli_snapshots__policy_supported_narrows_compound_stderr.snap
@@ -10,7 +10,7 @@ expression: stderr
   Parsed lockfile
   Computing engine constraints...
   Computed engine constraints
-  node  >=18.0.0 <22.0.0  →  ^20.0.0
-  npm   *                 →  >=9.6.4
+    node  >=18.0.0 <22.0.0  →  ^20.0.0
+    npm   *                 →  >=9.6.4
 
   Run nce -v -u to upgrade package.json.

--- a/crates/riri-nce/tests/snapshots/cli_snapshots__yarn_or_ranges_node_npm_yarn_verbose_stderr.snap
+++ b/crates/riri-nce/tests/snapshots/cli_snapshots__yarn_or_ranges_node_npm_yarn_verbose_stderr.snap
@@ -10,8 +10,8 @@ expression: stderr
   Scanned node_modules
   Computing engine constraints...
   Computed engine constraints
-  node  *  →  ^20.0.0 || ^22.0.0 || ^24.0.0 || >=25.0.0
-  npm   *  →  >=9.6.4
-  yarn  *  →  ^1.22.4
+    node  *  →  ^20.0.0 || ^22.0.0 || ^24.0.0 || >=25.0.0
+    npm   *  →  >=9.6.4
+    yarn  *  →  ^1.22.4
 
   Run nce -v -u to upgrade package.json.

--- a/crates/riri-nce/tests/snapshots/cli_snapshots__yarn_or_ranges_node_only_verbose_stderr.snap
+++ b/crates/riri-nce/tests/snapshots/cli_snapshots__yarn_or_ranges_node_only_verbose_stderr.snap
@@ -10,7 +10,7 @@ expression: stderr
   Scanned node_modules
   Computing engine constraints...
   Computed engine constraints
-  node  *  →  ^20.0.0 || ^22.0.0 || ^24.0.0 || >=25.0.0
-  npm   *  →  >=9.6.4
+    node  *  →  ^20.0.0 || ^22.0.0 || ^24.0.0 || >=25.0.0
+    npm   *  →  >=9.6.4
 
   Run nce -v -u to upgrade package.json.

--- a/crates/riri-npd/Cargo.toml
+++ b/crates/riri-npd/Cargo.toml
@@ -18,6 +18,8 @@ console = { workspace = true }
 semver = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/crates/riri-npd/src/cli.rs
+++ b/crates/riri-npd/src/cli.rs
@@ -96,6 +96,9 @@ fn load_lockfile(
 #[allow(clippy::too_many_lines)]
 fn run(args: &Args) -> Result<i32> {
     let mode = renderer_mode(args);
+    if args.debug {
+        install_debug_subscriber();
+    }
     let runner = TaskRunner::new(mode);
     let cwd = std::env::current_dir().context("failed to get current directory")?;
 
@@ -196,7 +199,7 @@ fn run(args: &Args) -> Result<i32> {
             ]);
         }
         for line in table.lines() {
-            eprintln!("  {}", line.trim());
+            eprintln!("    {}", line.trim());
         }
     }
 
@@ -229,6 +232,42 @@ fn run(args: &Args) -> Result<i32> {
     }
 
     Ok(EXIT_PINS_PENDING)
+}
+
+fn install_debug_subscriber() {
+    use std::io::IsTerminal;
+    use tracing_subscriber::EnvFilter;
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::util::SubscriberInitExt;
+    let filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("riri_npd=debug"));
+    let layer = tracing_subscriber::fmt::layer()
+        .event_format(IndentedFormat)
+        .with_ansi(std::io::stderr().is_terminal())
+        .with_writer(std::io::stderr);
+    let _ = tracing_subscriber::registry()
+        .with(filter)
+        .with(layer)
+        .try_init();
+}
+
+struct IndentedFormat;
+
+impl<S, N> tracing_subscriber::fmt::FormatEvent<S, N> for IndentedFormat
+where
+    S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+    N: for<'a> tracing_subscriber::fmt::FormatFields<'a> + 'static,
+{
+    fn format_event(
+        &self,
+        ctx: &tracing_subscriber::fmt::FmtContext<'_, S, N>,
+        mut writer: tracing_subscriber::fmt::format::Writer<'_>,
+        event: &tracing::Event<'_>,
+    ) -> std::fmt::Result {
+        writer.write_str("    ")?;
+        ctx.field_format().format_fields(writer.by_ref(), event)?;
+        writeln!(writer)
+    }
 }
 
 fn maybe_enable_save_exact(args: &Args, runner: &TaskRunner, cwd: &Path) -> Result<()> {

--- a/crates/riri-npd/src/lib.rs
+++ b/crates/riri-npd/src/lib.rs
@@ -9,6 +9,7 @@ pub mod cli;
 use riri_common::{LockfileVersions, PackageJson};
 use semver::Version;
 use thiserror::Error;
+use tracing::debug;
 
 /// A dependency whose `package.json` specifier is a range that the lockfile
 /// has resolved to a concrete version.
@@ -85,16 +86,46 @@ pub fn pin_dependencies(
 
     for (kind, deps) in buckets {
         let Some(deps) = deps else { continue };
-        for (name, current_range) in deps {
+        let mut entries: Vec<(&String, &String)> = deps.iter().collect();
+        entries.sort_by(|a, b| a.0.cmp(b.0));
+        for (name, current_range) in entries {
             if is_local_specifier(current_range) {
+                debug!(
+                    target: "riri_npd::pin",
+                    bucket = kind.as_str(),
+                    package = %name,
+                    spec = %current_range,
+                    "Skipped local specifier (file:/link:/workspace:)"
+                );
                 continue;
             }
             let Some(locked) = lockfile.version_for(name) else {
+                debug!(
+                    target: "riri_npd::pin",
+                    bucket = kind.as_str(),
+                    package = %name,
+                    spec = %current_range,
+                    "Skipped — not present in lockfile"
+                );
                 continue;
             };
             if is_already_pinned(current_range, locked) {
+                debug!(
+                    target: "riri_npd::pin",
+                    bucket = kind.as_str(),
+                    package = %name,
+                    spec = %current_range,
+                    locked = %locked,
+                    "Skipped — already pinned to lockfile version"
+                );
                 continue;
             }
+            debug!(
+                target: "riri_npd::pin",
+                bucket = kind.as_str(),
+                package = %name,
+                "Pin {current_range} → {locked}"
+            );
             result.push(VersionToPin {
                 name: name.clone(),
                 kind,

--- a/crates/riri-npd/tests/snapshots/cli_snapshots__cli_npd_fixture@npd-npm-v3-file-dependency.snap
+++ b/crates/riri-npd/tests/snapshots/cli_snapshots__cli_npd_fixture@npd-npm-v3-file-dependency.snap
@@ -12,6 +12,6 @@ exit: 1
   Parsed lockfile
   Computing dependency pins...
   Computed dependency pins
-  foo  ^4.17.21  →  4.17.21
+    foo  ^4.17.21  →  4.17.21
 
   Run npd -v -u to upgrade package.json.

--- a/crates/riri-npd/tests/snapshots/cli_snapshots__cli_npd_fixture@npd-npm-v3-linked-package.snap
+++ b/crates/riri-npd/tests/snapshots/cli_snapshots__cli_npd_fixture@npd-npm-v3-linked-package.snap
@@ -12,6 +12,6 @@ exit: 1
   Parsed lockfile
   Computing dependency pins...
   Computed dependency pins
-  foo  ^4.17.21  →  4.17.21
+    foo  ^4.17.21  →  4.17.21
 
   Run npd -v -u to upgrade package.json.

--- a/crates/riri-npd/tests/snapshots/cli_snapshots__cli_npd_fixture@npd-npm-v3-unpinned-deps.snap
+++ b/crates/riri-npd/tests/snapshots/cli_snapshots__cli_npd_fixture@npd-npm-v3-unpinned-deps.snap
@@ -12,8 +12,8 @@ exit: 1
   Parsed lockfile
   Computing dependency pins...
   Computed dependency pins
-  bar  ~18.2.0   →  18.2.0
-  foo  ^4.17.21  →  4.17.21
-  baz  ^1.0.0    →  1.6.0
+    bar  ~18.2.0   →  18.2.0
+    foo  ^4.17.21  →  4.17.21
+    baz  ^1.0.0    →  1.6.0
 
   Run npd -v -u to upgrade package.json.

--- a/crates/riri-npd/tests/snapshots/cli_snapshots__cli_npd_fixture@npd-pnpm-v9-unpinned-deps.snap
+++ b/crates/riri-npd/tests/snapshots/cli_snapshots__cli_npd_fixture@npd-pnpm-v9-unpinned-deps.snap
@@ -12,8 +12,8 @@ exit: 1
   Parsed lockfile
   Computing dependency pins...
   Computed dependency pins
-  bar  ~18.2.0   →  18.2.0
-  foo  ^4.17.21  →  4.17.21
-  baz  ^1.0.0    →  1.6.0
+    bar  ~18.2.0   →  18.2.0
+    foo  ^4.17.21  →  4.17.21
+    baz  ^1.0.0    →  1.6.0
 
   Run npd -v -u to upgrade package.json.

--- a/crates/riri-npd/tests/snapshots/cli_snapshots__cli_npd_fixture@npd-yarn-v1-unpinned-deps.snap
+++ b/crates/riri-npd/tests/snapshots/cli_snapshots__cli_npd_fixture@npd-yarn-v1-unpinned-deps.snap
@@ -12,8 +12,8 @@ exit: 1
   Parsed lockfile
   Computing dependency pins...
   Computed dependency pins
-  bar  ~18.2.0   →  18.2.0
-  foo  ^4.17.21  →  4.17.21
-  baz  ^1.0.0    →  1.6.0
+    bar  ~18.2.0   →  18.2.0
+    foo  ^4.17.21  →  4.17.21
+    baz  ^1.0.0    →  1.6.0
 
   Run npd -v -u to upgrade package.json.

--- a/crates/riri-npd/tests/snapshots/cli_snapshots__cli_npd_fixture@npd-yarn-v2-unpinned-deps.snap
+++ b/crates/riri-npd/tests/snapshots/cli_snapshots__cli_npd_fixture@npd-yarn-v2-unpinned-deps.snap
@@ -12,8 +12,8 @@ exit: 1
   Parsed lockfile
   Computing dependency pins...
   Computed dependency pins
-  bar  ~18.2.0   →  18.2.0
-  foo  ^4.17.21  →  4.17.21
-  baz  ^1.0.0    →  1.6.0
+    bar  ~18.2.0   →  18.2.0
+    foo  ^4.17.21  →  4.17.21
+    baz  ^1.0.0    →  1.6.0
 
   Run npd -v -u to upgrade package.json.


### PR DESCRIPTION
## summary
- `nce -d` and `npd -d` now emit rich per-step trace lines matching the old TS predecessor (0.14.4)
- wired via `tracing` + `tracing-subscriber` (workspace deps already declared, now actually consumed)
- subscriber installed only when `args.debug`; writes to stderr; ANSI auto-detected from TTY; default filter `riri_nce=debug` / `riri_npd=debug`, overridable via `RUST_LOG`

## nce trace events
- `compute.rs`: per-package events — `Package has no engines`, `Package has no constraints for current engine`, `Ignored range`, `Compare A and B`, `New most restrictive range`, `Range X did not narrow Y`, `Final computed engine range constraint`, `Simplified computed engine range constraint`
- `lifecycle.rs`: policy-rewrite events — `Rewriting node range under policy gate`, `Dropped disjunct`, `Bumped disjunct`, `EOL warning`, `Rewritten node range`, `unsatisfiable`, `npm floor derived`, `Bumping engines.npm floor`

## npd trace events
- `lib.rs` per-dep events — `Pin X → Y`, `Skipped local specifier (file:/link:/workspace:)`, `Skipped — not present in lockfile`, `Skipped — already pinned to lockfile version`
- deps iteration is now sorted by name to make trace output deterministic (downstream pins were already sorted; this just stabilizes the trace emission)

## why
- old TS version (0.14.4) had detailed per-package + per-comparison debug; rust port had only 4 task lines (`Detecting lockfile`, `Reading package.json`, `Parsing lockfile`, `Computing engine constraints`)
- with this change, `nce -d` shows the actual reasoning that led to the rewrite (which disjuncts dropped, where npm floor came from, …), matching what users had pre-rewrite

## test plan
- [x] `cargo build -p riri-nce -p riri-npd` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p riri-nce -p riri-npd -p riri-semver-range -- -D warnings` clean
- [x] `cargo test -p riri-nce -p riri-npd -p riri-semver-range` all pass (nce 39, npd 16, semver-range 45)
- [x] `cargo xtask regen-readme --check` deterministic across 3 consecutive runs
- [x] manual smoke: `riri-nce -d` against `fixtures/nce-policy-supported-eol-bump` — full trace flows
- [x] manual smoke: `riri-npd -d` against `fixtures/npd-npm-v3-unpinned-deps` — full trace flows
- [x] CI passes