### PR TITLE
chore: bump npm cargo & pre-commit deps

### DIFF
--- a/.github/actions/bench-compare/package-lock.json
+++ b/.github/actions/bench-compare/package-lock.json
@@ -13,16 +13,16 @@
         "markdown-table": "3.0.4"
       },
       "devDependencies": {
-        "@types/node": "24.12.4",
-        "npm-check-updates": "22.2.1",
-        "oxfmt": "0.52.0",
-        "oxlint": "1.67.0",
-        "rolldown": "1.0.3",
+        "@types/node": "22.19.20",
+        "npm-check-updates": "22.2.3",
+        "oxfmt": "0.54.0",
+        "oxlint": "1.69.0",
+        "rolldown": "1.1.0",
         "typescript": "6.0.3"
       },
       "engines": {
-        "node": "^24.0.0 || >=26.0.0",
-        "npm": ">=11.3.0"
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0",
+        "npm": ">=10.9.7"
       }
     },
     "node_modules/@actions/core": {
@@ -267,9 +267,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
-      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "version": "0.134.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.134.0.tgz",
+      "integrity": "sha512-T0xuRRKrQFmocH8y+jGfpmSkGcheaJExY9lEihmR1Gm2aH+75B8CzgU2rABRQSzzDxLjZ15Sc0bRVLj5lVeNXQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -277,9 +277,9 @@
       }
     },
     "node_modules/@oxfmt/binding-android-arm-eabi": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.52.0.tgz",
-      "integrity": "sha512-17EMSJnQ9g+upVHrAUYDMfH5lvRKQ9Nvg8WtEoH72oDr1VpWz+7/o3tD97U1EToen2YAQ/68JmtDYkQUi20dfQ==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.54.0.tgz",
+      "integrity": "sha512-NAtpl/SiaeU103e7/OmZw0MvUnsUUopW7hEm/ecegJg7YM0skQaA0IXEZoyTV6NUdiNPupdIUreRqUZTShbn/g==",
       "cpu": [
         "arm"
       ],
@@ -294,9 +294,9 @@
       }
     },
     "node_modules/@oxfmt/binding-android-arm64": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.52.0.tgz",
-      "integrity": "sha512-A2G1IdwGEW2lLJkIxcvuirRH1CzSl/e0NX11zTlW1gvxJThfwbI/BEoaKrTNpm7M2FchvIf6guvIQU7d5iz+OQ==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.54.0.tgz",
+      "integrity": "sha512-B4VZfBUlKK1rmMChsssNZbkZjE8+FzG3avMjGgMDwbGxXRoXkoeXiAZ+78Oa+eyDPHvDCiUb4zH/vmCOUSafLQ==",
       "cpu": [
         "arm64"
       ],
@@ -311,9 +311,9 @@
       }
     },
     "node_modules/@oxfmt/binding-darwin-arm64": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.52.0.tgz",
-      "integrity": "sha512-f9+bLvOYxy7NttCLFTvQ7afmqDOWY4wIP9xdvfj5trQ1qj6f2UFAGwZESlfsMjvJNTyRpXfIlOanCI9FOvoeQA==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.54.0.tgz",
+      "integrity": "sha512-i02vF75b+ePsQP3tHqSxVYI5S6b8X/xqdPu7/mDHXtpgXLTYXi3jJmfHU0j+dnZZDKaYTx/ioCK7QYJmtiJR2g==",
       "cpu": [
         "arm64"
       ],
@@ -328,9 +328,9 @@
       }
     },
     "node_modules/@oxfmt/binding-darwin-x64": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.52.0.tgz",
-      "integrity": "sha512-YSTB9sJ5nnQd/Q0ddHkgof0ZCHPAnWZT1IW2SJ8omz7CP7KluJhO1fNHrpqdxCtpztJwSs4hY1uAee35wKxxaw==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.54.0.tgz",
+      "integrity": "sha512-8VMFvGvooXj7mswkbrhdVZ2/sgiDaBzWpkkbtO+qGDLV4EfJd67nQadHkQC0ZNbaWA9ajXfqI6i7PZLIeDzxEQ==",
       "cpu": [
         "x64"
       ],
@@ -345,9 +345,9 @@
       }
     },
     "node_modules/@oxfmt/binding-freebsd-x64": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.52.0.tgz",
-      "integrity": "sha512-NIrRNTTPCs4UbmVs0bxLSCDlLCtIRMJIXklNKaXa5Oj2/K1UIMBvgE8+uPVo01Io3N9HF0+GAX+aAHjUgZS7vA==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.54.0.tgz",
+      "integrity": "sha512-0cRHnp43WN1Jrc5s0BdbdKgR1XirdvHy7TAFi3JEsoEVQVJxTXMbpVd76sxXlgRswNMDhVFSJw+y7Eb8mEavFQ==",
       "cpu": [
         "x64"
       ],
@@ -362,9 +362,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm-gnueabihf": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.52.0.tgz",
-      "integrity": "sha512-JXUCde8mn3GpgQouz2PXUokgy/uT1QrRJBL2s983VWcSQp62wTFYiNXgTKdeo1Jgbr0IgUnKKvzIk/YBlj/nVQ==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.54.0.tgz",
+      "integrity": "sha512-JyQAk3hK/OEtup7Rw6kZwfdzbKqTVD5jXXb8Xpfay29suwZyfBDMVW/bj4RqEPySYWc6zCp198pOluf8n5uYzg==",
       "cpu": [
         "arm"
       ],
@@ -379,9 +379,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm-musleabihf": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.52.0.tgz",
-      "integrity": "sha512-psbUXaRZ+V8DaXz10Qf7LSHtdtdKAmC8fxXgeU608jjzrmWK4quamZMOpl6sf+dikoFHA85uE93Q0BqxrCdQrQ==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.54.0.tgz",
+      "integrity": "sha512-qnvLatTpM8vtvjOfcckBOzJjk+n6ce/wwpP8OFeUrD5aNLYcKyWAitwj+Rk3PK9jGanbZvKsJnv14JGQ6XqFdw==",
       "cpu": [
         "arm"
       ],
@@ -396,16 +396,13 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm64-gnu": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.52.0.tgz",
-      "integrity": "sha512-Jw7MgWUU9lcLCcy82updISP3EthTlfvAwR6gWNxPzqly7+fLvOi2gHQE9xXQjpqaVLm/8P+gOzlv9ODuoVlaaw==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.54.0.tgz",
+      "integrity": "sha512-SMkhnCzIYZYDk9vw3W/80eeYKmrMpGF0Giuxt4HruFlCH7jEtnPeb3SdQKMfgYi/dgtaf+hZAb5XWPYnxqCQ3w==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -416,16 +413,13 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm64-musl": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.52.0.tgz",
-      "integrity": "sha512-wZg6bLjDvh2KibyI3QFUYo8GTXneIFsd0JvehtvJiUmQ8WRPERgxd/VM4ctWb86U5FT1FkqgS8/wZKVB+AZScg==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.54.0.tgz",
+      "integrity": "sha512-QrwJlBFFKnxOd95TAaszpMbZBLzMoYMpGaQTZF8oibacnF5rv8l12IhILhQRPmksWiBqg0YSe2Mnl7ayeJAHSA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -436,16 +430,13 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-ppc64-gnu": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.52.0.tgz",
-      "integrity": "sha512-IngE8uxhNvxcMrLjZNDo9xNLY7rEK33AKnaMd2B46he1e/mz2CfcW6If/U1wUjdRZddm1QzQaciqZkuMkdh1FA==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.54.0.tgz",
+      "integrity": "sha512-WILatiol/TUHTlhod7R09+7Az/XlhKwmY1MHfLZNmewltPWNN/EwxP2rQSHahibZ/cB8gmckEBjBOByD+5bYsQ==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -456,16 +447,13 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-riscv64-gnu": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.52.0.tgz",
-      "integrity": "sha512-H3+DdFMv/efN3Efmhsv18jDrpiWWqKG7wsfAlQBqAt6z/E2Bx+TwEj2Nowe51CPOWB8/mFBC2dAMSgVFLvvowA==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.54.0.tgz",
+      "integrity": "sha512-f05YMG4BH4G8S4ME6UM6fi1MnJ9094mrnvO5Pa4SJlMfWlUM+1/ZWMEF4NnjM7shZAvbHsHRuVYpUo0PHC4P9Q==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -476,16 +464,13 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-riscv64-musl": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.52.0.tgz",
-      "integrity": "sha512-zji+1kb7lJKohSDjzC1IsS+K/cKRs1hdVf0ZH0VbdbiakmtLvN9twBoXo/k8VdjFax7kfo+DyPxS7vv52br1aw==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.54.0.tgz",
+      "integrity": "sha512-UfL+2hj1ClNqcCRT9s8vBU4axDpjxgVxX96G+9DYAYjoc5b0u15CJtn2jgsi9iM+EbGNc5CW1HVRgwVu76UsSA==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -496,16 +481,13 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-s390x-gnu": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.52.0.tgz",
-      "integrity": "sha512-hcLBYedpCy7ToUvvBidWk7+11Yhg1oAZ4+6hKPic/mQI6NaqXJSXMps5nFlwUuX2ewhtLZZDPg63TI042qGKBg==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.54.0.tgz",
+      "integrity": "sha512-3/XZe931Hka+J6NjnaqJzYpsWWxDTuRdUdwSQHnOuJEgbC+SehIMFJS8hsEjV7LBhVSL2OCnRLvbVW8O97XIyw==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -516,16 +498,13 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-x64-gnu": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.52.0.tgz",
-      "integrity": "sha512-IDO2loXK2OtTOhSPchU9MW25mWL2QCDGdJbjN8MXKZVS80qXe5gMTwQWu/gMJ3juoBHbkuUZNB2N1LHzNT7DoA==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.54.0.tgz",
+      "integrity": "sha512-Ik93RlObtu43GbxApafayFjwYE06L6Xr08cSwpBPYbDrLp2ReZx0Jm1DqwRyYRnukUJy+rK2WaEvUQOxdytU9Q==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -536,16 +515,13 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-x64-musl": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.52.0.tgz",
-      "integrity": "sha512-mAV2Hjn0SatJ+KoAzKUC3eJhdJ8wv+3m1KyuS0dTsbF0c5weq+QrCt/DRZZM+uj/XiKzCDEUKYsBF30e2qkcyw==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.54.0.tgz",
+      "integrity": "sha512-yZcakmPlD86CNymknd7KfW+FH+qfbqJH+i0h69CYfV1+KMoVeM9UED+8+TDVoU4haxI0NxY7RPCvRLy3Sqd2Qg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -556,9 +532,9 @@
       }
     },
     "node_modules/@oxfmt/binding-openharmony-arm64": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.52.0.tgz",
-      "integrity": "sha512-vd4npaUIwChxp7XzkqmepBWTT9YMcSe/NBApVGPC30/lLyOVaV3dvma1SKo03t8O73BPRAG7EyJzGlN5cJM5hQ==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.54.0.tgz",
+      "integrity": "sha512-GiVBZNnEZnKu00f1jTg49nomv187d0GQX+O+ocykoLeiaALuEO+swoTehHn9TehTfi7V8H0i0e/yvUjCqnwk1w==",
       "cpu": [
         "arm64"
       ],
