### PR TITLE
ci(release-please): inline internal deps for plugin changelog rendering

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,19 +42,3 @@ criterion = { version = "0.8.2", features = ["html_reports"] }
 insta = "1.47.2"
 rstest = "0.26.1"
 tempfile = "3.27.0"
-
-# workspace internal
-riri-find-up = { path = "crates/riri-find-up" }
-riri-common = { path = "crates/riri-common" }
-riri-npm = { path = "crates/riri-npm" }
-riri-pnpm = { path = "crates/riri-pnpm" }
-riri-yarn = { path = "crates/riri-yarn" }
-riri-bun = { path = "crates/riri-bun" }
-riri-semver-range = { path = "crates/riri-semver-range" }
-riri-nce = { path = "crates/riri-nce", default-features = false }
-riri-napi-nce = { path = "crates/riri-napi-nce" }
-riri-napi-npd = { path = "crates/riri-napi-npd" }
-riri-node-lifecycle = { path = "crates/riri-node-lifecycle" }
-riri-npd = { path = "crates/riri-npd" }
-riri-task-runner = { path = "crates/riri-task-runner" }
-riri-workspace = { path = "crates/riri-workspace" }

--- a/crates/riri-common/Cargo.toml
+++ b/crates/riri-common/Cargo.toml
@@ -10,7 +10,7 @@ sort = ["sort-package-json"]
 
 [dependencies]
 detect-indent = "0.1.0"
-riri-find-up = { workspace = true }
+riri-find-up = { path = "../riri-find-up", version = "0.1.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sort-package-json = { version = "0.0.13", optional = true }

--- a/crates/riri-napi-nce/Cargo.toml
+++ b/crates/riri-napi-nce/Cargo.toml
@@ -12,13 +12,13 @@ crate-type = ["cdylib"]
 [dependencies]
 napi = { workspace = true }
 napi-derive = { workspace = true }
-riri-common = { workspace = true }
-riri-nce = { workspace = true }
-riri-npm = { workspace = true }
-riri-pnpm = { workspace = true }
-riri-semver-range = { workspace = true }
+riri-common = { path = "../riri-common", version = "0.1.0" }
+riri-nce = { path = "../riri-nce", version = "0.1.0", default-features = false }
+riri-npm = { path = "../riri-npm", version = "0.1.0" }
+riri-pnpm = { path = "../riri-pnpm", version = "0.1.0" }
+riri-semver-range = { path = "../riri-semver-range", version = "0.1.0" }
 semver = { workspace = true }
-riri-yarn = { workspace = true }
+riri-yarn = { path = "../riri-yarn", version = "0.1.0" }
 serde_json = { workspace = true }
 
 [build-dependencies]

--- a/crates/riri-napi-npd/Cargo.toml
+++ b/crates/riri-napi-npd/Cargo.toml
@@ -11,10 +11,10 @@ crate-type = ["cdylib"]
 [dependencies]
 napi = { workspace = true }
 napi-derive = { workspace = true }
-riri-common = { workspace = true }
-riri-npd = { workspace = true }
-riri-npm = { workspace = true }
-riri-pnpm = { workspace = true }
+riri-common = { path = "../riri-common", version = "0.1.0" }
+riri-npd = { path = "../riri-npd", version = "0.1.0" }
+riri-npm = { path = "../riri-npm", version = "0.1.0" }
+riri-pnpm = { path = "../riri-pnpm", version = "0.1.0" }
 serde_json = { workspace = true }
 
 [build-dependencies]

--- a/crates/riri-nce/Cargo.toml
+++ b/crates/riri-nce/Cargo.toml
@@ -6,13 +6,13 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
-riri-common = { workspace = true, features = ["sort"] }
-riri-node-lifecycle = { workspace = true }
-riri-npm = { workspace = true }
-riri-pnpm = { workspace = true }
-riri-semver-range = { workspace = true }
-riri-yarn = { workspace = true }
-riri-task-runner = { workspace = true }
+riri-common = { path = "../riri-common", version = "0.1.0", features = ["sort"] }
+riri-node-lifecycle = { path = "../riri-node-lifecycle", version = "0.1.0" }
+riri-npm = { path = "../riri-npm", version = "0.1.0" }
+riri-pnpm = { path = "../riri-pnpm", version = "0.1.0" }
+riri-semver-range = { path = "../riri-semver-range", version = "0.1.0" }
+riri-yarn = { path = "../riri-yarn", version = "0.1.0" }
+riri-task-runner = { path = "../riri-task-runner", version = "0.1.0" }
 anyhow = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }

--- a/crates/riri-npd/Cargo.toml
+++ b/crates/riri-npd/Cargo.toml
@@ -6,12 +6,12 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
-riri-common = { workspace = true, features = ["sort"] }
-riri-npm = { workspace = true }
-riri-pnpm = { workspace = true }
-riri-task-runner = { workspace = true }
-riri-workspace = { workspace = true }
-riri-yarn = { workspace = true }
+riri-common = { path = "../riri-common", version = "0.1.0", features = ["sort"] }
+riri-npm = { path = "../riri-npm", version = "0.1.0" }
+riri-pnpm = { path = "../riri-pnpm", version = "0.1.0" }
+riri-task-runner = { path = "../riri-task-runner", version = "0.1.0" }
+riri-workspace = { path = "../riri-workspace", version = "0.1.0" }
+riri-yarn = { path = "../riri-yarn", version = "0.1.0" }
 anyhow = { workspace = true }
 clap = { workspace = true }
 comfy-table = { workspace = true }

--- a/crates/riri-npm/Cargo.toml
+++ b/crates/riri-npm/Cargo.toml
@@ -6,7 +6,7 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
-riri-common = { workspace = true }
+riri-common = { path = "../riri-common", version = "0.1.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/riri-pnpm/Cargo.toml
+++ b/crates/riri-pnpm/Cargo.toml
@@ -6,8 +6,8 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
-riri-common = { workspace = true }
-riri-find-up = { workspace = true }
+riri-common = { path = "../riri-common", version = "0.1.0" }
+riri-find-up = { path = "../riri-find-up", version = "0.1.0" }
 serde = { workspace = true }
 serde-saphyr = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/riri-workspace/Cargo.toml
+++ b/crates/riri-workspace/Cargo.toml
@@ -6,8 +6,8 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
-riri-common = { workspace = true }
-riri-find-up = { workspace = true }
+riri-common = { path = "../riri-common", version = "0.1.0" }
+riri-find-up = { path = "../riri-find-up", version = "0.1.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde-saphyr = { workspace = true }

--- a/crates/riri-yarn/Cargo.toml
+++ b/crates/riri-yarn/Cargo.toml
@@ -6,7 +6,7 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
-riri-common = { workspace = true }
+riri-common = { path = "../riri-common", version = "0.1.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 anyhow = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
-riri-node-lifecycle = { workspace = true, features = ["refresh"] }
+riri-node-lifecycle = { path = "../riri-node-lifecycle", version = "0.1.0", features = ["refresh"] }
 serde_json = { workspace = true }
 similar = "3.1.1"
 tera = { version = "1.20.1", default-features = false }


### PR DESCRIPTION
Convert internal-crate dependencies from `workspace = true` inheritance to inline `path + version`. This enables release-please's `cargo-workspace` plugin to read internal dep versions per consumer and render `Dependencies bumped from X to Y` entries in npm-shipping NAPI crate CHANGELOGs.

## Why

Plugin's `[dependencies]` updater only acts on inline `path + version` entries — workspace-inherited deps (`workspace = true`) get skipped. Without this refactor, the riri-napi-nce CHANGELOG produced by release-please only mentions chore commits in its own path; it doesn't list cascaded bumps of `riri-nce`, `riri-common`, etc. that motivated the version bump.

## Changes

- 31 `workspace = true` references across 10 consumer Cargo.toml files converted to inline `path = "../X", version = "0.1.0"` (preserving any `features` / `default-features` flags).
- Dropped the `# workspace internal` block from root `Cargo.toml` `[workspace.dependencies]` — it's dead config after the refactor.
- Third-party `[workspace.dependencies]` entries (anyhow, serde, etc.) untouched.

## Result

- cargo build/test still green (verified locally).
- Next release-please run produces CHANGELOG entries on dependent crates that mention the source bump (e.g. `riri-nce bumped from 0.1.0 to 0.1.1` in `riri-napi-nce` CHANGELOG).