### PR TITLE
chore(bench): wire npd v1-vs-v0 comparison to match nce

### DIFF
--- a/bench-js/.ncurc.mjs
+++ b/bench-js/.ncurc.mjs
@@ -6,6 +6,7 @@ export default {
       '@types/node': 'minor',
       // Benchmark baselines: keep each alias on its own major line (v0→0.x, v1→1.x).
       'npm-check-engines': 'minor',
+      'npm-pin-dependencies': 'minor',
     };
 
     const keys = Object.keys(targets);

--- a/bench-js/bench-npd.mjs
+++ b/bench-js/bench-npd.mjs
@@ -1,4 +1,5 @@
-import { pinDependenciesFromString } from '@smarlhens/npm-pin-dependencies';
+import { pinDependenciesFromString as pinDepsV0 } from '@smarlhens/npm-pin-dependencies-v0';
+import { pinDependencies as pinDepsV1 } from '@smarlhens/npm-pin-dependencies-v1';
 import { readFileSync, readdirSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, resolve } from 'node:path';
@@ -8,13 +9,14 @@ import { Bench } from 'tinybench';
 const require = createRequire(import.meta.url);
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+// Load the local .node binary — represents the unpublished working-tree code.
 const napiDir = resolve(__dirname, '../crates/riri-napi-npd');
 const nodeFile = readdirSync(napiDir).find(f => f.startsWith('npm-pin-dependencies.') && f.endsWith('.node'));
 if (!nodeFile) {
   console.error('No .node binary found. Run `cd crates/riri-napi-npd && npx napi build --platform --release` first.');
   process.exit(1);
 }
-const napi = require(resolve(napiDir, nodeFile));
+const napiLocal = require(resolve(napiDir, nodeFile));
 const rootDir = resolve(__dirname, '..');
 
 const fixtures = {
@@ -53,15 +55,23 @@ for (const [name, data] of Object.entries(fixtureData)) {
     warmupTime: 0,
   });
 