@@ -573,9 +549,9 @@
       }
     },
     "node_modules/@oxfmt/binding-win32-arm64-msvc": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.52.0.tgz",
-      "integrity": "sha512-k2sz6gWQdMfh5HPpIS+Bw/0UEV/kaK2xuqJRrWL233sEHx9WLlsmvlPFM4HUNThkYbSN0U0vPW7LVKZWDS8hPQ==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.54.0.tgz",
+      "integrity": "sha512-J0SSB8Z1Fre2sxRolYcW6Rl1RQmKdQ2hnHyq4YJrfBRiXTObLw4DXnIVraM/UyqGqwOi7yTrQA4VT7DPxlHVKA==",
       "cpu": [
         "arm64"
       ],
@@ -590,9 +566,9 @@
       }
     },
     "node_modules/@oxfmt/binding-win32-ia32-msvc": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.52.0.tgz",
-      "integrity": "sha512-rhke69GTcArodLHpjMTfNnvjTEBryDeZcUCKK/VjXDMtfTULl6QRh0ymX5/hbCUv2WjYm9h/QbW++q2vE15gWQ==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.54.0.tgz",
+      "integrity": "sha512-O61UDVj8zz6yXJjkHPf05VaMLOXmEF8P5kf/N0W7AQMmd6bcQogl+KJc7rMutKTL524oE9iH32JXZClBFmEQIg==",
       "cpu": [
         "ia32"
       ],
@@ -607,9 +583,9 @@
       }
     },
     "node_modules/@oxfmt/binding-win32-x64-msvc": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.52.0.tgz",
-      "integrity": "sha512-q5xL7oeXkZdEtNZWBdvehJcmt+GRu9l2bK40yJs1jJXlqq+r0Hygb1rTjq+FM2o/2xyt4cufH6KRplHp3Jjsvw==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.54.0.tgz",
+      "integrity": "sha512-1MDpqJPiFqxWtIHas8vkb1VZ7f7eKyTffAwmO8isxQYMaG1OFKsH666BWLeXQLO+IWNfiMssLD55hbR1lIPTqg==",
       "cpu": [
         "x64"
       ],
@@ -624,9 +600,9 @@
       }
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.67.0.tgz",
-      "integrity": "sha512-VrSi571rDv1N8HaEDM+DEX8nmT0y9jJo8tzzW13vsOWTx59xQczCIJx68n2zWOXRT5YKZsOZXp4qkHN/10x4mw==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.69.0.tgz",
+      "integrity": "sha512-DKQQbD5cZ/MYfDgDI7YGyGD9FSxABlsBsYFo5p26lloob543tP9+4N3guwdXIYJN+7HSZxLe8YJuwcOWw5qnHg==",
       "cpu": [
         "arm"
       ],
@@ -641,9 +617,9 @@
       }
     },
     "node_modules/@oxlint/binding-android-arm64": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.67.0.tgz",
-      "integrity": "sha512-l6+NdYxMoRohix5r5bbigW16LPicceCwGcQ6LKKuE1kUdjgFfQolJjrJsQYPFetIs78Gxj/G/f5TEGoTCwj9nQ==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.69.0.tgz",
+      "integrity": "sha512-lEhb+I5pr4inux+JFwfCa1HRq3Os7NirEFQ0H1I35SVEHPm6byX0Ah47xmRha3qi6LAkxUcxViL8o/9PivjzBg==",
       "cpu": [
         "arm64"
       ],
@@ -658,9 +634,9 @@
       }
     },
     "node_modules/@oxlint/binding-darwin-arm64": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.67.0.tgz",
-      "integrity": "sha512-jOzXxS1AxFxhImLIRbtGIMrEwaXcgMw3gR57WB1cRk8ai+vpr6726kxXqVvlNsrXtJ/FrmOm8RxlC0m8SW24Qg==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.69.0.tgz",
+      "integrity": "sha512-GY2YE8lOZW59BW1Ia1y+1gR0XyjrZRvVWHAr8LGeGhYHE0OQJ/7cRKXTkx1P+E9/6awEc3SX8a68SFTjh/E//A==",
       "cpu": [
         "arm64"
       ],
@@ -675,9 +651,9 @@
       }
     },
     "node_modules/@oxlint/binding-darwin-x64": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.67.0.tgz",
-      "integrity": "sha512-3DFAVY94OqjIZHXIPz37yGRSWwOFTAqChQ64/M69GYLawzP0KiwdhDNfqdKKYT0bTR/DNxmMnQsj3ns+8+X/Lg==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.69.0.tgz",
+      "integrity": "sha512-ax1oZnOjHX3LB7myQyHEaQkDwfLb6str3/nSP6O7EVUviQGNkEGzGV0EqcBJWK+Ufwx0l4xPgyYayurvhAdl2Q==",
       "cpu": [
         "x64"
       ],
@@ -692,9 +668,9 @@
       }
     },
     "node_modules/@oxlint/binding-freebsd-x64": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.67.0.tgz",
-      "integrity": "sha512-e4dDKZuLu8TR9DEBssWSDahlPgZBwojTTHZUvnjBRJfJJbpxYCjfjKfi0Z1+CSLMiJBwI2yCDtRM1XJQaARjmg==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.69.0.tgz",
+      "integrity": "sha512-kHWeHv4g2h8NY+mpCxzCtY4uerMJWTN/TSnNj1CPbakFpHEJ6cTya2wWV0pDSYWOJ2+0UiEbhn3AtXxHtsnKjg==",
       "cpu": [
         "x64"
       ],
@@ -709,9 +685,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.67.0.tgz",
-      "integrity": "sha512-BKytFdcQzbITV3xlnzDUDTEDtbUMCCiC4EaNTDZ4FyT8gdNvBC4gfiLucXp/sQl0XU3p7syTlorUWVVVBZab2g==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.69.0.tgz",
+      "integrity": "sha512-gq84vM1a1oEehXo27YCDzGVcxPsZDI1yswZwz2Da1/cbnWtrL16XZZnz0G/+gIU8edtHpfjxq5c+vWEHqJfWoQ==",
       "cpu": [
         "arm"
       ],
@@ -726,9 +702,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm-musleabihf": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.67.0.tgz",
-      "integrity": "sha512-XYAv0esBDX7BpTzRDjVX2Vdj+zndd8ll2dFQiaeQ6zTZr7A8GRDTN7fH3FP3jU+O0vCDx85oH/EtG7BzPgAXuw==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.69.0.tgz",
+      "integrity": "sha512-kIqEa98JQ0VRyrcncxA417m2AzasqTlD+FyVT1AksjvjkqQcvm7pBWYvoW3/mpyOP2XYvi5nSCCTIe6De1yu5g==",
       "cpu": [
         "arm"
       ],
@@ -743,16 +719,13 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm64-gnu": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.67.0.tgz",
-      "integrity": "sha512-zizRMjA0i6u/2B0evgda04iycu+MoNuf1pBy6Eh+1CjC5wMEG7qN5zdDKTCvFc0KSYSDM9QTG3gjZHirgtQuKg==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.69.0.tgz",
+      "integrity": "sha512-j+xYiXozxGWx2cpjCrwwGR4awTxPFsRv3JZrv23RCogEPMc4R7UqjHW47p/RG0aRlbWiROCJ8coUfCwy0dvzHA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -763,16 +736,13 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm64-musl": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.67.0.tgz",
-      "integrity": "sha512-zB/Tf6sUjmmvvbva9Gj3JTJ8rJ9t4I8/U0o6vSRtd0DRIsIuyegBwJAzhSUFQHdMijIRJkW0exs/yBhpw2S20w==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.69.0.tgz",
+      "integrity": "sha512-xEPpNppTfN1l/nM7gYSf9iocscu/as+p/7vxkLeLEKnYU+09Dm+5V6IhDYDh+Uz6FajEupWwCLt5SOG0y1PCKg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -783,16 +753,13 @@
       }
     },
     "node_modules/@oxlint/binding-linux-ppc64-gnu": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.67.0.tgz",
-      "integrity": "sha512-kgU40Gt74CK0TCsF51KZymkIwN9U0BajKsMijB52zPqOeZU9NAHkA/NSQkZDHEaCakx42DxhXkODiAqf2b4Gug==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.69.0.tgz",
+      "integrity": "sha512-Ug0+eU7HJBlek+SjklYH62IlOMirEJsdxpihH0kSqX0XdrDD4NdHpQc10fK1JC35yn6KrrcN+uYzlHD38XAf8Q==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -803,16 +770,13 @@
       }
     },
     "node_modules/@oxlint/binding-linux-riscv64-gnu": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.67.0.tgz",
-      "integrity": "sha512-tOYhkk/iaG9aD3FvGpBFd1Lrw0x0RaVoJBxjUkfNzS50rC5NS5BteNCwgr8A2zCdADrIIoze6D7u6U5Ic++/iQ==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.69.0.tgz",
+      "integrity": "sha512-iEyI3GIg0l/s3G4qy2TlaaWKdzj4PJJStwtlocpDTC00PY9hZueotf6OKUj9+yfQh0lrpBW/pLMgTztbAHKJEg==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -823,16 +787,13 @@
       }
     },
     "node_modules/@oxlint/binding-linux-riscv64-musl": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.67.0.tgz",
-      "integrity": "sha512-sEtywrPb+0b+tHYl1SDCrw903fiC4eyKoNqzP3v+f2JT3Xcv4NEYG+P8rj+eEnX7IWhqV/xj8/JmcmVj21CXaA==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.69.0.tgz",
+      "integrity": "sha512-NjHjpiI4WIKSMwuoJSZi5VToPeoYOS1FR52HLIDG6lidMdqquusgtODb4iLk0+lb1q3Z0nv2/aPRcC/olmpQGg==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -843,16 +804,13 @@
       }
     },
     "node_modules/@oxlint/binding-linux-s390x-gnu": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.67.0.tgz",
-      "integrity": "sha512-BvR8Moa0zCLxroOx4vZaZN9nUfwAUpSTwjZdxZyKy4bv3PrzrXrxKR/ZQ0L9wNSvlPhnMJeZfa3q5w6ZCTuN6Q==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.69.0.tgz",
+      "integrity": "sha512-Ai/prDewoItkDXbp38gwGZi41DycZbUTZJ3UidwoHgQC0/DaqC2TGdtBTQLJ6hSD+SAxASzh8+/eSBPmxfOacA==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -863,16 +821,13 @@
       }
     },
     "node_modules/@oxlint/binding-linux-x64-gnu": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.67.0.tgz",
-      "integrity": "sha512-mm2cxM6fksOpq6l0uFws8BUGKAR4dNa/cZCn37Npq7PFbhD5HDJqWfnoIvTaeRKMy5XdS2tO0MA0qbHDrnXAAA==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.69.0.tgz",
+      "integrity": "sha512-Gt3KHgp46mRKz4sJeaASmKvD8ayXookRw07RMf+NowhEztGGDZ7VrXpoW96XuKJLjFukWizOFVNjmYb/u7caNQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -883,16 +838,13 @@
       }
     },
     "node_modules/@oxlint/binding-linux-x64-musl": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.67.0.tgz",
