### PR TITLE
ci(release-please): fix unbumpable workspace.deps baseline

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,12 +1,12 @@
 {
-  "crates/riri-common": "0.0.0",
-  "crates/riri-find-up": "0.0.0",
-  "crates/riri-nce": "0.0.0",
-  "crates/riri-npd": "0.0.0",
-  "crates/riri-npm": "0.0.0",
-  "crates/riri-pnpm": "0.0.0",
-  "crates/riri-semver-range": "0.0.0",
-  "crates/riri-yarn": "0.0.0",
+  "crates/riri-common": "0.1.0",
+  "crates/riri-find-up": "0.1.0",
+  "crates/riri-nce": "0.1.0",
+  "crates/riri-npd": "0.1.0",
+  "crates/riri-npm": "0.1.0",
+  "crates/riri-pnpm": "0.1.0",
+  "crates/riri-semver-range": "0.1.0",
+  "crates/riri-yarn": "0.1.0",
   "crates/riri-napi-nce": "1.2.0",
-  "crates/riri-napi-npd": "0.0.0"
+  "crates/riri-napi-npd": "0.1.0"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1499,11 +1499,11 @@ dependencies = [
 
 [[package]]
 name = "riri-bun"
-version = "0.0.0"
+version = "0.1.0"
 
 [[package]]
 name = "riri-common"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "detect-indent",
  "riri-find-up",
@@ -1516,7 +1516,7 @@ dependencies = [
 
 [[package]]
 name = "riri-find-up"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "tempfile",
 ]
@@ -1540,7 +1540,7 @@ dependencies = [
 
 [[package]]
 name = "riri-napi-npd"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "napi",
  "napi-build",
@@ -1554,7 +1554,7 @@ dependencies = [
 
 [[package]]
 name = "riri-nce"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1581,7 +1581,7 @@ dependencies = [
 
 [[package]]
 name = "riri-node-lifecycle"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1595,7 +1595,7 @@ dependencies = [
 
 [[package]]
 name = "riri-npd"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1620,7 +1620,7 @@ dependencies = [
 
 [[package]]
 name = "riri-npm"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "insta",
  "riri-common",
@@ -1632,7 +1632,7 @@ dependencies = [
 
 [[package]]
 name = "riri-pnpm"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "insta",
  "riri-common",
@@ -1646,7 +1646,7 @@ dependencies = [
 
 [[package]]
 name = "riri-semver-range"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "criterion",
  "nodejs-semver",
@@ -1656,7 +1656,7 @@ dependencies = [
 
 [[package]]
 name = "riri-task-runner"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "console",
  "indicatif",
@@ -1664,7 +1664,7 @@ dependencies = [
 
 [[package]]
 name = "riri-workspace"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "globset",
  "insta",
@@ -1680,7 +1680,7 @@ dependencies = [
 
 [[package]]
 name = "riri-yarn"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "insta",
  "riri-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,17 +44,17 @@ rstest = "0.26.1"
 tempfile = "3.27.0"
 
 # workspace internal
-riri-find-up = { path = "crates/riri-find-up", version = "0.0.0" }
-riri-common = { path = "crates/riri-common", version = "0.0.0" }
-riri-npm = { path = "crates/riri-npm", version = "0.0.0" }
-riri-pnpm = { path = "crates/riri-pnpm", version = "0.0.0" }
-riri-yarn = { path = "crates/riri-yarn", version = "0.0.0" }
-riri-bun = { path = "crates/riri-bun", version = "0.0.0" }
-riri-semver-range = { path = "crates/riri-semver-range", version = "0.0.0" }
-riri-nce = { path = "crates/riri-nce", version = "0.0.0", default-features = false }
-riri-napi-nce = { path = "crates/riri-napi-nce", version = "1.2.0" }
-riri-napi-npd = { path = "crates/riri-napi-npd", version = "0.0.0" }
-riri-node-lifecycle = { path = "crates/riri-node-lifecycle", version = "0.0.0" }
-riri-npd = { path = "crates/riri-npd", version = "0.0.0" }
-riri-task-runner = { path = "crates/riri-task-runner", version = "0.0.0" }
-riri-workspace = { path = "crates/riri-workspace", version = "0.0.0" }
+riri-find-up = { path = "crates/riri-find-up" }
+riri-common = { path = "crates/riri-common" }
+riri-npm = { path = "crates/riri-npm" }
+riri-pnpm = { path = "crates/riri-pnpm" }
+riri-yarn = { path = "crates/riri-yarn" }
+riri-bun = { path = "crates/riri-bun" }
+riri-semver-range = { path = "crates/riri-semver-range" }
+riri-nce = { path = "crates/riri-nce", default-features = false }
+riri-napi-nce = { path = "crates/riri-napi-nce" }
+riri-napi-npd = { path = "crates/riri-napi-npd" }
+riri-node-lifecycle = { path = "crates/riri-node-lifecycle" }
+riri-npd = { path = "crates/riri-npd" }
+riri-task-runner = { path = "crates/riri-task-runner" }
+riri-workspace = { path = "crates/riri-workspace" }

--- a/crates/riri-bun/Cargo.toml
+++ b/crates/riri-bun/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riri-bun"
-version = "0.0.0"
+version = "0.1.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/riri-common/Cargo.toml
+++ b/crates/riri-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riri-common"
-version = "0.0.0"
+version = "0.1.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/riri-find-up/Cargo.toml
+++ b/crates/riri-find-up/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riri-find-up"
-version = "0.0.0"
+version = "0.1.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/riri-napi-npd/Cargo.toml
+++ b/crates/riri-napi-npd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riri-napi-npd"
-version = "0.0.0"
+version = "0.1.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/riri-napi-npd/package-lock.json
+++ b/crates/riri-napi-npd/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@smarlhens/npm-pin-dependencies",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@smarlhens/npm-pin-dependencies",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "license": "BlueOak-1.0.0",
       "bin": {
         "npd": "bin/npd.js",

--- a/crates/riri-napi-npd/package.json
+++ b/crates/riri-napi-npd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smarlhens/npm-pin-dependencies",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Pin dependency ranges in package.json to the exact versions resolved by the lockfile",
   "keywords": [
     "cli",

--- a/crates/riri-nce/Cargo.toml
+++ b/crates/riri-nce/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riri-nce"
-version = "0.0.0"
+version = "0.1.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/riri-node-lifecycle/Cargo.toml
+++ b/crates/riri-node-lifecycle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riri-node-lifecycle"
-version = "0.0.0"
+version = "0.1.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/riri-npd/Cargo.toml
+++ b/crates/riri-npd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riri-npd"
-version = "0.0.0"
+version = "0.1.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/riri-npm/Cargo.toml
+++ b/crates/riri-npm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riri-npm"
-version = "0.0.0"
+version = "0.1.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/riri-pnpm/Cargo.toml
+++ b/crates/riri-pnpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riri-pnpm"
-version = "0.0.0"
+version = "0.1.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/riri-semver-range/Cargo.toml
+++ b/crates/riri-semver-range/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riri-semver-range"
-version = "0.0.0"
+version = "0.1.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/riri-task-runner/Cargo.toml
+++ b/crates/riri-task-runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riri-task-runner"
-version = "0.0.0"
+version = "0.1.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/riri-workspace/Cargo.toml
+++ b/crates/riri-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riri-workspace"
-version = "0.0.0"
+version = "0.1.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/riri-yarn/Cargo.toml
+++ b/crates/riri-yarn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riri-yarn"
-version = "0.0.0"
+version = "0.1.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "rust",
   "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true,
   "changelog-sections": [
     { "type": "feat", "section": "Features", "hidden": false },
     { "type": "fix", "section": "Bug Fixes", "hidden": false },
@@ -15,7 +16,7 @@
     { "type": "revert", "section": "Reverts", "hidden": false }
   ],
   "include-component-in-tag": true,
-  "separate-pull-requests": true,
+  "separate-pull-requests": false,
   "plugins": [{ "type": "cargo-workspace", "merge": true }],
   "packages": {
     "crates/riri-napi-nce": {


### PR DESCRIPTION
Recover from broken release-please setup introduced in #183.

## Root cause

- Pre-1.0 cargo semver: `^0.0.0` accepts only exact `0.0.0`. Any bump (to `0.0.1` or `0.1.0`) breaks dependents that inherit via `workspace = true`.
- release-please's `cargo-workspace` plugin never updates root `[workspace.dependencies]` version fields (upstream bug [#1896](https://github.com/googleapis/release-please/issues/1896), open since 2023).
- Combined: every bumped crate immediately broke `cargo check` for any dependent. All 9 new release PRs (#184-#192) failed CI.

## Fix

- Remove `version` field from all internal entries in root `[workspace.dependencies]` (path-only resolution; cargo handles it via path; plugin no longer triggers stale constraints).
- Bump 13 crate `[package].version` from `0.0.0` to `0.1.0` (standard pre-1.0 baseline).
- Seed `.release-please-manifest.json` at `0.1.0` for tracked internal crates (`1.2.0` for `riri-napi-nce`).
- Add `bump-patch-for-minor-pre-major: true` so 0.x feats produce patch bumps (`0.1.0` -> `0.1.1`), keeping `^0.1.0` constraints valid even when consumers declare versions directly in the future.
- Set `separate-pull-requests: false` to honor the cargo-workspace plugin's `merge: true` and ship a single consolidated release PR per run.

## Behavior after merge

- release-please re-evaluates state on push to main. Stale PRs #184-#192 become obsolete and will be replaced/closed.
- Next release run opens ONE combined PR bumping every tracked crate that has unreleased commits.
- First post-fix release: each tracked internal crate goes from `0.1.0` to `0.1.1` (patches on accumulated commits).
- `riri-napi-nce` patch-cascades to `1.2.1`, `riri-napi-npd` to `0.1.1` if affected by internal-dep bumps.