### PR TITLE
feat(bench): add v1 napi to bench-nce, alias v0 + pin 0.x in renovate

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -14,4 +14,17 @@
   "pre-commit": {
     enabled: true,
   },
+  packageRules: [
+    {
+      // Pin 0.x of the TS predecessors used by bench-js — they only exist
+      // to compare against the rust port and should never auto-update.
+      matchManagers: ["npm"],
+      matchPackageNames: [
+        "@smarlhens/npm-check-engines",
+        "@smarlhens/npm-pin-dependencies",
+      ],
+      matchCurrentVersion: "/^0\\./",
+      enabled: false,
+    },
+  ],
 }

--- a/bench-js/bench-nce.mjs
+++ b/bench-js/bench-nce.mjs
@@ -1,4 +1,5 @@
-import { checkEnginesFromString } from '@smarlhens/npm-check-engines';
+import { checkEnginesFromString as checkEnginesV0 } from '@smarlhens/npm-check-engines-v0';
+import { checkEngines as checkEnginesV1 } from '@smarlhens/npm-check-engines-v1';
 import { readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { resolve, dirname } from 'node:path';
@@ -8,7 +9,7 @@ import { Bench } from 'tinybench';
 const require = createRequire(import.meta.url);
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-// Find the .node binary for the current platform
+// Load the local .node binary — represents the unpublished working-tree code.
 const napiDir = resolve(__dirname, '../crates/riri-napi-nce');
 const { readdirSync } = await import('node:fs');
 const nodeFile = readdirSync(napiDir).find(f => f.startsWith('npm-check-engines.') && f.endsWith('.node'));
@@ -16,7 +17,7 @@ if (!nodeFile) {
   console.error('No .node binary found. Run `cd crates/riri-napi-nce && npx napi build --platform --release` first.');
   process.exit(1);
 }
-const napi = require(resolve(napiDir, nodeFile));
+const napiLocal = require(resolve(napiDir, nodeFile));
 const rootDir = resolve(__dirname, '..');
 
 const fixtures = {
@@ -52,15 +53,23 @@ for (const [name, data] of Object.entries(fixtureData)) {
     warmupTime: 0,
   });
 
-  bench.add('js checkEnginesFromString', () => {
-    checkEnginesFromString({
+  bench.add('js v0.x (TS predecessor)', () => {
+    checkEnginesV0({
       packageJsonString: data.packageJsonString,
       packageLockString: data.packageLockString,
     });
   });
 
-  bench.add('napi checkEngines', () => {
-    napi.checkEngines({
+  bench.add('napi v1.x (published)', () => {
+    checkEnginesV1({
+      lockfileContent: data.packageLockString,
+      lockfileType: 'npm',
+      packageJson: data.packageJsonString,
+    });
+  });
+
+  bench.add('napi local (unpublished)', () => {
+    napiLocal.checkEngines({
       lockfileContent: data.packageLockString,
       lockfileType: 'npm',
       packageJson: data.packageJsonString,

--- a/bench-js/cross-validate-nce.mjs
+++ b/bench-js/cross-validate-nce.mjs
@@ -5,7 +5,7 @@
 //! Only npm fixtures are cross-validated: the JS package has no pnpm/yarn
 //! string entry point.
 
-import { checkEnginesFromString } from '@smarlhens/npm-check-engines';
+import { checkEnginesFromString } from '@smarlhens/npm-check-engines-v0';
 import { readFileSync, readdirSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, join, resolve } from 'node:path';

--- a/bench-js/package-lock.json
+++ b/bench-js/package-lock.json
@@ -6,7 +6,8 @@
     "": {
       "name": "bench-js",
       "dependencies": {
-        "@smarlhens/npm-check-engines": "0.14.4",
+        "@smarlhens/npm-check-engines-v0": "npm:@smarlhens/npm-check-engines@0.14.4",
+        "@smarlhens/npm-check-engines-v1": "npm:@smarlhens/npm-check-engines@1.1.0",
         "@smarlhens/npm-pin-dependencies": "0.11.1",
         "tinybench": "6.0.2"
       },
@@ -342,7 +343,104 @@
         "node": ">=18.12"
       }
     },
-    "node_modules/@smarlhens/npm-check-engines": {
+    "node_modules/@smarlhens/npm-check-engines-darwin-arm64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smarlhens/npm-check-engines-darwin-arm64/-/npm-check-engines-darwin-arm64-1.1.0.tgz",
+      "integrity": "sha512-AU2VVQctBsHO+05TsX0nhdaMy1TEkhx9SCpKX1rpyhmDlqfTb4gttniiE2AzASoSU+wn5EVZvst8l77M9pDqiA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.17.0 || ^22.13.0 || >=23.5.0"
+      }
+    },
+    "node_modules/@smarlhens/npm-check-engines-darwin-x64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smarlhens/npm-check-engines-darwin-x64/-/npm-check-engines-darwin-x64-1.1.0.tgz",
+      "integrity": "sha512-rWXBQYNAWyJ/129I6lcpUfnA4RxZ36rgPQhjnjCg76Lj04VYinz1y8OhtRpL6xlXvT0FbthBPIw9IeleGrDwyg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.17.0 || ^22.13.0 || >=23.5.0"
+      }
+    },
+    "node_modules/@smarlhens/npm-check-engines-linux-arm64-gnu": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smarlhens/npm-check-engines-linux-arm64-gnu/-/npm-check-engines-linux-arm64-gnu-1.1.0.tgz",
+      "integrity": "sha512-1Pea/OLcpQTi9hswIvrCRw42YP9JJ2g1qLBBoMdb1Chd2daaRM+t8EhVznzxeZjTrf3uecty5RkG/wfSJ+d54Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.17.0 || ^22.13.0 || >=23.5.0"
+      }
+    },
+    "node_modules/@smarlhens/npm-check-engines-linux-arm64-musl": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smarlhens/npm-check-engines-linux-arm64-musl/-/npm-check-engines-linux-arm64-musl-1.1.0.tgz",
+      "integrity": "sha512-JsR9DXlSyX0EZOm4jiHZJRtkp3PJkG6+BXcggNbw+j7RXJoyGnbT5qxBmBWVe11ct/7afV9+eh/NuQSgvfdnpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.17.0 || ^22.13.0 || >=23.5.0"
+      }
+    },
+    "node_modules/@smarlhens/npm-check-engines-linux-x64-gnu": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smarlhens/npm-check-engines-linux-x64-gnu/-/npm-check-engines-linux-x64-gnu-1.1.0.tgz",
+      "integrity": "sha512-gmeOyjr/Lt2bYov1nYhlKziMbMl8SnyAGeNBvx3W2qgOE9JfcYesmdOBdBTecAsdTuy/WDYkMRpmyiwiRN2NJw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.17.0 || ^22.13.0 || >=23.5.0"
+      }
+    },
+    "node_modules/@smarlhens/npm-check-engines-linux-x64-musl": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smarlhens/npm-check-engines-linux-x64-musl/-/npm-check-engines-linux-x64-musl-1.1.0.tgz",
+      "integrity": "sha512-cBoM2d4N9B2u+axrdK5soe9fe3D4yCNSiptRkGFk93/fMQtUI1oRkFW+uwJm0YuiBo9h4G1iocy8duyAuxEkxw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.17.0 || ^22.13.0 || >=23.5.0"
+      }
+    },
+    "node_modules/@smarlhens/npm-check-engines-v0": {
+      "name": "@smarlhens/npm-check-engines",
       "version": "0.14.4",
       "resolved": "https://registry.npmjs.org/@smarlhens/npm-check-engines/-/npm-check-engines-0.14.4.tgz",
       "integrity": "sha512-gLG0Caz1tKHu3o0ZXXzFDZ+gmJqHr9jyrJhM/Vraj1WOnce1BNFWhlQytjHQ3vBrj07E0/WrrF5H/953k6laBg==",
@@ -367,6 +465,45 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
         "npm": ">=10.0.0"
+      }
+    },
+    "node_modules/@smarlhens/npm-check-engines-v1": {
+      "name": "@smarlhens/npm-check-engines",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smarlhens/npm-check-engines/-/npm-check-engines-1.1.0.tgz",
+      "integrity": "sha512-SglcGF37B6fDDypMdjYyNRXceoKu/QsRfIh5cFDBwx9Q35cZ9MXur8O/hK+0ZZQA0zTe7HmxvHoetByGP4gE3w==",
+      "license": "BlueOak-1.0.0",
+      "bin": {
+        "nce": "bin/nce.js",
+        "npm-check-engines": "bin/nce.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || ^22.13.0 || >=23.5.0"
+      },
+      "optionalDependencies": {
+        "@smarlhens/npm-check-engines-darwin-arm64": "1.1.0",
+        "@smarlhens/npm-check-engines-darwin-x64": "1.1.0",
+        "@smarlhens/npm-check-engines-linux-arm64-gnu": "1.1.0",
+        "@smarlhens/npm-check-engines-linux-arm64-musl": "1.1.0",
+        "@smarlhens/npm-check-engines-linux-x64-gnu": "1.1.0",
+        "@smarlhens/npm-check-engines-linux-x64-musl": "1.1.0",
+        "@smarlhens/npm-check-engines-win32-x64-msvc": "1.1.0"
+      }
+    },
+    "node_modules/@smarlhens/npm-check-engines-win32-x64-msvc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smarlhens/npm-check-engines-win32-x64-msvc/-/npm-check-engines-win32-x64-msvc-1.1.0.tgz",
+      "integrity": "sha512-FE2wPjITVNOXhY53icRnJRqD5E3wCSwTCwp9wkGaSudUMxHQ2Pe6aGmO9YqqJs7mcgVhe1LzBrIGAdH7wyxB0w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.17.0 || ^22.13.0 || >=23.5.0"
       }
     },
     "node_modules/@smarlhens/npm-pin-dependencies": {

--- a/bench-js/package.json
+++ b/bench-js/package.json
@@ -13,7 +13,8 @@
     "postncu:apply": "npm install --registry https://registry.npmjs.org && npm update --registry https://registry.npmjs.org"
   },
   "dependencies": {
-    "@smarlhens/npm-check-engines": "0.14.4",
+    "@smarlhens/npm-check-engines-v0": "npm:@smarlhens/npm-check-engines@0.14.4",
+    "@smarlhens/npm-check-engines-v1": "npm:@smarlhens/npm-check-engines@1.1.0",
     "@smarlhens/npm-pin-dependencies": "0.11.1",
     "tinybench": "6.0.2"
   },