-      "integrity": "sha512-WmbMuLapKyDlobMkXAaAL0Y+Uczh4LETfIfQsUpbId4Ip8Ai82/jqeYTOoUCkuuhBFapgqP253+d83tLKOksJg==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.69.0.tgz",
+      "integrity": "sha512-7tQhJ2+p/oHv1zcfnjYI7YVzC/7iBaVOfIvFYtxdJ5F45mWgEdrCyXZXZGfiLey5t/5JhOhsaMnnv1kAzckd7g==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -903,9 +855,9 @@
       }
     },
     "node_modules/@oxlint/binding-openharmony-arm64": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.67.0.tgz",
-      "integrity": "sha512-9g/PqxYJelzzTAOR5Y+RiRqdeydhEuXv2KxNeFcAKQ7UsvnWSY1OP4MsuPMbTO2Pf70tz7mFhl1j13H3fyh+8g==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.69.0.tgz",
+      "integrity": "sha512-vmWz6TKp/3hfA4lksR0zHBv/6xuX1jhym6eqOjdH2DXsDDHZWcp2f0KG0VCAnlVbIrjk29G4wAWMXb/Hn1YobA==",
       "cpu": [
         "arm64"
       ],
@@ -920,9 +872,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-arm64-msvc": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.67.0.tgz",
-      "integrity": "sha512-2VhwE6Gatb0vJGnN0TBuQMbKCOiZlSQ/zJvVWYLK4a9d4iDiJOen/yVQkGpmsJ90MuH66fzi0kEKI0jRQMDxGA==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.69.0.tgz",
+      "integrity": "sha512-9RExaLgmaw6IoIkU9cTpT71mLfI0xZ86iZH8x518LVsOkjquJMYqb9P7KpC8lgd1t0Dxs41p2pxynq4XR3Ttzw==",
       "cpu": [
         "arm64"
       ],
@@ -937,9 +889,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-ia32-msvc": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.67.0.tgz",
-      "integrity": "sha512-EQ3VExXfeM1InbE5+JjufhZZTWy+kHUwgt3yZR7gQ47Je/mE0WspQPan0OJznh493L5anM210YNJtH1PXjTSFg==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.69.0.tgz",
+      "integrity": "sha512-1907kRPF8/PrcIw1E7LMs9JbVrpgnt/MvFdss3an8oDkYNAACXzTntV3t3869ZZhMZxb2AzRGbz1pA/jdFatXA==",
       "cpu": [
         "ia32"
       ],
@@ -954,9 +906,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-x64-msvc": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.67.0.tgz",
-      "integrity": "sha512-bw24y+/1MHS4QDkons3YyHkPT9uCMoLHHgQhb+mb8NOjTYwub1CZ+K9Ngr8aO5DMrDrkqHwTzlTwFP2vS8Y/ZQ==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.69.0.tgz",
+      "integrity": "sha512-w8SOXv3mT9Fi6jY8OXdXCfnvX/3KNLXGNr4HEz2TA7S4Mv/PYAOmpB8y/ge40mxvBMgGNaSaaDwZpAsQn7HtWA==",
       "cpu": [
         "x64"
       ],
@@ -971,9 +923,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
-      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.0.tgz",
+      "integrity": "sha512-gCYzGOSkYY6Z034suzd20euvds7lPzMEEla62DJGE/ZAlR4OMBnNbvnBSsIGUCAr52gaWMsloGxP4tVGtN5aCA==",
       "cpu": [
         "arm64"
       ],
@@ -988,9 +940,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
-      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.0.tgz",
+      "integrity": "sha512-JQBD77MNgu+4Z6RAyg69acugdrhhVoWesr3l47zohYZ2YV2fwkWMArkN/2p4l6Ei+Sno7W5q+UsKdVWq5Ens0w==",
       "cpu": [
         "arm64"
       ],
@@ -1005,9 +957,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
-      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.0.tgz",
+      "integrity": "sha512-p/8cXUTK4Sob604e+xxPhVSbDFf29E6J0l/xESM9rdCfn3aDai3nEs6TnMHUsdD5aNlFz0+gDbiGlozLKGa2YA==",
       "cpu": [
         "x64"
       ],
@@ -1022,9 +974,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
-      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.0.tgz",
+      "integrity": "sha512-KbtOSlVv6fElujiZWMcC3aQYhEwLVVf073RcwlSmpGQvIsKZFUqc0ef4sjUuurRwfbiI6JJXji9DQn+86hawmQ==",
       "cpu": [
         "x64"
       ],
@@ -1039,9 +991,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
-      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.0.tgz",
+      "integrity": "sha512-9fZ9i0o0/MQaw7om6Z6TsT7tfCk0jtbEFtC+aPqZL5RNsGWNcHvn6EHgL3dAprjq+AZzPTAQjg2JtpJaMt+6pg==",
       "cpu": [
         "arm"
       ],
@@ -1056,16 +1008,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
-      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.0.tgz",
+      "integrity": "sha512-+tog7T66i+yFyIuuAnjL6xmW182W/qTBOUt6BtQ6lBIM1Eikh/fSMz4HGgvuCp5uU0zuIVWng7kDYthjCMOHcg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1076,16 +1025,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
-      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.0.tgz",
+      "integrity": "sha512-4b7yruLIIj/oZ3GpcLOvxcLCLDMraohn3IhQfN2hBP4w9UekG0DTIajWguJosRGfySf/+h/NwRUiMKoCpxCrqQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1096,16 +1042,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
-      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.0.tgz",
+      "integrity": "sha512-QRDOVZd0bhQ5jLsUsCC3dUxDWdTSVY9WMznowZgCGOrZfLLgctWpelhUASEiBwsXfat/JwYnVd1EaxMhqyT+UQ==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1116,16 +1059,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
-      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.0.tgz",
+      "integrity": "sha512-ypxT+Hq76NFG7woFbNbySnGEajFuYuIXeKz/jfCU+lXUoxfi3zLE6OG/ZQNeK3RpZSYJlAe2bokpsQ046CaieQ==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1136,16 +1076,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
-      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.0.tgz",
+      "integrity": "sha512-IdovCmfROFmpTLahdecTDFL74aLERVYN68F/mLZjfVh6LfoplPfI6deyHNMTcVujbokDV5k05XrFO22zfv+qjg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1156,16 +1093,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
-      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.0.tgz",
+      "integrity": "sha512-pcA8xlFp2tyk9T2R6Fi/rPe3bQ1MA+sSMDNUU5Ogu80GHOatkE4P8YCreGAvZErm5Ho2YRXnyvNrWiRncfVysQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1176,9 +1110,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
-      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.0.tgz",
+      "integrity": "sha512-4+fexHayrLCWpriPh4c6dNvL4an34DEZCG7zOM/FD5QNF6h8DT+bDXzyB/kfC8lDJbaFb7jKShtnjDQFXVQEjg==",
       "cpu": [
         "arm64"
       ],
@@ -1193,9 +1127,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
-      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.0.tgz",
+      "integrity": "sha512-SbL++MNmOw6QamrwIGDMSSfM4ceTzFr+RjbOExJSLLBinScU4WI5OdA413h1qwPw2yH7lVF1+H4svQ+6mSXKTQ==",
       "cpu": [
         "wasm32"
       ],
@@ -1212,9 +1146,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
-      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.0.tgz",
+      "integrity": "sha512-+xTE6XC7wBgk0VKRXGG+QAnyW5S9b8vfsFpiMjf0waQTmSQSU8onsH/beyZ8X4aXVveJnotiy7VDjLOaW8bTrg==",
       "cpu": [
         "arm64"
       ],
@@ -1229,9 +1163,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
-      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.0.tgz",
+      "integrity": "sha512-Ogji1TQNqH3ACLnYr+1Ns1nyrJ0CO2P585u9Hsh02pXvtFiFpgtgT2b3P4PnCOU86VVCvqtAeCN4OftMT8KU4w==",
       "cpu": [
         "x64"
       ],
@@ -1264,13 +1198,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.12.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
-      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/before-after-hook": {
@@ -1309,9 +1243,9 @@
       }
     },
     "node_modules/npm-check-updates": {
-      "version": "22.2.1",
-      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-22.2.1.tgz",
-      "integrity": "sha512-mGdIJfhtg+q0BzhbOpbOL73zhMZlgBQMG4wnBwPMMD5k96028UCuV0753YeSYk9odoh7HWK6/cY69bWxT7o+yg==",
+      "version": "22.2.3",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-22.2.3.tgz",
+      "integrity": "sha512-n8HZ0ywZugYRgEqIm67hbZC5L/9S/gLX+MkGchJB43pP2xib1+u76OpVEJRZ4QP2BksPRi5M1CCStJVfc16+/A==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1324,9 +1258,9 @@
       }
     },
     "node_modules/oxfmt": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.52.0.tgz",
-      "integrity": "sha512-nJlYM35F64zTDMecCNhoHNkf+D/eHv7xcjj9XDSj+bFAVtN93m7v8DQMdHd6nDG6Akf/kEYYHmDUBs2Dz27Sug==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.54.0.tgz",
+      "integrity": "sha512-DjnMwn7smSLF+Mc2+pRItnuPftm/dkUFpY/d4+33y9TfKrsHZo8GLhmUg9BrOIUEy94Rlom1Q11N6vuhE+e0oQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1342,25 +1276,25 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxfmt/binding-android-arm-eabi": "0.52.0",
-        "@oxfmt/binding-android-arm64": "0.52.0",
-        "@oxfmt/binding-darwin-arm64": "0.52.0",
-        "@oxfmt/binding-darwin-x64": "0.52.0",
-        "@oxfmt/binding-freebsd-x64": "0.52.0",
-        "@oxfmt/binding-linux-arm-gnueabihf": "0.52.0",
-        "@oxfmt/binding-linux-arm-musleabihf": "0.52.0",
-        "@oxfmt/binding-linux-arm64-gnu": "0.52.0",
-        "@oxfmt/binding-linux-arm64-musl": "0.52.0",
-        "@oxfmt/binding-linux-ppc64-gnu": "0.52.0",
-        "@oxfmt/binding-linux-riscv64-gnu": "0.52.0",
-        "@oxfmt/binding-linux-riscv64-musl": "0.52.0",
-        "@oxfmt/binding-linux-s390x-gnu": "0.52.0",
-        "@oxfmt/binding-linux-x64-gnu": "0.52.0",
-        "@oxfmt/binding-linux-x64-musl": "0.52.0",
-        "@oxfmt/binding-openharmony-arm64": "0.52.0",
-        "@oxfmt/binding-win32-arm64-msvc": "0.52.0",
-        "@oxfmt/binding-win32-ia32-msvc": "0.52.0",
-        "@oxfmt/binding-win32-x64-msvc": "0.52.0"
+        "@oxfmt/binding-android-arm-eabi": "0.54.0",
+        "@oxfmt/binding-android-arm64": "0.54.0",
+        "@oxfmt/binding-darwin-arm64": "0.54.0",
+        "@oxfmt/binding-darwin-x64": "0.54.0",
+        "@oxfmt/binding-freebsd-x64": "0.54.0",
+        "@oxfmt/binding-linux-arm-gnueabihf": "0.54.0",
+        "@oxfmt/binding-linux-arm-musleabihf": "0.54.0",
+        "@oxfmt/binding-linux-arm64-gnu": "0.54.0",
+        "@oxfmt/binding-linux-arm64-musl": "0.54.0",
+        "@oxfmt/binding-linux-ppc64-gnu": "0.54.0",
+        "@oxfmt/binding-linux-riscv64-gnu": "0.54.0",
+        "@oxfmt/binding-linux-riscv64-musl": "0.54.0",
+        "@oxfmt/binding-linux-s390x-gnu": "0.54.0",
+        "@oxfmt/binding-linux-x64-gnu": "0.54.0",
+        "@oxfmt/binding-linux-x64-musl": "0.54.0",
+        "@oxfmt/binding-openharmony-arm64": "0.54.0",
+        "@oxfmt/binding-win32-arm64-msvc": "0.54.0",
+        "@oxfmt/binding-win32-ia32-msvc": "0.54.0",
+        "@oxfmt/binding-win32-x64-msvc": "0.54.0"
       },
       "peerDependencies": {
         "svelte": "^5.0.0",
@@ -1376,9 +1310,9 @@
       }
     },
     "node_modules/oxlint": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.67.0.tgz",
