### PR TITLE
ci(release): wire release-please cargo-workspace plugin

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,12 @@
 {
+  "crates/riri-common": "0.0.0",
+  "crates/riri-find-up": "0.0.0",
+  "crates/riri-nce": "0.0.0",
+  "crates/riri-npd": "0.0.0",
+  "crates/riri-npm": "0.0.0",
+  "crates/riri-pnpm": "0.0.0",
+  "crates/riri-semver-range": "0.0.0",
+  "crates/riri-yarn": "0.0.0",
   "crates/riri-napi-nce": "1.2.0",
-  "crates/riri-napi-npd": "0.1.0"
+  "crates/riri-napi-npd": "0.0.0"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1499,11 +1499,11 @@ dependencies = [
 
 [[package]]
 name = "riri-bun"
-version = "0.1.0"
+version = "0.0.0"
 
 [[package]]
 name = "riri-common"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "detect-indent",
  "riri-find-up",
@@ -1516,7 +1516,7 @@ dependencies = [
 
 [[package]]
 name = "riri-find-up"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "tempfile",
 ]
@@ -1540,7 +1540,7 @@ dependencies = [
 
 [[package]]
 name = "riri-napi-npd"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "napi",
  "napi-build",
@@ -1554,7 +1554,7 @@ dependencies = [
 
 [[package]]
 name = "riri-nce"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1581,7 +1581,7 @@ dependencies = [
 
 [[package]]
 name = "riri-node-lifecycle"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1595,7 +1595,7 @@ dependencies = [
 
 [[package]]
 name = "riri-npd"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1620,7 +1620,7 @@ dependencies = [
 
 [[package]]
 name = "riri-npm"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "insta",
  "riri-common",
@@ -1632,7 +1632,7 @@ dependencies = [
 
 [[package]]
 name = "riri-pnpm"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "insta",
  "riri-common",
@@ -1646,7 +1646,7 @@ dependencies = [
 
 [[package]]
 name = "riri-semver-range"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "criterion",
  "nodejs-semver",
@@ -1656,7 +1656,7 @@ dependencies = [
 
 [[package]]
 name = "riri-task-runner"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "console",
  "indicatif",
@@ -1664,7 +1664,7 @@ dependencies = [
 
 [[package]]
 name = "riri-workspace"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "globset",
  "insta",
@@ -1680,7 +1680,7 @@ dependencies = [
 
 [[package]]
 name = "riri-yarn"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "insta",
  "riri-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,17 +44,17 @@ rstest = "0.26.1"
 tempfile = "3.27.0"
 
 # workspace internal
-riri-find-up = { path = "crates/riri-find-up" }
-riri-common = { path = "crates/riri-common" }
-riri-npm = { path = "crates/riri-npm" }
-riri-pnpm = { path = "crates/riri-pnpm" }
-riri-yarn = { path = "crates/riri-yarn" }
-riri-bun = { path = "crates/riri-bun" }
-riri-semver-range = { path = "crates/riri-semver-range" }
-riri-nce = { path = "crates/riri-nce", default-features = false }
-riri-napi-nce = { path = "crates/riri-napi-nce" }
-riri-napi-npd = { path = "crates/riri-napi-npd" }
-riri-node-lifecycle = { path = "crates/riri-node-lifecycle" }
-riri-npd = { path = "crates/riri-npd" }
-riri-task-runner = { path = "crates/riri-task-runner" }
-riri-workspace = { path = "crates/riri-workspace" }
+riri-find-up = { path = "crates/riri-find-up", version = "0.0.0" }
+riri-common = { path = "crates/riri-common", version = "0.0.0" }
+riri-npm = { path = "crates/riri-npm", version = "0.0.0" }
+riri-pnpm = { path = "crates/riri-pnpm", version = "0.0.0" }
+riri-yarn = { path = "crates/riri-yarn", version = "0.0.0" }
+riri-bun = { path = "crates/riri-bun", version = "0.0.0" }
+riri-semver-range = { path = "crates/riri-semver-range", version = "0.0.0" }
+riri-nce = { path = "crates/riri-nce", version = "0.0.0", default-features = false }
+riri-napi-nce = { path = "crates/riri-napi-nce", version = "1.2.0" }
+riri-napi-npd = { path = "crates/riri-napi-npd", version = "0.0.0" }
+riri-node-lifecycle = { path = "crates/riri-node-lifecycle", version = "0.0.0" }
+riri-npd = { path = "crates/riri-npd", version = "0.0.0" }
+riri-task-runner = { path = "crates/riri-task-runner", version = "0.0.0" }
+riri-workspace = { path = "crates/riri-workspace", version = "0.0.0" }

--- a/crates/riri-bun/Cargo.toml
+++ b/crates/riri-bun/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riri-bun"
-version = "0.1.0"
+version = "0.0.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/riri-common/Cargo.toml
+++ b/crates/riri-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riri-common"
-version = "0.1.0"
+version = "0.0.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/riri-find-up/Cargo.toml
+++ b/crates/riri-find-up/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riri-find-up"
-version = "0.1.0"
+version = "0.0.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/riri-napi-npd/Cargo.toml
+++ b/crates/riri-napi-npd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riri-napi-npd"
-version = "0.1.0"
+version = "0.0.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/riri-napi-npd/package-lock.json
+++ b/crates/riri-napi-npd/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@smarlhens/npm-pin-dependencies",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@smarlhens/npm-pin-dependencies",
-      "version": "0.1.0",
+      "version": "0.0.0",
       "license": "BlueOak-1.0.0",
       "bin": {
         "npd": "bin/npd.js",

--- a/crates/riri-napi-npd/package.json
+++ b/crates/riri-napi-npd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smarlhens/npm-pin-dependencies",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "description": "Pin dependency ranges in package.json to the exact versions resolved by the lockfile",
   "keywords": [
     "cli",

--- a/crates/riri-nce/Cargo.toml
+++ b/crates/riri-nce/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riri-nce"
-version = "0.1.0"
+version = "0.0.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/riri-node-lifecycle/Cargo.toml
+++ b/crates/riri-node-lifecycle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riri-node-lifecycle"
-version = "0.1.0"
+version = "0.0.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/riri-npd/Cargo.toml
+++ b/crates/riri-npd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riri-npd"
-version = "0.1.0"
+version = "0.0.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/riri-npm/Cargo.toml
+++ b/crates/riri-npm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riri-npm"
-version = "0.1.0"
+version = "0.0.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/riri-pnpm/Cargo.toml
+++ b/crates/riri-pnpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riri-pnpm"
-version = "0.1.0"
+version = "0.0.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/riri-semver-range/Cargo.toml
+++ b/crates/riri-semver-range/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riri-semver-range"
-version = "0.1.0"
+version = "0.0.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/riri-task-runner/Cargo.toml
+++ b/crates/riri-task-runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riri-task-runner"
-version = "0.1.0"
+version = "0.0.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/riri-workspace/Cargo.toml
+++ b/crates/riri-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riri-workspace"
-version = "0.1.0"
+version = "0.0.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/riri-yarn/Cargo.toml
+++ b/crates/riri-yarn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riri-yarn"
-version = "0.1.0"
+version = "0.0.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,35 +16,80 @@
   ],
   "include-component-in-tag": true,
   "separate-pull-requests": true,
+  "plugins": [{ "type": "cargo-workspace", "merge": true }],
   "packages": {
     "crates/riri-napi-nce": {
       "package-name": "@smarlhens/npm-check-engines",
       "extra-files": [
-        {
-          "type": "json",
-          "path": "package.json",
-          "jsonpath": "$.version"
-        },
-        {
-          "type": "toml",
-          "path": "/Cargo.lock",
-          "jsonpath": "$.package[?(@.name.value=='riri-napi-nce')].version"
-        }
+        { "type": "json", "path": "package.json", "jsonpath": "$.version" },
+        { "type": "json", "path": "package-lock.json", "jsonpath": "$.version" },
+        { "type": "json", "path": "package-lock.json", "jsonpath": "$.packages[\"\"].version" },
+        { "type": "toml", "path": "/Cargo.lock", "jsonpath": "$.package[?(@.name.value=='riri-napi-nce')].version" }
       ]
     },
     "crates/riri-napi-npd": {
       "package-name": "@smarlhens/npm-pin-dependencies",
       "extra-files": [
-        {
-          "type": "json",
-          "path": "package.json",
-          "jsonpath": "$.version"
-        },
-        {
-          "type": "toml",
-          "path": "/Cargo.lock",
-          "jsonpath": "$.package[?(@.name.value=='riri-napi-npd')].version"
-        }
+        { "type": "json", "path": "package.json", "jsonpath": "$.version" },
+        { "type": "json", "path": "package-lock.json", "jsonpath": "$.version" },
+        { "type": "json", "path": "package-lock.json", "jsonpath": "$.packages[\"\"].version" },
+        { "type": "toml", "path": "/Cargo.lock", "jsonpath": "$.package[?(@.name.value=='riri-napi-npd')].version" }
+      ]
+    },
+    "crates/riri-common": {
+      "skip-github-release": true,
+      "draft": true,
+      "extra-files": [
+        { "type": "toml", "path": "/Cargo.lock", "jsonpath": "$.package[?(@.name.value=='riri-common')].version" }
+      ]
+    },
+    "crates/riri-find-up": {
+      "skip-github-release": true,
+      "draft": true,
+      "extra-files": [
+        { "type": "toml", "path": "/Cargo.lock", "jsonpath": "$.package[?(@.name.value=='riri-find-up')].version" }
+      ]
+    },
+    "crates/riri-nce": {
+      "skip-github-release": true,
+      "draft": true,
+      "extra-files": [
+        { "type": "toml", "path": "/Cargo.lock", "jsonpath": "$.package[?(@.name.value=='riri-nce')].version" }
+      ]
+    },
+    "crates/riri-npd": {
+      "skip-github-release": true,
+      "draft": true,
+      "extra-files": [
+        { "type": "toml", "path": "/Cargo.lock", "jsonpath": "$.package[?(@.name.value=='riri-npd')].version" }
+      ]
+    },
+    "crates/riri-npm": {
+      "skip-github-release": true,
+      "draft": true,
+      "extra-files": [
+        { "type": "toml", "path": "/Cargo.lock", "jsonpath": "$.package[?(@.name.value=='riri-npm')].version" }
+      ]
+    },
+    "crates/riri-pnpm": {
+      "skip-github-release": true,
+      "draft": true,
+      "extra-files": [
+        { "type": "toml", "path": "/Cargo.lock", "jsonpath": "$.package[?(@.name.value=='riri-pnpm')].version" }
+      ]
+    },
+    "crates/riri-semver-range": {
+      "skip-github-release": true,
+      "draft": true,
+      "extra-files": [
+        { "type": "toml", "path": "/Cargo.lock", "jsonpath": "$.package[?(@.name.value=='riri-semver-range')].version" }
+      ]
+    },
+    "crates/riri-yarn": {
+      "skip-github-release": true,
+      "draft": true,
+      "extra-files": [
+        { "type": "toml", "path": "/Cargo.lock", "jsonpath": "$.package[?(@.name.value=='riri-yarn')].version" }
       ]
     }
   }


### PR DESCRIPTION
Wire release-please's `cargo-workspace` plugin so fixes in internal Rust crates (e.g. `riri-nce`) cascade version bumps to the consuming npm packages (`@smarlhens/npm-check-engines`, `@smarlhens/npm-pin-dependencies`).

Fixes the missed-changes issue in #180 where `fix(nce): preserve lockfile indentation` did not appear in the `@smarlhens/npm-check-engines` 1.2.1 release notes.

## Changes

- All 14 workspace-internal `[workspace.dependencies]` entries declare an explicit `version`. 13 aligned to `0.0.0`; `riri-napi-nce` stays at `1.2.0`.
- 13 crate `Cargo.toml` versions reset to `0.0.0` (`riri-napi-nce`, `xtask` excluded).
- `riri-napi-npd` npm version files (`package.json` + `package-lock.json`) reset to `0.0.0`.
- `release-please-config.json` adds `cargo-workspace` plugin (`merge: true`) and registers 8 internal libraries with `skip-github-release: true`.
- Both shipping NAPI crates gain `package-lock.json` entries in `extra-files` (both `$.version` and `$.packages[""].version`).
- `.release-please-manifest.json` seeded with 10 in-graph crates.

## Behavior after merge

- First post-merge release-please run drains accumulated commit backlog, bumping each internal crate to its first real version (`0.0.0` → `0.1.0`) and cascading patch bumps to npm-shipping NAPI crates.
- Future fixes in any internal library trigger automatic patch releases of the consuming npm packages.
- Out-of-graph crates (`riri-bun`, `riri-node-lifecycle`, `riri-task-runner`, `riri-workspace`, `xtask`) carry version fields for consistency but are not tracked by release-please.