### PR TITLE
ci(release-please): drop sticky release-as pin from riri-napi-npd

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -30,7 +30,6 @@
     },
     "crates/riri-napi-npd": {
       "package-name": "@smarlhens/npm-pin-dependencies",
-      "release-as": "1.0.0",
       "extra-files": [
         { "type": "json", "path": "package.json", "jsonpath": "$.version" },
         { "type": "json", "path": "package-lock.json", "jsonpath": "$.version" },


### PR DESCRIPTION
## Problem

`release-please-config.json` pins `@smarlhens/npm-pin-dependencies` (crate `riri-napi-npd`) with `"release-as": "1.0.0"`, added in 248bec3 to force the initial 1.0.0 jump.

`release-as` is **sticky** — it re-targets that exact version on every run, not once. Since 1.0.0 is already in `.release-please-manifest.json` and tag `@smarlhens/npm-pin-dependencies-v1.0.0` already exists, release-please keeps regenerating a no-op release PR (compare `v1.0.0...v1.0.0`) that wants to re-tag the already-released version. See #197.

## Fix

Remove the `release-as` line. The force already did its job. release-please now bumps from the manifest normally — the existing `fix:` commit takes 1.0.0 → 1.0.1.

## After merge

The release-please PR (#197) regenerates and should target 1.0.1 for this package.