-      "integrity": "sha512-blwwaHPdoH8piQ5/z0KHeoHFR7FZgl12WluKJfu4qFLPkZl6mK04PkLE45Fw1NxfBRSlh40Gu7MkxHUw++ociQ==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.69.0.tgz",
+      "integrity": "sha512-ypZkK/aDc5NQV8zIR6s2H2Tl3aNW8FmJ1m9+2qsaYuRenl8vgnHNCGwTHviWJdUQzglOlHFchgopdtGhSy17Rw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1391,25 +1325,25 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxlint/binding-android-arm-eabi": "1.67.0",
-        "@oxlint/binding-android-arm64": "1.67.0",
-        "@oxlint/binding-darwin-arm64": "1.67.0",
-        "@oxlint/binding-darwin-x64": "1.67.0",
-        "@oxlint/binding-freebsd-x64": "1.67.0",
-        "@oxlint/binding-linux-arm-gnueabihf": "1.67.0",
-        "@oxlint/binding-linux-arm-musleabihf": "1.67.0",
-        "@oxlint/binding-linux-arm64-gnu": "1.67.0",
-        "@oxlint/binding-linux-arm64-musl": "1.67.0",
-        "@oxlint/binding-linux-ppc64-gnu": "1.67.0",
-        "@oxlint/binding-linux-riscv64-gnu": "1.67.0",
-        "@oxlint/binding-linux-riscv64-musl": "1.67.0",
-        "@oxlint/binding-linux-s390x-gnu": "1.67.0",
-        "@oxlint/binding-linux-x64-gnu": "1.67.0",
-        "@oxlint/binding-linux-x64-musl": "1.67.0",
-        "@oxlint/binding-openharmony-arm64": "1.67.0",
-        "@oxlint/binding-win32-arm64-msvc": "1.67.0",
-        "@oxlint/binding-win32-ia32-msvc": "1.67.0",
-        "@oxlint/binding-win32-x64-msvc": "1.67.0"
+        "@oxlint/binding-android-arm-eabi": "1.69.0",
+        "@oxlint/binding-android-arm64": "1.69.0",
+        "@oxlint/binding-darwin-arm64": "1.69.0",
+        "@oxlint/binding-darwin-x64": "1.69.0",
+        "@oxlint/binding-freebsd-x64": "1.69.0",
+        "@oxlint/binding-linux-arm-gnueabihf": "1.69.0",
+        "@oxlint/binding-linux-arm-musleabihf": "1.69.0",
+        "@oxlint/binding-linux-arm64-gnu": "1.69.0",
+        "@oxlint/binding-linux-arm64-musl": "1.69.0",
+        "@oxlint/binding-linux-ppc64-gnu": "1.69.0",
+        "@oxlint/binding-linux-riscv64-gnu": "1.69.0",
+        "@oxlint/binding-linux-riscv64-musl": "1.69.0",
+        "@oxlint/binding-linux-s390x-gnu": "1.69.0",
+        "@oxlint/binding-linux-x64-gnu": "1.69.0",
+        "@oxlint/binding-linux-x64-musl": "1.69.0",
+        "@oxlint/binding-openharmony-arm64": "1.69.0",
+        "@oxlint/binding-win32-arm64-msvc": "1.69.0",
+        "@oxlint/binding-win32-ia32-msvc": "1.69.0",
+        "@oxlint/binding-win32-x64-msvc": "1.69.0"
       },
       "peerDependencies": {
         "oxlint-tsgolint": ">=0.22.1",
@@ -1425,13 +1359,13 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
-      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.0.tgz",
+      "integrity": "sha512-zpMvlJhs5PkXRTtKc0CaLBVI9AR/VDiJFpM+kx//hgToEca7FgMlGjaRIisXBcb19T76LswgmKECSQ96hjWr5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.133.0",
+        "@oxc-project/types": "=0.134.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -1441,21 +1375,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.3",
-        "@rolldown/binding-darwin-arm64": "1.0.3",
-        "@rolldown/binding-darwin-x64": "1.0.3",
-        "@rolldown/binding-freebsd-x64": "1.0.3",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
-        "@rolldown/binding-linux-arm64-musl": "1.0.3",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
-        "@rolldown/binding-linux-x64-gnu": "1.0.3",
-        "@rolldown/binding-linux-x64-musl": "1.0.3",
-        "@rolldown/binding-openharmony-arm64": "1.0.3",
-        "@rolldown/binding-wasm32-wasi": "1.0.3",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
-        "@rolldown/binding-win32-x64-msvc": "1.0.3"
+        "@rolldown/binding-android-arm64": "1.1.0",
+        "@rolldown/binding-darwin-arm64": "1.1.0",
+        "@rolldown/binding-darwin-x64": "1.1.0",
+        "@rolldown/binding-freebsd-x64": "1.1.0",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.0",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.0",
+        "@rolldown/binding-linux-arm64-musl": "1.1.0",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.0",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.0",
+        "@rolldown/binding-linux-x64-gnu": "1.1.0",
+        "@rolldown/binding-linux-x64-musl": "1.1.0",
+        "@rolldown/binding-openharmony-arm64": "1.1.0",
+        "@rolldown/binding-wasm32-wasi": "1.1.0",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.0",
+        "@rolldown/binding-win32-x64-msvc": "1.1.0"
       }
     },
     "node_modules/tinypool": {
@@ -1509,9 +1443,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/.github/actions/bench-compare/package.json
+++ b/.github/actions/bench-compare/package.json
@@ -20,11 +20,11 @@
     "markdown-table": "3.0.4"
   },
   "devDependencies": {
-    "@types/node": "24.12.4",
-    "npm-check-updates": "22.2.1",
-    "oxfmt": "0.52.0",
-    "oxlint": "1.67.0",
-    "rolldown": "1.0.3",
+    "@types/node": "22.19.20",
+    "npm-check-updates": "22.2.3",
+    "oxfmt": "0.54.0",
+    "oxlint": "1.69.0",
+    "rolldown": "1.1.0",
     "typescript": "6.0.3"
   },
   "engines": {

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/oxc-project/mirrors-oxfmt
-    rev: "v0.52.0"
+    rev: "v0.54.0"
     hooks:
       - id: oxfmt
         types_or: [javascript, jsx, ts, tsx, json, yaml, markdown, css]
@@ -26,7 +26,7 @@ repos:
         exclude: '(^|/)(package-lock\.json|pnpm-lock\.yaml)$'
 
   - repo: https://github.com/oxc-project/mirrors-oxlint
-    rev: "v1.67.0"
+    rev: "v1.69.0"
     hooks:
       - id: oxlint
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,9 +245,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ unwrap_used = "deny"
 
 [workspace.dependencies]
 anyhow = "1.0.102"
-chrono = { version = "0.4.44", default-features = false, features = ["clock", "std", "serde"] }
+chrono = { version = "0.4.45", default-features = false, features = ["clock", "std", "serde"] }
 clap = { version = "4.6.1", features = ["derive"] }
 comfy-table = "7.2.2"
 console = "0.16.3"

--- a/bench-js/package-lock.json
+++ b/bench-js/package-lock.json
@@ -7,7 +7,7 @@
       "name": "bench-js",
       "dependencies": {
         "@smarlhens/npm-check-engines-v0": "npm:@smarlhens/npm-check-engines@0.14.4",
-        "@smarlhens/npm-check-engines-v1": "npm:@smarlhens/npm-check-engines@1.2.0",
+        "@smarlhens/npm-check-engines-v1": "npm:@smarlhens/npm-check-engines@1.2.2",
         "@smarlhens/npm-pin-dependencies-v0": "npm:@smarlhens/npm-pin-dependencies@0.11.1",
         "@smarlhens/npm-pin-dependencies-v1": "npm:@smarlhens/npm-pin-dependencies@1.0.1",
         "markdown-table": "3.0.4",
@@ -15,11 +15,11 @@
         "tinybench": "6.0.2"
       },
       "devDependencies": {
-        "@types/node": "24.12.4",
-        "envinfo": "7.14.0",
-        "npm-check-updates": "22.2.1",
-        "oxfmt": "0.53.0",
-        "oxlint": "1.67.0",
+        "@types/node": "22.19.20",
+        "envinfo": "7.21.0",
+        "npm-check-updates": "22.2.3",
+        "oxfmt": "0.54.0",
+        "oxlint": "1.69.0",
         "typescript": "6.0.3"
       },
       "engines": {
@@ -28,9 +28,9 @@
       }
     },
     "node_modules/@oxfmt/binding-android-arm-eabi": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.53.0.tgz",
-      "integrity": "sha512-XfVM8AmIovBTKXCt14Op5wbfcoM8418nttd+nhMgM3RAVaJg1MtJc73FyWfUt0oxLyBGVwfniNVUsbV/b3VmPg==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.54.0.tgz",
+      "integrity": "sha512-NAtpl/SiaeU103e7/OmZw0MvUnsUUopW7hEm/ecegJg7YM0skQaA0IXEZoyTV6NUdiNPupdIUreRqUZTShbn/g==",
       "cpu": [
         "arm"
       ],
@@ -45,9 +45,9 @@
       }
     },
     "node_modules/@oxfmt/binding-android-arm64": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.53.0.tgz",
-      "integrity": "sha512-btHDfXckwdf9zgyAVznfZkf+GVyB0I1m1hlvaOMRx2xoyz3hphfPX97s89J3wfCN8QBETLtk4lQUaeOkrMuQOg==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.54.0.tgz",
+      "integrity": "sha512-B4VZfBUlKK1rmMChsssNZbkZjE8+FzG3avMjGgMDwbGxXRoXkoeXiAZ+78Oa+eyDPHvDCiUb4zH/vmCOUSafLQ==",
       "cpu": [
         "arm64"
       ],
@@ -62,9 +62,9 @@
       }
     },
     "node_modules/@oxfmt/binding-darwin-arm64": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.53.0.tgz",
-      "integrity": "sha512-k2RjMcSTkHjoOlsVGbL35JVzXL+oQco3GHPl/5kjebVF4oHNfE24In8F5isqBh9LBJucycWHKDXdGrCchdWcHQ==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.54.0.tgz",
+      "integrity": "sha512-i02vF75b+ePsQP3tHqSxVYI5S6b8X/xqdPu7/mDHXtpgXLTYXi3jJmfHU0j+dnZZDKaYTx/ioCK7QYJmtiJR2g==",
       "cpu": [
         "arm64"
       ],
