### PR TITLE
ci(release-please): force riri-napi-npd to 1.0.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -30,6 +30,7 @@
     },
     "crates/riri-napi-npd": {
       "package-name": "@smarlhens/npm-pin-dependencies",
+      "release-as": "1.0.0",
       "extra-files": [
         { "type": "json", "path": "package.json", "jsonpath": "$.version" },
         { "type": "json", "path": "package-lock.json", "jsonpath": "$.version" },


### PR DESCRIPTION
Force first stable release of the Rust rewrite of `@smarlhens/npm-pin-dependencies` to 1.0.0 via `release-as` override.

## Why

The Rust NAPI rewrite of npm-pin-dependencies has been parked at `0.1.0` in the manifest. The existing npm registry version (`0.11.1`) is the legacy TypeScript package; the rewrite is functionally complete and ready to ship as a 1.0.0.

## Effect

- release-please's next run will update PR #184 to bump `riri-napi-npd` from `0.1.0` to `1.0.0` (instead of the cascaded `0.1.1`).
- After PR #184 merges and publishes `@smarlhens/npm-pin-dependencies@1.0.0`, the `release-as` override must be removed in a follow-up PR. Future bumps then proceed normally from `1.0.0` per semver.