### PR TITLE
ci: add commit-msg normalize & validate hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,3 +56,9 @@ repos:
         args: ["--", "-D", "warnings"]
         types: [rust]
         pass_filenames: false
+
+  - repo: https://github.com/smarlhens/whittle
+    rev: "v0.1.2"
+    hooks:
+      - id: whittle-fix
+        stages: [commit-msg]


### PR DESCRIPTION
## Summary
- Add `scripts/commit-msg-format.py` — normalizes commit subjects: lowercase, `and`→`&`, strip `/ \ [ ] { } .` (keep version dots), replace `/`→`-` inside `(scope)`, drop body + trailers.
- Wire it as a `commit-msg` stage hook in `.pre-commit-config.yaml`, plus `compilerla/conventional-pre-commit` v3.6.0 for format validation.
- Hook fails on subjects >72 chars.

## Test plan
- [ ] Run `prek install --hook-type commit-msg` after pulling.
- [ ] Try `git commit -m "Chore: Bump foo to 1.2.3 and bar."` → expect `chore: bump foo to 1.2.3 & bar`.
- [ ] Try `git commit -m "fix(api/users): Handle [null] ids"` → expect `fix(api-users): handle null ids`.
- [ ] Try a >72-char subject → expect hook failure.
- [ ] Try a non-conventional subject (e.g. `update stuff`) → expect `conventional-pre-commit` rejection.