@@ -79,9 +79,9 @@
       }
     },
     "node_modules/@oxfmt/binding-darwin-x64": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.53.0.tgz",
-      "integrity": "sha512-65jIBE2H1l5SSs16fmv6/7b6sAx/WpvnsgDhVWK9qSjNFDUro7MPQ6q5UhpY7kl46yltfR046iAnxy/Bzqbiew==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.54.0.tgz",
+      "integrity": "sha512-8VMFvGvooXj7mswkbrhdVZ2/sgiDaBzWpkkbtO+qGDLV4EfJd67nQadHkQC0ZNbaWA9ajXfqI6i7PZLIeDzxEQ==",
       "cpu": [
         "x64"
       ],
@@ -96,9 +96,9 @@
       }
     },
     "node_modules/@oxfmt/binding-freebsd-x64": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.53.0.tgz",
-      "integrity": "sha512-oYe1gkz7U49PCYrS9147d2fJZj8mDI4Di6AvlsU5fu9p+Tq8S7qqOMSZjUiVTLX8bXuSA9Lk/tIxuegVjkNYRA==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.54.0.tgz",
+      "integrity": "sha512-0cRHnp43WN1Jrc5s0BdbdKgR1XirdvHy7TAFi3JEsoEVQVJxTXMbpVd76sxXlgRswNMDhVFSJw+y7Eb8mEavFQ==",
       "cpu": [
         "x64"
       ],
@@ -113,9 +113,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm-gnueabihf": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.53.0.tgz",
-      "integrity": "sha512-ailB2vLzGi629tymdAb2VYJyEHref7oqGxP+tRBrtRBxQrb6NV55JMT7xtGZ8uTeG2+Y9zojqW4LhJYxQnz9Pg==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.54.0.tgz",
+      "integrity": "sha512-JyQAk3hK/OEtup7Rw6kZwfdzbKqTVD5jXXb8Xpfay29suwZyfBDMVW/bj4RqEPySYWc6zCp198pOluf8n5uYzg==",
       "cpu": [
         "arm"
       ],
@@ -130,9 +130,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm-musleabihf": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.53.0.tgz",
-      "integrity": "sha512-abh4mWBvOvD966sobqF7r103y2yYx7Rb4WGHLOS4+5igGqLbbPxS9aK5+45D6iUY7dWMsk3Muz9a8gUtufvqJA==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.54.0.tgz",
+      "integrity": "sha512-qnvLatTpM8vtvjOfcckBOzJjk+n6ce/wwpP8OFeUrD5aNLYcKyWAitwj+Rk3PK9jGanbZvKsJnv14JGQ6XqFdw==",
       "cpu": [
         "arm"
       ],
@@ -147,16 +147,13 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm64-gnu": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.53.0.tgz",
-      "integrity": "sha512-z73PvuhJ8qA+cDbaiqbtopHglA91U4+y5wn2sTJJrnpB957d5P33FEuyP3DQIFd7ofljmDmfVT4G0CVGHZaJWg==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.54.0.tgz",
+      "integrity": "sha512-SMkhnCzIYZYDk9vw3W/80eeYKmrMpGF0Giuxt4HruFlCH7jEtnPeb3SdQKMfgYi/dgtaf+hZAb5XWPYnxqCQ3w==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -167,16 +164,13 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm64-musl": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.53.0.tgz",
-      "integrity": "sha512-I6bhOTroqc3ThrwZ89l2k3ivKuELhdPLbAcJhRNyjWvlgwb0vjRgEnVL1XLx5Jud04/ypNRZBykAWrSk6l/D+g==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.54.0.tgz",
+      "integrity": "sha512-QrwJlBFFKnxOd95TAaszpMbZBLzMoYMpGaQTZF8oibacnF5rv8l12IhILhQRPmksWiBqg0YSe2Mnl7ayeJAHSA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -187,16 +181,13 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-ppc64-gnu": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.53.0.tgz",
-      "integrity": "sha512-w0p3JzB/PkkQjXALMJMqP9YfP3yq4w6zGsu5kezQmUnxRkN3b/Theg2l/nDgBsOcczxS3gL6Gam5XNAVrO6QJQ==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.54.0.tgz",
+      "integrity": "sha512-WILatiol/TUHTlhod7R09+7Az/XlhKwmY1MHfLZNmewltPWNN/EwxP2rQSHahibZ/cB8gmckEBjBOByD+5bYsQ==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -207,16 +198,13 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-riscv64-gnu": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.53.0.tgz",
-      "integrity": "sha512-mzBhF6k1Yq1K/dqDmVe/AAafnlJfEpx7yfUiksyeWXJk5iSzZqBSxcsa02zIytYgQFRZ7h6WPZfwHg/DoOE1Kw==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.54.0.tgz",
+      "integrity": "sha512-f05YMG4BH4G8S4ME6UM6fi1MnJ9094mrnvO5Pa4SJlMfWlUM+1/ZWMEF4NnjM7shZAvbHsHRuVYpUo0PHC4P9Q==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -227,16 +215,13 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-riscv64-musl": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.53.0.tgz",
-      "integrity": "sha512-AlFCpnRQhogQFzZXWbO6xB6/Udy745L+eQNmDPGg7G/OeWsYmJc4jZYfUN5pQg0reOPWSED2mOQqKZOJM1U8cA==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.54.0.tgz",
+      "integrity": "sha512-UfL+2hj1ClNqcCRT9s8vBU4axDpjxgVxX96G+9DYAYjoc5b0u15CJtn2jgsi9iM+EbGNc5CW1HVRgwVu76UsSA==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -247,16 +232,13 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-s390x-gnu": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.53.0.tgz",
-      "integrity": "sha512-XD4ulY4f1DWbuuZXAqxhVn+gdPmrhnmojWtFN78ctVoupmS845fGhsUrk1HZXKQI+iymbaiz9vAjPsghHNQ7Ag==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.54.0.tgz",
+      "integrity": "sha512-3/XZe931Hka+J6NjnaqJzYpsWWxDTuRdUdwSQHnOuJEgbC+SehIMFJS8hsEjV7LBhVSL2OCnRLvbVW8O97XIyw==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -267,16 +249,13 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-x64-gnu": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.53.0.tgz",
-      "integrity": "sha512-xg8KWX0QnxmYWRe60CgHYWXI0ZOtBbqTsXvWiWrcl2XUHJ3fht2QerOk2iWvylzX3zNT2GpvBRxGoR4d3sxPRQ==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.54.0.tgz",
+      "integrity": "sha512-Ik93RlObtu43GbxApafayFjwYE06L6Xr08cSwpBPYbDrLp2ReZx0Jm1DqwRyYRnukUJy+rK2WaEvUQOxdytU9Q==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -287,16 +266,13 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-x64-musl": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.53.0.tgz",
-      "integrity": "sha512-MWExpYBGvl+pIvVB/gj/CcWlN2al8AizT7rUbtaYaWNoQkhWARM6W3qpgoCr72CYSN9PborzPmM5MIRe2BrNdA==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.54.0.tgz",
+      "integrity": "sha512-yZcakmPlD86CNymknd7KfW+FH+qfbqJH+i0h69CYfV1+KMoVeM9UED+8+TDVoU4haxI0NxY7RPCvRLy3Sqd2Qg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -307,9 +283,9 @@
       }
     },
     "node_modules/@oxfmt/binding-openharmony-arm64": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.53.0.tgz",
-      "integrity": "sha512-u4sajgO4nxgmJIgc/y2AqPhkdbOkQH8WugXpA1+pW0ESQhvGZ1oGq61Q4xMbJHJU1hFgtO18QNrcFYDPYH0gwQ==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.54.0.tgz",
+      "integrity": "sha512-GiVBZNnEZnKu00f1jTg49nomv187d0GQX+O+ocykoLeiaALuEO+swoTehHn9TehTfi7V8H0i0e/yvUjCqnwk1w==",
       "cpu": [
         "arm64"
       ],
@@ -324,9 +300,9 @@
       }
     },
     "node_modules/@oxfmt/binding-win32-arm64-msvc": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.53.0.tgz",
-      "integrity": "sha512-Yq9sOZoIOJ5xPjO0qOyHJS4CiPuTkB2en9auxZz7Ar2p5RaC7BzLyVVmAA7zz9/L9YnjjY1DwNxN+ivKXimN/A==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.54.0.tgz",
+      "integrity": "sha512-J0SSB8Z1Fre2sxRolYcW6Rl1RQmKdQ2hnHyq4YJrfBRiXTObLw4DXnIVraM/UyqGqwOi7yTrQA4VT7DPxlHVKA==",
       "cpu": [
         "arm64"
       ],
@@ -341,9 +317,9 @@
       }
     },
     "node_modules/@oxfmt/binding-win32-ia32-msvc": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.53.0.tgz",
-      "integrity": "sha512-es1fVNZEkBqEcQtBpn19SYFgZF7FawlkCjkT/iImfEAus4gun8fBwB1E9hpV5LcR9B0DBNvRIXhW8BQk3JaE+Q==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.54.0.tgz",
+      "integrity": "sha512-O61UDVj8zz6yXJjkHPf05VaMLOXmEF8P5kf/N0W7AQMmd6bcQogl+KJc7rMutKTL524oE9iH32JXZClBFmEQIg==",
       "cpu": [
         "ia32"
       ],
@@ -358,9 +334,9 @@
       }
     },
     "node_modules/@oxfmt/binding-win32-x64-msvc": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.53.0.tgz",
-      "integrity": "sha512-QFmJs2bEu9AO4O6qsmEaZNGi6dFq8N+rT8EHAAnZIq/B9SeJDUbc4DzVxQ48MfDsL7D3sCZzo37zuTuspcURgg==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.54.0.tgz",
+      "integrity": "sha512-1MDpqJPiFqxWtIHas8vkb1VZ7f7eKyTffAwmO8isxQYMaG1OFKsH666BWLeXQLO+IWNfiMssLD55hbR1lIPTqg==",
       "cpu": [
         "x64"
       ],
@@ -375,9 +351,9 @@
       }
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.67.0.tgz",
-      "integrity": "sha512-VrSi571rDv1N8HaEDM+DEX8nmT0y9jJo8tzzW13vsOWTx59xQczCIJx68n2zWOXRT5YKZsOZXp4qkHN/10x4mw==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.69.0.tgz",
+      "integrity": "sha512-DKQQbD5cZ/MYfDgDI7YGyGD9FSxABlsBsYFo5p26lloob543tP9+4N3guwdXIYJN+7HSZxLe8YJuwcOWw5qnHg==",
       "cpu": [
         "arm"
       ],
@@ -392,9 +368,9 @@
       }
     },
     "node_modules/@oxlint/binding-android-arm64": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.67.0.tgz",
-      "integrity": "sha512-l6+NdYxMoRohix5r5bbigW16LPicceCwGcQ6LKKuE1kUdjgFfQolJjrJsQYPFetIs78Gxj/G/f5TEGoTCwj9nQ==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.69.0.tgz",
+      "integrity": "sha512-lEhb+I5pr4inux+JFwfCa1HRq3Os7NirEFQ0H1I35SVEHPm6byX0Ah47xmRha3qi6LAkxUcxViL8o/9PivjzBg==",
       "cpu": [
         "arm64"
       ],
