### PR TITLE
ci: gate dist-trigger to dist-able package tags

### DIFF
--- a/.github/workflows/dist-trigger.yml
+++ b/.github/workflows/dist-trigger.yml
@@ -1,6 +1,10 @@
 # Bridge between release-please and cargo-dist.
 # When release-please publishes a GitHub Release, dispatch the dist workflow
 # to build and attach prebuilt CLI binaries.
+#
+# release-please tags every workspace package, but only riri-nce and riri-npd
+# are dist-able (see packages in the root Cargo.toml). Dispatching dist for any
+# other tag fails 'dist plan', so the trigger is gated to those two prefixes.
 
 name: dist-trigger
 
@@ -15,6 +19,7 @@ permissions:
 jobs:
   trigger:
     runs-on: ubuntu-24.04
+    if: startsWith(github.event.release.tag_name, 'riri-nce-v') || startsWith(github.event.release.tag_name, 'riri-npd-v')
     steps:
       - name: Dispatch dist workflow
         uses: benc-uk/workflow-dispatch@v1


### PR DESCRIPTION
## Problem

The `dist` job fails for every release-please tag except `riri-nce-*` and `riri-npd-*`.

`release-please` manages 14 workspace packages with `include-component-in-tag: true`, so each release publishes its own tag + GitHub Release. `dist-trigger.yml` fired on **every** `release: published` and dispatched `dist plan --tag=<tag>`. Only `riri-nce` and `riri-npd` are dist-able (`packages` in the root `Cargo.toml`) and carry `repository.workspace = true`, so the other 12 tags died with:

```
× Github CI support requires you to specify the URL of your repository
  help: Set the repository = "..." key in: crates/riri-yarn/Cargo.toml
```

Reproduced locally with cargo-dist 0.32.0: `dist plan --tag=riri-yarn-v0.1.2` → exit 255; nce/npd tags → exit 0.

Adding `repository.workspace = true` to the non-dist crates is **not** the fix: `dist plan` then exits 0 but announces the dist-able package sharing that version number (e.g. a `riri-yarn-v0.1.2` tag announces `riri-npd 0.1.2`), attaching the wrong binaries to the release.

## Fix

Gate the trigger job to the two dist-able tag prefixes so dist only runs for `riri-nce-*` / `riri-npd-*`. No Cargo.toml changes.