### PR TITLE
ci: match actual release-please commit title for auto-release detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
         run: cargo test --workspace --verbose
       - name: Set release-please variables
         env:
-          HAS_RELEASE_COMMIT: "${{ contains(toJson(github.event.commits.*.message), 'chore(main): release') }}"
+          HAS_RELEASE_COMMIT: "${{ contains(toJson(github.event.commits.*.message), 'chore: release main') }}"
         run: |
           if [ "$HAS_RELEASE_COMMIT" = "true" ]; then
             echo "skip_github_pull_request=true"  >> "$GITHUB_ENV"


### PR DESCRIPTION
## Problem

`ci.yml` auto-creates GitHub Releases + tags (which trigger the npm publish workflows) only when the merged commit message matches:

```yaml
HAS_RELEASE_COMMIT: "${{ contains(toJson(github.event.commits.*.message), 'chore(main): release') }}"
```

But release-please in this repo titles its release commits **`chore: release main`**, not `chore(main): release` (the older release-please default `chore${scope}: release`).

`contains("chore: release main", "chore(main): release")` is always **false** → the merge always falls into the PR-only branch (`skip-github-release=true`) → releases/tags are never auto-created → publish never fires. This is why releases had to be cut manually via `release.yml` every time.

## Fix

Point the substring check at the title release-please actually emits:

```yaml
contains(..., 'chore: release main')
```

After merge, merging a release PR auto-tags + auto-publishes. The manual `release.yml` dispatch becomes a redundant fallback.