@@ -409,9 +385,9 @@
       }
     },
     "node_modules/@oxlint/binding-darwin-arm64": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.67.0.tgz",
-      "integrity": "sha512-jOzXxS1AxFxhImLIRbtGIMrEwaXcgMw3gR57WB1cRk8ai+vpr6726kxXqVvlNsrXtJ/FrmOm8RxlC0m8SW24Qg==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.69.0.tgz",
+      "integrity": "sha512-GY2YE8lOZW59BW1Ia1y+1gR0XyjrZRvVWHAr8LGeGhYHE0OQJ/7cRKXTkx1P+E9/6awEc3SX8a68SFTjh/E//A==",
       "cpu": [
         "arm64"
       ],
@@ -426,9 +402,9 @@
       }
     },
     "node_modules/@oxlint/binding-darwin-x64": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.67.0.tgz",
-      "integrity": "sha512-3DFAVY94OqjIZHXIPz37yGRSWwOFTAqChQ64/M69GYLawzP0KiwdhDNfqdKKYT0bTR/DNxmMnQsj3ns+8+X/Lg==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.69.0.tgz",
+      "integrity": "sha512-ax1oZnOjHX3LB7myQyHEaQkDwfLb6str3/nSP6O7EVUviQGNkEGzGV0EqcBJWK+Ufwx0l4xPgyYayurvhAdl2Q==",
       "cpu": [
         "x64"
       ],
@@ -443,9 +419,9 @@
       }
     },
     "node_modules/@oxlint/binding-freebsd-x64": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.67.0.tgz",
-      "integrity": "sha512-e4dDKZuLu8TR9DEBssWSDahlPgZBwojTTHZUvnjBRJfJJbpxYCjfjKfi0Z1+CSLMiJBwI2yCDtRM1XJQaARjmg==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.69.0.tgz",
+      "integrity": "sha512-kHWeHv4g2h8NY+mpCxzCtY4uerMJWTN/TSnNj1CPbakFpHEJ6cTya2wWV0pDSYWOJ2+0UiEbhn3AtXxHtsnKjg==",
       "cpu": [
         "x64"
       ],
@@ -460,9 +436,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.67.0.tgz",
-      "integrity": "sha512-BKytFdcQzbITV3xlnzDUDTEDtbUMCCiC4EaNTDZ4FyT8gdNvBC4gfiLucXp/sQl0XU3p7syTlorUWVVVBZab2g==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.69.0.tgz",
+      "integrity": "sha512-gq84vM1a1oEehXo27YCDzGVcxPsZDI1yswZwz2Da1/cbnWtrL16XZZnz0G/+gIU8edtHpfjxq5c+vWEHqJfWoQ==",
       "cpu": [
         "arm"
       ],
@@ -477,9 +453,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm-musleabihf": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.67.0.tgz",
-      "integrity": "sha512-XYAv0esBDX7BpTzRDjVX2Vdj+zndd8ll2dFQiaeQ6zTZr7A8GRDTN7fH3FP3jU+O0vCDx85oH/EtG7BzPgAXuw==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.69.0.tgz",
+      "integrity": "sha512-kIqEa98JQ0VRyrcncxA417m2AzasqTlD+FyVT1AksjvjkqQcvm7pBWYvoW3/mpyOP2XYvi5nSCCTIe6De1yu5g==",
       "cpu": [
         "arm"
       ],
@@ -494,16 +470,13 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm64-gnu": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.67.0.tgz",
-      "integrity": "sha512-zizRMjA0i6u/2B0evgda04iycu+MoNuf1pBy6Eh+1CjC5wMEG7qN5zdDKTCvFc0KSYSDM9QTG3gjZHirgtQuKg==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.69.0.tgz",
+      "integrity": "sha512-j+xYiXozxGWx2cpjCrwwGR4awTxPFsRv3JZrv23RCogEPMc4R7UqjHW47p/RG0aRlbWiROCJ8coUfCwy0dvzHA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -514,16 +487,13 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm64-musl": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.67.0.tgz",
-      "integrity": "sha512-zB/Tf6sUjmmvvbva9Gj3JTJ8rJ9t4I8/U0o6vSRtd0DRIsIuyegBwJAzhSUFQHdMijIRJkW0exs/yBhpw2S20w==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.69.0.tgz",
+      "integrity": "sha512-xEPpNppTfN1l/nM7gYSf9iocscu/as+p/7vxkLeLEKnYU+09Dm+5V6IhDYDh+Uz6FajEupWwCLt5SOG0y1PCKg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -534,16 +504,13 @@
       }
     },
     "node_modules/@oxlint/binding-linux-ppc64-gnu": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.67.0.tgz",
-      "integrity": "sha512-kgU40Gt74CK0TCsF51KZymkIwN9U0BajKsMijB52zPqOeZU9NAHkA/NSQkZDHEaCakx42DxhXkODiAqf2b4Gug==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.69.0.tgz",
+      "integrity": "sha512-Ug0+eU7HJBlek+SjklYH62IlOMirEJsdxpihH0kSqX0XdrDD4NdHpQc10fK1JC35yn6KrrcN+uYzlHD38XAf8Q==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -554,16 +521,13 @@
       }
     },
     "node_modules/@oxlint/binding-linux-riscv64-gnu": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.67.0.tgz",
-      "integrity": "sha512-tOYhkk/iaG9aD3FvGpBFd1Lrw0x0RaVoJBxjUkfNzS50rC5NS5BteNCwgr8A2zCdADrIIoze6D7u6U5Ic++/iQ==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.69.0.tgz",
+      "integrity": "sha512-iEyI3GIg0l/s3G4qy2TlaaWKdzj4PJJStwtlocpDTC00PY9hZueotf6OKUj9+yfQh0lrpBW/pLMgTztbAHKJEg==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -574,16 +538,13 @@
       }
     },
     "node_modules/@oxlint/binding-linux-riscv64-musl": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.67.0.tgz",
-      "integrity": "sha512-sEtywrPb+0b+tHYl1SDCrw903fiC4eyKoNqzP3v+f2JT3Xcv4NEYG+P8rj+eEnX7IWhqV/xj8/JmcmVj21CXaA==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.69.0.tgz",
+      "integrity": "sha512-NjHjpiI4WIKSMwuoJSZi5VToPeoYOS1FR52HLIDG6lidMdqquusgtODb4iLk0+lb1q3Z0nv2/aPRcC/olmpQGg==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -594,16 +555,13 @@
       }
     },
     "node_modules/@oxlint/binding-linux-s390x-gnu": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.67.0.tgz",
-      "integrity": "sha512-BvR8Moa0zCLxroOx4vZaZN9nUfwAUpSTwjZdxZyKy4bv3PrzrXrxKR/ZQ0L9wNSvlPhnMJeZfa3q5w6ZCTuN6Q==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.69.0.tgz",
+      "integrity": "sha512-Ai/prDewoItkDXbp38gwGZi41DycZbUTZJ3UidwoHgQC0/DaqC2TGdtBTQLJ6hSD+SAxASzh8+/eSBPmxfOacA==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -614,16 +572,13 @@
       }
     },
     "node_modules/@oxlint/binding-linux-x64-gnu": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.67.0.tgz",
-      "integrity": "sha512-mm2cxM6fksOpq6l0uFws8BUGKAR4dNa/cZCn37Npq7PFbhD5HDJqWfnoIvTaeRKMy5XdS2tO0MA0qbHDrnXAAA==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.69.0.tgz",
+      "integrity": "sha512-Gt3KHgp46mRKz4sJeaASmKvD8ayXookRw07RMf+NowhEztGGDZ7VrXpoW96XuKJLjFukWizOFVNjmYb/u7caNQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -634,16 +589,13 @@
       }
     },
     "node_modules/@oxlint/binding-linux-x64-musl": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.67.0.tgz",
-      "integrity": "sha512-WmbMuLapKyDlobMkXAaAL0Y+Uczh4LETfIfQsUpbId4Ip8Ai82/jqeYTOoUCkuuhBFapgqP253+d83tLKOksJg==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.69.0.tgz",
+      "integrity": "sha512-7tQhJ2+p/oHv1zcfnjYI7YVzC/7iBaVOfIvFYtxdJ5F45mWgEdrCyXZXZGfiLey5t/5JhOhsaMnnv1kAzckd7g==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -654,9 +606,9 @@
       }
     },
     "node_modules/@oxlint/binding-openharmony-arm64": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.67.0.tgz",
-      "integrity": "sha512-9g/PqxYJelzzTAOR5Y+RiRqdeydhEuXv2KxNeFcAKQ7UsvnWSY1OP4MsuPMbTO2Pf70tz7mFhl1j13H3fyh+8g==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.69.0.tgz",
+      "integrity": "sha512-vmWz6TKp/3hfA4lksR0zHBv/6xuX1jhym6eqOjdH2DXsDDHZWcp2f0KG0VCAnlVbIrjk29G4wAWMXb/Hn1YobA==",
       "cpu": [
         "arm64"
       ],
@@ -671,9 +623,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-arm64-msvc": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.67.0.tgz",
-      "integrity": "sha512-2VhwE6Gatb0vJGnN0TBuQMbKCOiZlSQ/zJvVWYLK4a9d4iDiJOen/yVQkGpmsJ90MuH66fzi0kEKI0jRQMDxGA==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.69.0.tgz",
+      "integrity": "sha512-9RExaLgmaw6IoIkU9cTpT71mLfI0xZ86iZH8x518LVsOkjquJMYqb9P7KpC8lgd1t0Dxs41p2pxynq4XR3Ttzw==",
       "cpu": [
         "arm64"
       ],
@@ -688,9 +640,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-ia32-msvc": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.67.0.tgz",
-      "integrity": "sha512-EQ3VExXfeM1InbE5+JjufhZZTWy+kHUwgt3yZR7gQ47Je/mE0WspQPan0OJznh493L5anM210YNJtH1PXjTSFg==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.69.0.tgz",
+      "integrity": "sha512-1907kRPF8/PrcIw1E7LMs9JbVrpgnt/MvFdss3an8oDkYNAACXzTntV3t3869ZZhMZxb2AzRGbz1pA/jdFatXA==",
       "cpu": [
         "ia32"
       ],
@@ -705,9 +657,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-x64-msvc": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.67.0.tgz",
-      "integrity": "sha512-bw24y+/1MHS4QDkons3YyHkPT9uCMoLHHgQhb+mb8NOjTYwub1CZ+K9Ngr8aO5DMrDrkqHwTzlTwFP2vS8Y/ZQ==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.69.0.tgz",
+      "integrity": "sha512-w8SOXv3mT9Fi6jY8OXdXCfnvX/3KNLXGNr4HEz2TA7S4Mv/PYAOmpB8y/ge40mxvBMgGNaSaaDwZpAsQn7HtWA==",
       "cpu": [
         "x64"
       ],
@@ -1050,9 +1002,9 @@
       }
     },
     "node_modules/@smarlhens/npm-check-engines-darwin-arm64": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@smarlhens/npm-check-engines-darwin-arm64/-/npm-check-engines-darwin-arm64-1.2.0.tgz",