-  bench.add('js pinDependenciesFromString', async () => {
-    await pinDependenciesFromString({
+  bench.add('js v0.x (TS predecessor)', async () => {
+    await pinDepsV0({
       packageJsonString: data.packageJsonString,
       packageLockString: data.lockfileString,
     });
   });
 
-  bench.add('napi pinDependencies', () => {
-    napi.pinDependencies({
+  bench.add('napi v1.x (published)', () => {
+    pinDepsV1({
+      packageJson: data.packageJsonString,
+      lockfileContent: data.lockfileString,
+      lockfileType: data.lockfileType,
+    });
+  });
+
+  bench.add('napi local (unpublished)', () => {
+    napiLocal.pinDependencies({
       packageJson: data.packageJsonString,
       lockfileContent: data.lockfileString,
       lockfileType: data.lockfileType,

--- a/bench-js/cross-validate-npd.mjs
+++ b/bench-js/cross-validate-npd.mjs
@@ -5,7 +5,7 @@
 //! Yarn v1 fixtures are skipped because the NAPI binding does not yet expose
 //! a string-based yarn path (Phase 11 — `pinDependenciesFromPath`).
 
-import { pinDependenciesFromString } from '@smarlhens/npm-pin-dependencies';
+import { pinDependenciesFromString } from '@smarlhens/npm-pin-dependencies-v0';
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, join, resolve } from 'node:path';

--- a/bench-js/package-lock.json
+++ b/bench-js/package-lock.json
@@ -8,15 +8,16 @@
       "dependencies": {
         "@smarlhens/npm-check-engines-v0": "npm:@smarlhens/npm-check-engines@0.14.4",
         "@smarlhens/npm-check-engines-v1": "npm:@smarlhens/npm-check-engines@1.2.0",
-        "@smarlhens/npm-pin-dependencies": "0.11.1",
+        "@smarlhens/npm-pin-dependencies-v0": "npm:@smarlhens/npm-pin-dependencies@0.11.1",
+        "@smarlhens/npm-pin-dependencies-v1": "npm:@smarlhens/npm-pin-dependencies@1.0.1",
         "tinybench": "6.0.2"
       },
       "devDependencies": {
         "npm-check-updates": "22.2.1"
       },
       "engines": {
-        "node": "^22.13.0 || ^24.0.0 || >=26.0.0",
-        "npm": ">=10.9.2"
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0",
+        "npm": ">=10.9.7"
       }
     },
     "node_modules/@pnpm/config.env-replace": {
@@ -388,9 +389,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "BlueOak-1.0.0",
       "optional": true,
       "os": [
@@ -407,9 +405,6 @@
       "integrity": "sha512-l4QoUpXw1mUwhS/1FY4tb/jT/EhORQsRd9s8Zsw9OuJLOkLSWsNgUXaIVmYNd5K8od7VsUNWfGNCZg6Lq/bZ6w==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "BlueOak-1.0.0",
       "optional": true,
@@ -428,9 +423,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "BlueOak-1.0.0",
       "optional": true,
       "os": [
@@ -447,9 +439,6 @@
       "integrity": "sha512-PGrFEHq32Pg655LikUWd60tbtf0YCD+QlMm2b8sBUtXzKDxYbmKLWUtEmxVSaQsiYd/RFeFYEeDq2xKbgKHncQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "BlueOak-1.0.0",
       "optional": true,
@@ -530,7 +519,110 @@
         "npm": ">=10.9.2"
       }
     },
-    "node_modules/@smarlhens/npm-pin-dependencies": {
+    "node_modules/@smarlhens/npm-pin-dependencies-darwin-arm64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smarlhens/npm-pin-dependencies-darwin-arm64/-/npm-pin-dependencies-darwin-arm64-1.0.1.tgz",
+      "integrity": "sha512-h3Y9ltjsfx/yifY+arsii9Wq2STxmCRQiYdHVXMmjsx5ZKjlHrKUK+2MVWNtunohcO7TZxdk7HKA2VK+q4yl3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0",
+        "npm": ">=10.9.7"
+      }
+    },
+    "node_modules/@smarlhens/npm-pin-dependencies-darwin-x64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smarlhens/npm-pin-dependencies-darwin-x64/-/npm-pin-dependencies-darwin-x64-1.0.1.tgz",
+      "integrity": "sha512-qx6eKB7+54+uCRGLu1pkOGIklWFj99EFthQORISH/MPe4wRqaFYU5eof95b+IcOVtuUMW4sZm43w+elNErEF9w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0",
+        "npm": ">=10.9.7"
+      }
+    },
+    "node_modules/@smarlhens/npm-pin-dependencies-linux-arm64-gnu": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smarlhens/npm-pin-dependencies-linux-arm64-gnu/-/npm-pin-dependencies-linux-arm64-gnu-1.0.1.tgz",
+      "integrity": "sha512-pIrq4htECkw1gHPNqgXCjBa3XPGgqutkg7LxpZxWXqCT19CW9AaCh61C5F3D3UmIYVfJtfcXJztEZ3/BKa4uBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0",
+        "npm": ">=10.9.7"
+      }
+    },
+    "node_modules/@smarlhens/npm-pin-dependencies-linux-arm64-musl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smarlhens/npm-pin-dependencies-linux-arm64-musl/-/npm-pin-dependencies-linux-arm64-musl-1.0.1.tgz",
+      "integrity": "sha512-SvPhk38HnnXJYyJ4M9kg11SFFzeeIZJybWTRV+itn3Ed0D3rDeb6Z3zc+AjLJ40aHocb7gkoUu6fAOWHo7MzrQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0",
+        "npm": ">=10.9.7"
+      }
+    },
+    "node_modules/@smarlhens/npm-pin-dependencies-linux-x64-gnu": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smarlhens/npm-pin-dependencies-linux-x64-gnu/-/npm-pin-dependencies-linux-x64-gnu-1.0.1.tgz",
+      "integrity": "sha512-HJ5IcsxPmHx0yvi+P7dUPSqGarlZyIwWyTgDu20pWTTMkEOqrn7UV0EofWlahfJIXaUM41Fk7jUUbm7BvpnJxA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0",
+        "npm": ">=10.9.7"
+      }
+    },
+    "node_modules/@smarlhens/npm-pin-dependencies-linux-x64-musl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smarlhens/npm-pin-dependencies-linux-x64-musl/-/npm-pin-dependencies-linux-x64-musl-1.0.1.tgz",
+      "integrity": "sha512-1EKtmgaLJoYy074XiJIAPvVXHH/IWJgzAsk9rKdRknpxbt4KAiepSghvukuoe3a7miuesiYxmcgDJbkLbnYkbw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0",
+        "npm": ">=10.9.7"
+      }
+    },
+    "node_modules/@smarlhens/npm-pin-dependencies-v0": {
+      "name": "@smarlhens/npm-pin-dependencies",
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/@smarlhens/npm-pin-dependencies/-/npm-pin-dependencies-0.11.1.tgz",
       "integrity": "sha512-iavI+e5GivK31Mx6NiTz5Bq84rNzAlx5fKQ72q5gxrpjFa/Xc7YS42WtdBQTtoW6zgef/3lIMvAdEXBoMUw8kQ==",
@@ -557,6 +649,47 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
         "npm": ">=10.0.0"
+      }
+    },
+    "node_modules/@smarlhens/npm-pin-dependencies-v1": {
+      "name": "@smarlhens/npm-pin-dependencies",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smarlhens/npm-pin-dependencies/-/npm-pin-dependencies-1.0.1.tgz",
+      "integrity": "sha512-r8fIFFGKlb2WRdvXbBpDpyq3FeIn68TZXhPk6j44TGLpSgHHlVWhumTSHMBMAH4EdvOQDWcTafdAlKs9TZnw0w==",
+      "license": "BlueOak-1.0.0",
+      "bin": {
+        "npd": "bin/npd.js",
+        "npm-pin-dependencies": "bin/npd.js"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0",
+        "npm": ">=10.9.7"
+      },
+      "optionalDependencies": {
+        "@smarlhens/npm-pin-dependencies-darwin-arm64": "1.0.1",
+        "@smarlhens/npm-pin-dependencies-darwin-x64": "1.0.1",
+        "@smarlhens/npm-pin-dependencies-linux-arm64-gnu": "1.0.1",
+        "@smarlhens/npm-pin-dependencies-linux-arm64-musl": "1.0.1",
+        "@smarlhens/npm-pin-dependencies-linux-x64-gnu": "1.0.1",
+        "@smarlhens/npm-pin-dependencies-linux-x64-musl": "1.0.1",
+        "@smarlhens/npm-pin-dependencies-win32-x64-msvc": "1.0.1"
+      }
+    },
+    "node_modules/@smarlhens/npm-pin-dependencies-win32-x64-msvc": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smarlhens/npm-pin-dependencies-win32-x64-msvc/-/npm-pin-dependencies-win32-x64-msvc-1.0.1.tgz",
+      "integrity": "sha512-LzIw/+lRbfqjOWsngj49B7WqyZK5iXoZ7AkhdmymXz7+4T/NFpJcVTc7wTsEU3ChMJJMuWReNt+ObDWbVdsjRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0",
+        "npm": ">=10.9.7"
       }
     },
     "node_modules/@yarnpkg/lockfile": {
@@ -2015,9 +2148,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",

--- a/bench-js/package.json
+++ b/bench-js/package.json
@@ -15,14 +15,15 @@
   "dependencies": {
     "@smarlhens/npm-check-engines-v0": "npm:@smarlhens/npm-check-engines@0.14.4",
     "@smarlhens/npm-check-engines-v1": "npm:@smarlhens/npm-check-engines@1.2.0",
-    "@smarlhens/npm-pin-dependencies": "0.11.1",
+    "@smarlhens/npm-pin-dependencies-v0": "npm:@smarlhens/npm-pin-dependencies@0.11.1",
+    "@smarlhens/npm-pin-dependencies-v1": "npm:@smarlhens/npm-pin-dependencies@1.0.1",
     "tinybench": "6.0.2"
   },
   "devDependencies": {
     "npm-check-updates": "22.2.1"
   },
   "engines": {
-    "node": "^22.13.0 || ^24.0.0 || >=26.0.0",
-    "npm": ">=10.9.2"
+    "node": "^22.22.2 || ^24.15.0 || >=26.0.0",
+    "npm": ">=10.9.7"
   }
 }


