### PR TITLE
ci: bump prek to 0.4.3, update README tested-with versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Run prek hooks
         uses: j178/prek-action@v2.0.4
         with:
-          prek-version: "0.4.0"
+          prek-version: "0.4.3"
 
   rust:
     runs-on: ubuntu-24.04

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Run prek hooks
         uses: j178/prek-action@v2.0.4
         with:
-          prek-version: "0.4.0"
+          prek-version: "0.4.3"
 
   rust:
     runs-on: ubuntu-24.04

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@
 
 ### Prerequisites
 
-- [rustc][rustc] **>=1.85.0 <2.0.0** (_tested with 1.94.1_)
-- [prek][prek] **>=0.3.8** (_tested with 0.3.8_)
+- [rustc][rustc] **>=1.85.0 <2.0.0** (_tested with 1.95.0_)
+- [prek][prek] **>=0.3.8** (_tested with 0.4.3_)
 
 ### Installation
 


### PR DESCRIPTION
Bumps the prek version used in CI and refreshes the README prerequisite "tested with" markers.

## CI
- `prek-version` 0.4.0 → 0.4.3 in `ci.yml` and `pr.yml` (`j178/prek-action@v2.0.4`, already latest)

## README prerequisites
- rustc tested-with 1.94.1 → 1.95.0
- prek tested-with 0.3.8 → 0.4.3 (matches CI)

Local toolchain repinned to rustc 1.95.0; `cargo clippy --workspace --all-targets -- -D warnings` passes clean. `BENCHMARKS.md` left untouched (records the environment a past benchmark ran on, not a requirement).