-      "integrity": "sha512-VStXNwwM/PQRQIl0uGMDre6blOwWblXLf9PogokNY33XHfq2v3GlYTB4kWiQ4pRlLyiY0wSqnik/atAkxM20lw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@smarlhens/npm-check-engines-darwin-arm64/-/npm-check-engines-darwin-arm64-1.2.2.tgz",
+      "integrity": "sha512-kX0FDQSeUW1AitY+is/e7IycgEFkyxzc/JYx2jeK88vNJyYAmnSeOvSs5D/+eiSZtiNM8Xt0/l7uzbXqtDbPzg==",
       "cpu": [
         "arm64"
       ],
@@ -1062,14 +1014,14 @@
         "darwin"
       ],
       "engines": {
-        "node": "^22.13.0 || ^24.0.0 || ^25.0.0 || >=26.0.0",
-        "npm": ">=10.9.2"
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0",
+        "npm": ">=10.9.7"
       }
     },
     "node_modules/@smarlhens/npm-check-engines-darwin-x64": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@smarlhens/npm-check-engines-darwin-x64/-/npm-check-engines-darwin-x64-1.2.0.tgz",
-      "integrity": "sha512-UF2yCPiZVpX5O1MqFtYT5j9+t2d//rIbiCyrtvmpECM9bLV+6Kk+vcIru5i3U5uwUE0uf44KdNVDl8KxlGW0tA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@smarlhens/npm-check-engines-darwin-x64/-/npm-check-engines-darwin-x64-1.2.2.tgz",
+      "integrity": "sha512-aY4YQiSZYbiPsKX8k92djpa6Z8QUzRqt+qn0I+cOey+gCSb6XarxO9AEt3boyHD/RuxN65JsbYoIb91zkH3X6Q==",
       "cpu": [
         "x64"
       ],
@@ -1079,19 +1031,16 @@
         "darwin"
       ],
       "engines": {
-        "node": "^22.13.0 || ^24.0.0 || ^25.0.0 || >=26.0.0",
-        "npm": ">=10.9.2"
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0",
+        "npm": ">=10.9.7"
       }
     },
     "node_modules/@smarlhens/npm-check-engines-linux-arm64-gnu": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@smarlhens/npm-check-engines-linux-arm64-gnu/-/npm-check-engines-linux-arm64-gnu-1.2.0.tgz",
-      "integrity": "sha512-PomtlcR71ThCn9Kgsw2m1sadkFQ8c+wXIiwwwpnJWrSdWlP88E//h7Z0JbC4vpTw9Efp1nVbQ0BnosIBwieOEg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@smarlhens/npm-check-engines-linux-arm64-gnu/-/npm-check-engines-linux-arm64-gnu-1.2.2.tgz",
+      "integrity": "sha512-TsWshCXPW15C3f3pHdqafxBs0oFrLVFtMOylgyW+VVnducJvm7hf/RV/nqckTKOs61UHzHbchex9lt+GkRay9A==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "BlueOak-1.0.0",
       "optional": true,
@@ -1099,39 +1048,33 @@
         "linux"
       ],
       "engines": {
-        "node": "^22.13.0 || ^24.0.0 || ^25.0.0 || >=26.0.0",
-        "npm": ">=10.9.2"
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0",
+        "npm": ">=10.9.7"
       }
     },
     "node_modules/@smarlhens/npm-check-engines-linux-arm64-musl": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@smarlhens/npm-check-engines-linux-arm64-musl/-/npm-check-engines-linux-arm64-musl-1.2.0.tgz",
-      "integrity": "sha512-l4QoUpXw1mUwhS/1FY4tb/jT/EhORQsRd9s8Zsw9OuJLOkLSWsNgUXaIVmYNd5K8od7VsUNWfGNCZg6Lq/bZ6w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@smarlhens/npm-check-engines-linux-arm64-musl/-/npm-check-engines-linux-arm64-musl-1.2.2.tgz",
+      "integrity": "sha512-GarzoJwTnkcLkHnx6hsuM5+2YmAvKKFf5yJX2ftF2NPeWvaXAse5FSaAHD0UO2sZPwpa++RF5yl0wviagdkvXw==",
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "BlueOak-1.0.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^22.13.0 || ^24.0.0 || ^25.0.0 || >=26.0.0",
-        "npm": ">=10.9.2"
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0",
+        "npm": ">=10.9.7"
       }
     },
     "node_modules/@smarlhens/npm-check-engines-linux-x64-gnu": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@smarlhens/npm-check-engines-linux-x64-gnu/-/npm-check-engines-linux-x64-gnu-1.2.0.tgz",
-      "integrity": "sha512-PjH60Mh/eDYzFsazKFdO+mArZxbUKvEgmpDIeFm1nuiAqoGtRq+MPl0Ous6dMjVJqjIoKGgUD7Edb7/hvCB+HA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@smarlhens/npm-check-engines-linux-x64-gnu/-/npm-check-engines-linux-x64-gnu-1.2.2.tgz",
+      "integrity": "sha512-QuYK6Iw+xmHdG+RpHkrkrGjRgrWlJP8zdJiisuaSyt7BjLMD1jDU0u/kccCCELZL/HaXGiaS82OENfgl0z+5mw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "BlueOak-1.0.0",
       "optional": true,
@@ -1139,19 +1082,16 @@
         "linux"
       ],
       "engines": {
-        "node": "^22.13.0 || ^24.0.0 || ^25.0.0 || >=26.0.0",
-        "npm": ">=10.9.2"
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0",
+        "npm": ">=10.9.7"
       }
     },
     "node_modules/@smarlhens/npm-check-engines-linux-x64-musl": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@smarlhens/npm-check-engines-linux-x64-musl/-/npm-check-engines-linux-x64-musl-1.2.0.tgz",
-      "integrity": "sha512-PGrFEHq32Pg655LikUWd60tbtf0YCD+QlMm2b8sBUtXzKDxYbmKLWUtEmxVSaQsiYd/RFeFYEeDq2xKbgKHncQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@smarlhens/npm-check-engines-linux-x64-musl/-/npm-check-engines-linux-x64-musl-1.2.2.tgz",
+      "integrity": "sha512-Ev6XD4x8Uahs7IRjvDFFuNWYQthes7JjuG+m0yJtBNCr8JF4e9/AnQPVsWXhxAd4n/Nr2JNS8nSDELpNtfsK+Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "BlueOak-1.0.0",
       "optional": true,
@@ -1159,8 +1099,8 @@
         "linux"
       ],
       "engines": {
-        "node": "^22.13.0 || ^24.0.0 || ^25.0.0 || >=26.0.0",
-        "npm": ">=10.9.2"
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0",
+        "npm": ">=10.9.7"
       }
     },
     "node_modules/@smarlhens/npm-check-engines-v0": {
@@ -1193,32 +1133,32 @@
     },
     "node_modules/@smarlhens/npm-check-engines-v1": {
       "name": "@smarlhens/npm-check-engines",
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@smarlhens/npm-check-engines/-/npm-check-engines-1.2.0.tgz",
-      "integrity": "sha512-F72jeJHz4W6FHn0L1p7e1dB0SHJ5mlSUzNPtrt80l4XeixmykUrowms1i0hs5zg4Zq2KxW/BfFpahqWgKQoqQw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@smarlhens/npm-check-engines/-/npm-check-engines-1.2.2.tgz",
+      "integrity": "sha512-W7e67bnXzvc2EDuR64C3GDupAta3WTmks7cH8M7MWbp3m10zJfGDn+cFrdRzO6creSmC6Tf6T6MYdNFzhr8jwQ==",
       "license": "BlueOak-1.0.0",
       "bin": {
         "nce": "bin/nce.js",
         "npm-check-engines": "bin/nce.js"
       },
       "engines": {
-        "node": "^22.13.0 || ^24.0.0 || ^25.0.0 || >=26.0.0",
-        "npm": ">=10.9.2"
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0",
+        "npm": ">=10.9.7"
       },
       "optionalDependencies": {
-        "@smarlhens/npm-check-engines-darwin-arm64": "1.2.0",
-        "@smarlhens/npm-check-engines-darwin-x64": "1.2.0",
-        "@smarlhens/npm-check-engines-linux-arm64-gnu": "1.2.0",
-        "@smarlhens/npm-check-engines-linux-arm64-musl": "1.2.0",
-        "@smarlhens/npm-check-engines-linux-x64-gnu": "1.2.0",
-        "@smarlhens/npm-check-engines-linux-x64-musl": "1.2.0",
-        "@smarlhens/npm-check-engines-win32-x64-msvc": "1.2.0"
+        "@smarlhens/npm-check-engines-darwin-arm64": "1.2.2",
+        "@smarlhens/npm-check-engines-darwin-x64": "1.2.2",
+        "@smarlhens/npm-check-engines-linux-arm64-gnu": "1.2.2",
+        "@smarlhens/npm-check-engines-linux-arm64-musl": "1.2.2",
+        "@smarlhens/npm-check-engines-linux-x64-gnu": "1.2.2",
+        "@smarlhens/npm-check-engines-linux-x64-musl": "1.2.2",
+        "@smarlhens/npm-check-engines-win32-x64-msvc": "1.2.2"
       }
     },
     "node_modules/@smarlhens/npm-check-engines-win32-x64-msvc": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@smarlhens/npm-check-engines-win32-x64-msvc/-/npm-check-engines-win32-x64-msvc-1.2.0.tgz",
-      "integrity": "sha512-DR5cEPakmi9azVhFbg3FF+iesuoN5kDa18VORuTdEBaGsKlljSSh7cQ+gxnxXylbupsLNQlMLbXEojwOHoWuxQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@smarlhens/npm-check-engines-win32-x64-msvc/-/npm-check-engines-win32-x64-msvc-1.2.2.tgz",
+      "integrity": "sha512-nYv4j7oq9XT4hmLI5kEkEdS8N8whE3VqtaEZrSbiMfFklwJ3I2DlVkM7OjXUa6CdcTNbkDb1YJ5b8fIncRejGg==",
       "cpu": [
         "x64"
       ],
@@ -1228,8 +1168,8 @@
         "win32"
       ],
       "engines": {
-        "node": "^22.13.0 || ^24.0.0 || ^25.0.0 || >=26.0.0",
-        "npm": ">=10.9.2"
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0",
+        "npm": ">=10.9.7"
       }
     },
     "node_modules/@smarlhens/npm-pin-dependencies-darwin-arm64": {
@@ -1273,9 +1213,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "BlueOak-1.0.0",
       "optional": true,
       "os": [
@@ -1292,9 +1229,6 @@
       "integrity": "sha512-SvPhk38HnnXJYyJ4M9kg11SFFzeeIZJybWTRV+itn3Ed0D3rDeb6Z3zc+AjLJ40aHocb7gkoUu6fAOWHo7MzrQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "BlueOak-1.0.0",
       "optional": true,
@@ -1313,9 +1247,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "BlueOak-1.0.0",
       "optional": true,
       "os": [
@@ -1332,9 +1263,6 @@
       "integrity": "sha512-1EKtmgaLJoYy074XiJIAPvVXHH/IWJgzAsk9rKdRknpxbt4KAiepSghvukuoe3a7miuesiYxmcgDJbkLbnYkbw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "BlueOak-1.0.0",
       "optional": true,
@@ -1418,13 +1346,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.12.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
-      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@yarnpkg/lockfile": {
@@ -1923,9 +1851,9 @@
       }
     },
     "node_modules/envinfo": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.14.0.tgz",
-      "integrity": "sha512-CO40UI41xDQzhLB1hWyqUKgFhs250pNcGbyGKe1l/e4FSaI/+YE4IMG76GDt0In67WLPACIITC+sOi08x4wIvg==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.21.0.tgz",
+      "integrity": "sha512-Lw7I8Zp5YKHFCXL7+Dz95g4CcbMEpgvqZNNq3AmlT5XAV6CgAAk6gyAMqn2zjw08K9BHfcNuKrMiCPLByGafow==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2467,9 +2395,9 @@
       }
     },
     "node_modules/npm-check-updates": {
-      "version": "22.2.1",
-      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-22.2.1.tgz",
-      "integrity": "sha512-mGdIJfhtg+q0BzhbOpbOL73zhMZlgBQMG4wnBwPMMD5k96028UCuV0753YeSYk9odoh7HWK6/cY69bWxT7o+yg==",
+      "version": "22.2.3",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-22.2.3.tgz",
+      "integrity": "sha512-n8HZ0ywZugYRgEqIm67hbZC5L/9S/gLX+MkGchJB43pP2xib1+u76OpVEJRZ4QP2BksPRi5M1CCStJVfc16+/A==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2519,9 +2447,9 @@
       }
     },
     "node_modules/oxfmt": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.53.0.tgz",