### PR DESCRIPTION
## What

Brings the `npm-pin-dependencies` (npd) benchmark/cross-validation harness to parity with `npm-check-engines` (nce), now that npd 1.0.1 is published to npm, and refreshes bench-js engine constraints.

### Changes
- **`package.json`**: replace the single `@smarlhens/npm-pin-dependencies` (0.11.1) dep with the same dual-alias scheme nce uses:
  - `@smarlhens/npm-pin-dependencies-v0` → `@smarlhens/npm-pin-dependencies@0.11.1` (TS predecessor)
  - `@smarlhens/npm-pin-dependencies-v1` → `@smarlhens/npm-pin-dependencies@1.0.1` (published NAPI)
- **`bench-npd.mjs`**: 3-way bench mirroring `bench-nce.mjs` — `js v0.x (TS predecessor)` / `napi v1.x (published)` / `napi local (unpublished)`.
- **`cross-validate-npd.mjs`**: import from the `-v0` alias (bare specifier removed).
- **`.ncurc.mjs`**: pin `npm-pin-dependencies` ncu target to `minor` so ncu holds each alias on its major line (v0→0.x, v1→1.x), matching the existing nce rule.
- **`engines`** (recomputed by running the repo's own nce over bench-js):
  - node `^22.13.0 || ^24.0.0 || >=26.0.0` → `^22.22.2 || ^24.15.0 || >=26.0.0`
  - npm `>=10.9.2` → `>=10.9.7`
- **`package-lock.json`**: regenerated.

## Results (darwin-arm64, Node 22.22.2)

Cross-validate: **6/6 npm fixtures match** (Rust pins == JS v0 pins).

| Fixture | js v0.x (0.11.1) | napi v1.x (1.0.1) | Speedup |
|---|---|---|---|
| npm small (3 deps) | 0.0299 ms | 0.0061 ms | ~4.9x |
| npm large (500 deps) | 2.44 ms | 0.487 ms | ~5.0x |

## Notes
- The `napi local (unpublished)` row only produces meaningful numbers against a **release** build: `cd crates/riri-napi-npd && npx napi build --platform --release`.
- npd 1.0.1 platform packages require `node ^22.22.2 || ^24.15.0 || >=26.0.0` (matches nce 1.2.2). As optional deps, npm silently skips them on older Node patch levels — run the bench on a satisfying Node. The engines bump above makes bench-js declare this honestly.