### PR TITLE
chore(deps): bump cargo dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,9 +138,9 @@ checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "backtrace"
@@ -205,9 +205,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytecount"
@@ -476,9 +476,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "378f0974ae2468eaf63aa036dbe9c926b0dc7ea64c156f2ea618bc2f75b934f0"
+checksum = "6d765eb1c0bda10d31e0ea185f5ee15da532d60b0912d2bd1441783439e749c5"
 
 [[package]]
 name = "detect-indent"
@@ -527,9 +527,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "encode_unicode"
@@ -668,9 +668,9 @@ checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
@@ -775,9 +775,9 @@ dependencies = [
 
 [[package]]
 name = "granit-parser"
-version = "0.0.2"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e736dfe3881c53a7dce0685eb18202d0d9fe6911782f9870946eb9ee89d778"
+checksum = "f50ba32164f9e098d5da618776a32afbb32270adcbe3d3d006107dae11e37c91"
 dependencies = [
  "arraydeque",
  "smallvec",
@@ -817,9 +817,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -937,9 +937,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -998,9 +998,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "matchers"
@@ -1013,9 +1013,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "miette"
@@ -1851,9 +1851,9 @@ dependencies = [
 
 [[package]]
 name = "serde-saphyr"
-version = "0.0.26"
+version = "0.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcc7fe48e34d02a97bc8e6253b8b91e5a47fe2c47eaacb5149cefbb69922eaf0"
+checksum = "5897b4c3faadadd35fdb6689f015641f3bc481d5adaaac56231ea15aeb243db3"
 dependencies = [
  "ahash",
  "annotate-snippets",
@@ -1890,9 +1890,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "indexmap",
  "itoa",
@@ -1936,9 +1936,9 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "similar"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04d93e861ede2e497b47833469b8ec9d5c07fa4c78ce7a00f6eb7dd8168b4b3f"
+checksum = "e6505efef05804732ed8a3f2d4f279429eb485bd69d5b0cc6b19cc02005cda16"
 dependencies = [
  "bstr",
 ]
@@ -2072,9 +2072,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -2309,9 +2309,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2322,9 +2322,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2332,9 +2332,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2345,9 +2345,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -2388,9 +2388,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2708,24 +2708,24 @@ dependencies = [
  "clap",
  "riri-node-lifecycle",
  "serde_json",
- "similar 3.1.0",
+ "similar 3.1.1",
  "tera",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,37 +22,26 @@ unwrap_used = "deny"
 anyhow = "1.0.102"
 chrono = { version = "0.4.44", default-features = false, features = ["clock", "std", "serde"] }
 clap = { version = "4.6.1", features = ["derive"] }
-clap-verbosity-flag = "3.0.4"
 comfy-table = "7.2.2"
 console = "0.16.3"
-detect-indent = "0.1.0"
-globset = "0.4.18"
-indicatif = "0.18.4"
-log = "0.4.29"
-regex = "1.12.3"
 semver = "1.0.28"
 serde = { version = "1.0.228", features = ["derive"] }
-sort-package-json = "0.0.13"
-serde_json = { version = "1.0.149", features = ["preserve_order"] }
-serde_yml = "0.0.12"
-tera = { version = "1.20.1", default-features = false }
+serde_json = { version = "1.0.150", features = ["preserve_order"] }
+serde-saphyr = "0.0.27"
 tracing = "0.1.44"
-tracing-log = "0.2.0"
 thiserror = "2.0.18"
 tracing-subscriber = "0.3.23"
-ureq = { version = "3.3.0", default-features = false, features = ["rustls"] }
 
 # napi
 napi = { version = "3.9.0", default-features = false, features = ["napi6", "serde-json"] }
 napi-derive = { version = "3.5.6", features = ["type-def"] }
+napi-build = "2.3.2"
 
 # test infrastructure
 criterion = { version = "0.8.2", features = ["html_reports"] }
 insta = "1.47.2"
-proptest = "1.11.0"
 rstest = "0.26.1"
 tempfile = "3.27.0"
-walkdir = "2.5.0"
 
 # workspace internal
 riri-find-up = { path = "crates/riri-find-up" }

--- a/crates/riri-common/Cargo.toml
+++ b/crates/riri-common/Cargo.toml
@@ -9,11 +9,11 @@ license.workspace = true
 sort = ["sort-package-json"]
 
 [dependencies]
-detect-indent = { workspace = true }
+detect-indent = "0.1.0"
 riri-find-up = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-sort-package-json = { workspace = true, optional = true }
+sort-package-json = { version = "0.0.13", optional = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/crates/riri-napi-nce/Cargo.toml
+++ b/crates/riri-napi-nce/Cargo.toml
@@ -22,7 +22,7 @@ riri-yarn = { workspace = true }
 serde_json = { workspace = true }
 
 [build-dependencies]
-napi-build = "2.3.2"
+napi-build = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/riri-napi-npd/Cargo.toml
+++ b/crates/riri-napi-npd/Cargo.toml
@@ -18,7 +18,7 @@ riri-pnpm = { workspace = true }
 serde_json = { workspace = true }
 
 [build-dependencies]
-napi-build = "2.3.2"
+napi-build = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/riri-node-lifecycle/Cargo.toml
+++ b/crates/riri-node-lifecycle/Cargo.toml
@@ -12,7 +12,7 @@ semver = { workspace = true, features = ["serde"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-ureq = { workspace = true, optional = true }
+ureq = { version = "3.3.0", default-features = false, features = ["rustls"], optional = true }
 
 [features]
 default = []

--- a/crates/riri-pnpm/Cargo.toml
+++ b/crates/riri-pnpm/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 riri-common = { workspace = true }
 riri-find-up = { workspace = true }
 serde = { workspace = true }
-serde-saphyr = "0.0.26"
+serde-saphyr = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/crates/riri-semver-range/Cargo.toml
+++ b/crates/riri-semver-range/Cargo.toml
@@ -11,7 +11,7 @@ semver = { workspace = true }
 [dev-dependencies]
 criterion = { workspace = true }
 nodejs-semver = "4.2.0"
-proptest = { workspace = true }
+proptest = "1.11.0"
 
 [[bench]]
 name = "range_parsing"

--- a/crates/riri-task-runner/Cargo.toml
+++ b/crates/riri-task-runner/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 
 [dependencies]
 console = { workspace = true }
-indicatif = { workspace = true }
+indicatif = "0.18.4"
 
 [lints]
 workspace = true

--- a/crates/riri-workspace/Cargo.toml
+++ b/crates/riri-workspace/Cargo.toml
@@ -10,8 +10,8 @@ riri-common = { workspace = true }
 riri-find-up = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-serde-saphyr = "0.0.26"
-globset = { workspace = true }
+serde-saphyr = { workspace = true }
+globset = "0.4.18"
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/crates/riri-yarn/Cargo.toml
+++ b/crates/riri-yarn/Cargo.toml
@@ -10,7 +10,7 @@ riri-common = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-walkdir = { workspace = true }
+walkdir = "2.5.0"
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -12,8 +12,8 @@ chrono = { workspace = true }
 clap = { workspace = true }
 riri-node-lifecycle = { workspace = true, features = ["refresh"] }
 serde_json = { workspace = true }
-similar = "3.1.0"
-tera = { workspace = true }
+similar = "3.1.1"
+tera = { version = "1.20.1", default-features = false }
 
 [lib]
 path = "src/lib.rs"


### PR DESCRIPTION
## Version bumps
- `serde_json` 1.0.149 → 1.0.150
- `serde-saphyr` 0.0.26 → 0.0.27
- `similar` 3.1.0 → 3.1.1
- Transitive lockfile updates via `cargo update`

## Workspace dependency hygiene
- Removed unused `[workspace.dependencies]` entries (no consumers): `clap-verbosity-flag`, `log`, `regex`, `tracing-log`, `serde_yml`
- Hoisted deps shared by multiple crates into the workspace: `serde-saphyr`, `napi-build`
- Moved single-use deps from the workspace into their sole consumer crate: `detect-indent`, `sort-package-json`, `globset`, `indicatif`, `proptest`, `tera`, `ureq`, `walkdir`

Workspace builds, `clippy -D warnings`, and the full test suite pass.