-      "integrity": "sha512-9cB5glS3Ip6NMuZ+6NYTao9FCWkDhRtPYCtR3QBu/NxHoFbgzzTvi41N4jxz/GqGfuLKspui1qb/LlSu2IbMcw==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.54.0.tgz",
+      "integrity": "sha512-DjnMwn7smSLF+Mc2+pRItnuPftm/dkUFpY/d4+33y9TfKrsHZo8GLhmUg9BrOIUEy94Rlom1Q11N6vuhE+e0oQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2537,25 +2465,25 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxfmt/binding-android-arm-eabi": "0.53.0",
-        "@oxfmt/binding-android-arm64": "0.53.0",
-        "@oxfmt/binding-darwin-arm64": "0.53.0",
-        "@oxfmt/binding-darwin-x64": "0.53.0",
-        "@oxfmt/binding-freebsd-x64": "0.53.0",
-        "@oxfmt/binding-linux-arm-gnueabihf": "0.53.0",
-        "@oxfmt/binding-linux-arm-musleabihf": "0.53.0",
-        "@oxfmt/binding-linux-arm64-gnu": "0.53.0",
-        "@oxfmt/binding-linux-arm64-musl": "0.53.0",
-        "@oxfmt/binding-linux-ppc64-gnu": "0.53.0",
-        "@oxfmt/binding-linux-riscv64-gnu": "0.53.0",
-        "@oxfmt/binding-linux-riscv64-musl": "0.53.0",
-        "@oxfmt/binding-linux-s390x-gnu": "0.53.0",
-        "@oxfmt/binding-linux-x64-gnu": "0.53.0",
-        "@oxfmt/binding-linux-x64-musl": "0.53.0",
-        "@oxfmt/binding-openharmony-arm64": "0.53.0",
-        "@oxfmt/binding-win32-arm64-msvc": "0.53.0",
-        "@oxfmt/binding-win32-ia32-msvc": "0.53.0",
-        "@oxfmt/binding-win32-x64-msvc": "0.53.0"
+        "@oxfmt/binding-android-arm-eabi": "0.54.0",
+        "@oxfmt/binding-android-arm64": "0.54.0",
+        "@oxfmt/binding-darwin-arm64": "0.54.0",
+        "@oxfmt/binding-darwin-x64": "0.54.0",
+        "@oxfmt/binding-freebsd-x64": "0.54.0",
+        "@oxfmt/binding-linux-arm-gnueabihf": "0.54.0",
+        "@oxfmt/binding-linux-arm-musleabihf": "0.54.0",
+        "@oxfmt/binding-linux-arm64-gnu": "0.54.0",
+        "@oxfmt/binding-linux-arm64-musl": "0.54.0",
+        "@oxfmt/binding-linux-ppc64-gnu": "0.54.0",
+        "@oxfmt/binding-linux-riscv64-gnu": "0.54.0",
+        "@oxfmt/binding-linux-riscv64-musl": "0.54.0",
+        "@oxfmt/binding-linux-s390x-gnu": "0.54.0",
+        "@oxfmt/binding-linux-x64-gnu": "0.54.0",
+        "@oxfmt/binding-linux-x64-musl": "0.54.0",
+        "@oxfmt/binding-openharmony-arm64": "0.54.0",
+        "@oxfmt/binding-win32-arm64-msvc": "0.54.0",
+        "@oxfmt/binding-win32-ia32-msvc": "0.54.0",
+        "@oxfmt/binding-win32-x64-msvc": "0.54.0"
       },
       "peerDependencies": {
         "svelte": "^5.0.0",
@@ -2571,9 +2499,9 @@
       }
     },
     "node_modules/oxlint": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.67.0.tgz",
-      "integrity": "sha512-blwwaHPdoH8piQ5/z0KHeoHFR7FZgl12WluKJfu4qFLPkZl6mK04PkLE45Fw1NxfBRSlh40Gu7MkxHUw++ociQ==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.69.0.tgz",
+      "integrity": "sha512-ypZkK/aDc5NQV8zIR6s2H2Tl3aNW8FmJ1m9+2qsaYuRenl8vgnHNCGwTHviWJdUQzglOlHFchgopdtGhSy17Rw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2586,25 +2514,25 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxlint/binding-android-arm-eabi": "1.67.0",
-        "@oxlint/binding-android-arm64": "1.67.0",
-        "@oxlint/binding-darwin-arm64": "1.67.0",
-        "@oxlint/binding-darwin-x64": "1.67.0",
-        "@oxlint/binding-freebsd-x64": "1.67.0",
-        "@oxlint/binding-linux-arm-gnueabihf": "1.67.0",
-        "@oxlint/binding-linux-arm-musleabihf": "1.67.0",
-        "@oxlint/binding-linux-arm64-gnu": "1.67.0",
-        "@oxlint/binding-linux-arm64-musl": "1.67.0",
-        "@oxlint/binding-linux-ppc64-gnu": "1.67.0",
-        "@oxlint/binding-linux-riscv64-gnu": "1.67.0",
-        "@oxlint/binding-linux-riscv64-musl": "1.67.0",
-        "@oxlint/binding-linux-s390x-gnu": "1.67.0",
-        "@oxlint/binding-linux-x64-gnu": "1.67.0",
-        "@oxlint/binding-linux-x64-musl": "1.67.0",
-        "@oxlint/binding-openharmony-arm64": "1.67.0",
-        "@oxlint/binding-win32-arm64-msvc": "1.67.0",
-        "@oxlint/binding-win32-ia32-msvc": "1.67.0",
-        "@oxlint/binding-win32-x64-msvc": "1.67.0"
+        "@oxlint/binding-android-arm-eabi": "1.69.0",
+        "@oxlint/binding-android-arm64": "1.69.0",
+        "@oxlint/binding-darwin-arm64": "1.69.0",
+        "@oxlint/binding-darwin-x64": "1.69.0",
+        "@oxlint/binding-freebsd-x64": "1.69.0",
+        "@oxlint/binding-linux-arm-gnueabihf": "1.69.0",
+        "@oxlint/binding-linux-arm-musleabihf": "1.69.0",
+        "@oxlint/binding-linux-arm64-gnu": "1.69.0",
+        "@oxlint/binding-linux-arm64-musl": "1.69.0",
+        "@oxlint/binding-linux-ppc64-gnu": "1.69.0",
+        "@oxlint/binding-linux-riscv64-gnu": "1.69.0",
+        "@oxlint/binding-linux-riscv64-musl": "1.69.0",
+        "@oxlint/binding-linux-s390x-gnu": "1.69.0",
+        "@oxlint/binding-linux-x64-gnu": "1.69.0",
+        "@oxlint/binding-linux-x64-musl": "1.69.0",
+        "@oxlint/binding-openharmony-arm64": "1.69.0",
+        "@oxlint/binding-win32-arm64-msvc": "1.69.0",
+        "@oxlint/binding-win32-ia32-msvc": "1.69.0",
+        "@oxlint/binding-win32-x64-msvc": "1.69.0"
       },
       "peerDependencies": {
         "oxlint-tsgolint": ">=0.22.1",
@@ -3077,9 +3005,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/bench-js/package.json
+++ b/bench-js/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@smarlhens/npm-check-engines-v0": "npm:@smarlhens/npm-check-engines@0.14.4",
-    "@smarlhens/npm-check-engines-v1": "npm:@smarlhens/npm-check-engines@1.2.0",
+    "@smarlhens/npm-check-engines-v1": "npm:@smarlhens/npm-check-engines@1.2.2",
     "@smarlhens/npm-pin-dependencies-v0": "npm:@smarlhens/npm-pin-dependencies@0.11.1",
     "@smarlhens/npm-pin-dependencies-v1": "npm:@smarlhens/npm-pin-dependencies@1.0.1",
     "markdown-table": "3.0.4",
@@ -31,11 +31,11 @@
     "tinybench": "6.0.2"
   },
   "devDependencies": {
-    "@types/node": "24.12.4",
-    "envinfo": "7.14.0",
-    "npm-check-updates": "22.2.1",
-    "oxfmt": "0.53.0",
-    "oxlint": "1.67.0",
+    "@types/node": "22.19.20",
+    "envinfo": "7.21.0",
+    "npm-check-updates": "22.2.3",
+    "oxfmt": "0.54.0",
+    "oxlint": "1.69.0",
     "typescript": "6.0.3"
   },
   "engines": {


### PR DESCRIPTION
## Dependency bumps

### cargo
- `chrono` 0.4.44 → 0.4.45 (only outdated workspace dep; Cargo.lock synced)

### npm — bench-js
- `envinfo` 7.14.0 → 7.21.0
- `npm-check-updates` 22.2.1 → 22.2.3
- `oxfmt` 0.53.0 → 0.54.0
- `oxlint` 1.67.0 → 1.69.0
- `@types/node` 24.12.4 → 22.19.20 (pinned to the `.nvmrc` major, 22.x)
- benchmark baseline `nce-v1` 1.2.0 → 1.2.2
- lockfile regenerated against public npmjs

`@napi-rs/cli` (napi-nce / napi-npd) already at latest 3.7.0.

### npm — .github/actions/bench-compare
- `npm-check-updates` 22.2.1 → 22.2.3
- `oxfmt` 0.52.0 → 0.54.0
- `oxlint` 1.67.0 → 1.69.0
- `rolldown` 1.0.3 → 1.1.0
- `@types/node` 24.12.4 → 22.19.20 (pinned to the `.nvmrc` major, 22.x)
- lockfile regenerated against public npmjs

### pre-commit hooks
- `mirrors-oxfmt` v0.52.0 → v0.54.0
- `mirrors-oxlint` v1.67.0 → v1.69.0

## Verification
- `cargo check --workspace` ✓ (156 crates), `cargo clippy --workspace --all-targets -- -D warnings` ✓
- bench-js `tsc --noEmit` ✓ + 12/12 tests ✓
- bench-compare `tsc --noEmit` ✓ + `rolldown` bundle ✓
- `prek run --all-files` ✓ all hooks