### PR DESCRIPTION
## summary
- bench-nce now compares **three** configs: `v0.x` TS predecessor, `v1.x` napi (published), and the local working-tree napi (`.node` built from source)
- `bench-js/package.json` deps reshaped via npm aliases so both versions of `@smarlhens/npm-check-engines` can coexist:
  - `@smarlhens/npm-check-engines-v0` → `npm:@smarlhens/npm-check-engines@0.14.4`
  - `@smarlhens/npm-check-engines-v1` → `npm:@smarlhens/npm-check-engines@1.1.0`
- renovate pinned for the 0.x lines of both `@smarlhens/npm-check-engines` and `@smarlhens/npm-pin-dependencies` so updates inside 0.x no longer open PRs (these only exist for the bench comparison; they should never auto-bump)

## sample output (local)
```
=== small (7 deps) ===
js v0.x (TS predecessor)   avg 0.2104 ms   5753.89  ops/sec
napi v1.x (published)      avg 0.0241 ms  42888.29  ops/sec
napi local (unpublished)   avg 0.0231 ms  44241.22  ops/sec

=== large (500 deps) ===
js v0.x (TS predecessor)   avg 1.5207 ms    661.42  ops/sec
napi v1.x (published)      avg 0.4670 ms   2148.24  ops/sec
napi local (unpublished)   avg 0.4373 ms   2287.61  ops/sec
```

## why
- v0.x is the TS baseline we want to keep around for the perf delta story
- v1.x napi (published) is what users get from npm today — useful as the apples-to-apples comparison baseline
- the local `.node` is the WIP code under development; comparing it to v1.x catches perf regressions before publish
- 0.x is frozen by design — pinning in renovate stops daily noise PRs

## notes / followups
- `cross-validate-nce.mjs` already had a pre-existing `TypeError: Cannot read properties of undefined (reading 'engines')` failure on certain npm fixtures with the v0 TS lib — this PR only renames the import (`@smarlhens/npm-check-engines` → `-v0` alias); not introducing or fixing the crash
- npd not updated yet — v1 of `@smarlhens/npm-pin-dependencies` is not published. When it is, mirror this setup

## test plan
- [x] `npm install --registry https://registry.npmjs.org` in `bench-js/` resolves both aliases (`@smarlhens/npm-check-engines-v0@0.14.4`, `@smarlhens/npm-check-engines-v1@1.1.0`)
- [x] `npm run bench-nce` runs the 3 configs and produces a table for `small (7 deps)` and `large (500 deps)`
- [x] `.renovaterc.json5` validates as JSON5
- [x] CI passes