### PR TITLE
ci(pr-bench): bench only crates affected by the diff

### DIFF
--- a/.github/actions/bench-compare/action.yml
+++ b/.github/actions/bench-compare/action.yml
@@ -39,6 +39,10 @@ inputs:
     description: 'JSON object of base peak RSS in KB per binary, e.g. {"nce": 1234}'
     required: false
     default: "{}"
+  crates:
+    description: Space-separated crate set the PR benchmarked; when set, binary-size and RSS tables are limited to it. Empty compares everything present.
+    required: false
+    default: ""
   reference-prefix:
     description: "Comma-separated prefixes for reference benchmarks (excluded from regression, shown in cross-comparison)"
     required: false

--- a/.github/actions/bench-compare/src/main.ts
+++ b/.github/actions/bench-compare/src/main.ts
@@ -37,6 +37,20 @@ export const run = async (): Promise<void> => {
       .map(prefix => prefix.trim())
       .filter(prefix => prefix.length > 0);
 
+    // The PR may benchmark only a subset of crates; narrow the size/RSS maps to
+    // that set so unbenchmarked crates aren't reported as removed. Empty = all.
+    const affectedCrates = new Set(
+      core
+        .getInput('crates')
+        .split(/\s+/)
+        .map(crate => crate.trim())
+        .filter(crate => crate.length > 0),
+    );
+    const limitToAffected = (sizes: Record<string, number>): Record<string, number> =>
+      affectedCrates.size === 0
+        ? sizes
+        : Object.fromEntries(Object.entries(sizes).filter(([name]) => affectedCrates.has(name)));
+
     core.info(`Comparing criterion baselines: ${baseBaseline} vs ${prBaseline}`);
     core.info(`Criterion directory: ${criterionDirectory}`);
     core.info(`Threshold: ${threshold}%`);
@@ -69,8 +83,8 @@ export const run = async (): Promise<void> => {
 
     const benchmarkTable = formatBenchmarkTable(ownBenchmarkResults, threshold);
     const crossComparisonTable = formatCrossComparisonTable(crossComparisons);
-    const sizeTable = formatBinarySizeTable(prBinarySizes, baseBinarySizes);
-    const rssTable = formatRssTable(prPeakRssKilobytes, basePeakRssKilobytes);
+    const sizeTable = formatBinarySizeTable(limitToAffected(prBinarySizes), limitToAffected(baseBinarySizes));
+    const rssTable = formatRssTable(limitToAffected(prPeakRssKilobytes), limitToAffected(basePeakRssKilobytes));
     const testTable = formatTestCountTable(prTestCount, baseTestCount);
 
     const commentBody = buildFullComment(

--- a/.github/workflows/bench-run.yml
+++ b/.github/workflows/bench-run.yml
@@ -25,6 +25,11 @@ on:
         required: false
         type: string
         default: bench-v1
+      crates:
+        description: Space-separated benchable crates to run (nce ncd npd semver-range). Empty runs all.
+        required: false
+        type: string
+        default: ""
     outputs:
       binary-sizes:
         description: JSON object of binary sizes in bytes
@@ -62,22 +67,44 @@ jobs:
           prefix-key: ${{ inputs.rust-cache-prefix }}
           save-if: ${{ inputs.save-rust-cache }}
 
-      - name: Build release binaries
+      # Translate the crate set (default: all) into cargo `-p` flags for the
+      # binary builds. Bench targets are discovered per-ref below.
+      - name: Resolve crate set
+        id: resolve
+        env:
+          REQUESTED: ${{ inputs.crates }}
         run: |
-          members=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].name')
-          for p in riri-nce riri-npd riri-ncd; do
-            if echo "$members" | grep -qx "$p"; then
-              cargo build --release -p "$p"
-            else
-              echo "skip $p (not in workspace at this ref)"
-            fi
+          set="${REQUESTED:-}"
+          [ -z "$set" ] && set="nce npd ncd semver-range"
+          build=""
+          for c in $set; do
+            case "$c" in
+              nce | npd | ncd) build="$build -p riri-$c" ;;
+            esac
           done
+          {
+            echo "set=$set"
+            echo "build=$build"
+          } >> "$GITHUB_OUTPUT"
+          echo "Crate set: $set"
+
+      - name: Build release binaries
+        if: steps.resolve.outputs.build != ''
+        env:
+          BUILD_PKGS: ${{ steps.resolve.outputs.build }}
+        run: |
+          read -ra pkgs <<< "$BUILD_PKGS"
+          cargo build --release "${pkgs[@]}"
 
       - name: Record binary sizes
         id: sizes
+        env:
+          CRATE_SET: ${{ steps.resolve.outputs.set }}
         run: |
+          has() { case " $CRATE_SET " in *" $1 "*) return 0 ;; *) return 1 ;; esac; }
           sizes="{}"
           for bin in nce npd ncd; do
+            has "$bin" || continue
             if [ -f "target/release/$bin" ]; then
               s=$(stat --format='%s' "target/release/$bin")
               sizes=$(echo "$sizes" | jq -c --arg k "$bin" --argjson v "$s" '. + {($k): $v}')
@@ -93,7 +120,10 @@ jobs:
 
       - name: Measure peak RSS
         id: rss
+        env:
+          CRATE_SET: ${{ steps.resolve.outputs.set }}
         run: |
+          has() { case " $CRATE_SET " in *" $1 "*) return 0 ;; *) return 1 ;; esac; }
           measure_in() {
             local fixture="$1"
             local binary="$2"
@@ -124,22 +154,45 @@ jobs:
             (cd "$fixture" && { /usr/bin/time -v "$root/$binary" --quiet --registry "file://$reg" 2>&1 1>/dev/null; } 2>&1 \
               | grep 'Maximum resident set size' | grep -oP '\d+' || echo "0")
           }
-          rss_nce=$(measure_in fixtures/npm-v3-500-deps target/release/nce)
-          rss_npd=$(measure_in fixtures/npd-npm-v3-500-deps target/release/npd)
-          rss_ncd=$(measure_ncd fixtures/npd-npm-v3-500-deps target/release/ncd)
-          json=$(jq -nc --argjson nce "$rss_nce" --argjson npd "$rss_npd" --argjson ncd "$rss_ncd" \
-            '{"nce": $nce, "npd": $npd, "ncd": $ncd}')
+          json="{}"
+          if has nce; then
+            rss=$(measure_in fixtures/npm-v3-500-deps target/release/nce)
+            json=$(echo "$json" | jq -c --argjson v "$rss" '. + {"nce": $v}')
+          fi
+          if has npd; then
+            rss=$(measure_in fixtures/npd-npm-v3-500-deps target/release/npd)
+            json=$(echo "$json" | jq -c --argjson v "$rss" '. + {"npd": $v}')
+          fi
+          if has ncd; then
+            rss=$(measure_ncd fixtures/npd-npm-v3-500-deps target/release/ncd)
+            json=$(echo "$json" | jq -c --argjson v "$rss" '. + {"ncd": $v}')
+          fi
           echo "rss_kb=$json" >> "$GITHUB_OUTPUT"
 
+      # Select bench targets explicitly (not `--benches`, which also runs the
+      # lib/bin unittest harness and chokes on `--save-baseline`). Read names
+      # from each affected crate's manifest at this ref.
       - name: Discover bench targets
         id: discover
+        env:
+          CRATE_SET: ${{ steps.resolve.outputs.set }}
         run: |
-          targets=$(grep -r '^\[\[bench\]\]' crates/*/Cargo.toml -A1 \
-            | grep 'name =' | sed 's/.*name = "\(.*\)"/--bench \1/' | tr '\n' ' ')
+          declare -A dir=( [nce]=riri-nce [ncd]=riri-ncd [npd]=riri-npd [semver-range]=riri-semver-range )
+          tomls=()
+          for c in $CRATE_SET; do
+            d="${dir[$c]:-}"
+            [ -n "$d" ] && [ -f "crates/$d/Cargo.toml" ] && tomls+=("crates/$d/Cargo.toml")
+          done
+          targets=""
+          if [ ${#tomls[@]} -gt 0 ]; then
+            targets=$(grep '^\[\[bench\]\]' "${tomls[@]}" -A1 \
+              | grep 'name =' | sed 's/.*name = "\(.*\)"/--bench \1/' | tr '\n' ' ')
+          fi
           echo "targets=$targets" >> "$GITHUB_OUTPUT"
           echo "Discovered bench targets: $targets"
 
       - name: Run benchmarks
+        if: steps.discover.outputs.targets != ''
         env:
           BENCH_TARGETS: ${{ steps.discover.outputs.targets }}
           BASELINE_NAME: ${{ inputs.baseline-name }}

--- a/.github/workflows/pr-bench.yml
+++ b/.github/workflows/pr-bench.yml
@@ -22,6 +22,30 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # ── Resolve which benchable crates the diff affects ──────
+  changes:
+    runs-on: ubuntu-24.04
+    outputs:
+      crates: ${{ steps.affected.outputs.crates }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: bench-js/.nvmrc
+
+      - name: Compute affected benchable crates
+        id: affected
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: node bench-js/affected-crates.ts
+
   # ── Check for cached base results ────────────────────────
   check-cache:
     runs-on: ubuntu-24.04
@@ -37,8 +61,10 @@ jobs:
           restore-keys: bench-baseline-
           lookup-only: true
 
-  # ── Benchmark PR branch (always runs) ────────────────────
+  # ── Benchmark PR branch (only affected crates) ───────────
   bench-pr:
+    needs: changes
+    if: needs.changes.outputs.crates != ''
     uses: ./.github/workflows/bench-run.yml
     with:
       ref: ${{ github.event.pull_request.head.sha }}
@@ -46,21 +72,23 @@ jobs:
       artifact-name: criterion-pr
       save-rust-cache: true
       rust-cache-prefix: bench-v1
+      crates: ${{ needs.changes.outputs.crates }}
 
   # ── Benchmark base branch (only if no cache) ─────────────
   bench-base:
-    needs: check-cache
-    if: needs.check-cache.outputs.has-cache != 'true'
+    needs: [check-cache, changes]
+    if: needs.check-cache.outputs.has-cache != 'true' && needs.changes.outputs.crates != ''
     uses: ./.github/workflows/bench-run.yml
     with:
       ref: ${{ github.event.pull_request.base.sha }}
       baseline-name: base
       artifact-name: criterion-base
       save-rust-cache: false
+      crates: ${{ needs.changes.outputs.crates }}
 
   # ── Compare & report ─────────────────────────────────────
   compare:
-    needs: [check-cache, bench-pr, bench-base]
+    needs: [check-cache, changes, bench-pr, bench-base]
     if: always() && needs.bench-pr.result == 'success'
     runs-on: ubuntu-24.04
     permissions:
@@ -155,5 +183,6 @@ jobs:
           base-test-count: ${{ steps.base.outputs.test_count }}
           pr-peak-rss-kb: ${{ needs.bench-pr.outputs.peak-rss-kb }}
           base-peak-rss-kb: ${{ steps.base.outputs.rss_kb }}
+          crates: ${{ needs.changes.outputs.crates }}
           reference-prefix: "nodejs-semver"
           threshold: "10"

--- a/bench-js/affected-crates.ts
+++ b/bench-js/affected-crates.ts
@@ -1,0 +1,34 @@
+// bench-js/affected-crates.ts
+//
+// CI entry for the pr-bench `changes` gate. Reads the PR diff and the Cargo
+// workspace graph, then writes the affected benchable crate set to
+// $GITHUB_OUTPUT as `crates` (space-separated, empty when nothing is affected).
+import { execFileSync } from 'node:child_process';
+import { appendFileSync } from 'node:fs';
+
+import { affectedBenchableCrates, type CargoMetadata } from './lib/affected.ts';
+
+const MAX_BUFFER = 64 * 1024 * 1024;
+
+const base = process.env.BASE_SHA;
+const head = process.env.HEAD_SHA;
+if (!base || !head) throw new Error('BASE_SHA and HEAD_SHA must be set');
+
+const changedFiles = execFileSync('git', ['diff', '--name-only', base, head], { encoding: 'utf8' })
+  .split('\n')
+  .map(line => line.trim())
+  .filter(Boolean);
+
+const meta: CargoMetadata = JSON.parse(
+  execFileSync('cargo', ['metadata', '--no-deps', '--format-version', '1'], {
+    encoding: 'utf8',
+    maxBuffer: MAX_BUFFER,
+  }),
+);
+
+const crates = affectedBenchableCrates(changedFiles, meta).join(' ');
+
+console.log(`Changed files:\n${changedFiles.join('\n')}`);
+console.log(`Affected benchable crates: '${crates}'`);
+
+if (process.env.GITHUB_OUTPUT) appendFileSync(process.env.GITHUB_OUTPUT, `crates=${crates}\n`);

--- a/bench-js/lib/affected.test.ts
+++ b/bench-js/lib/affected.test.ts
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+// bench-js/lib/affected.test.ts
+import { test } from 'node:test';
+
+import { affectedBenchableCrates, type CargoMetadata } from './affected.ts';
+
+// Mirror of the real workspace dependency graph (path-deps only).
+const DEPS: Record<string, string[]> = {
+  'riri-nce': ['riri-common', 'riri-node-lifecycle', 'riri-npm', 'riri-pnpm', 'riri-semver-range', 'riri-yarn'],
+  'riri-ncd': ['riri-common', 'riri-npm', 'riri-pnpm', 'riri-semver-range', 'riri-workspace', 'riri-yarn'],
+  'riri-npd': ['riri-common', 'riri-npm', 'riri-pnpm', 'riri-workspace', 'riri-yarn'],
+  'riri-semver-range': [],
+  'riri-common': ['riri-find-up'],
+  'riri-pnpm': ['riri-find-up'],
+  'riri-workspace': ['riri-find-up'],
+  'riri-find-up': [],
+  'riri-npm': [],
+  'riri-yarn': [],
+  'riri-node-lifecycle': [],
+  'riri-napi-nce': ['riri-nce', 'riri-semver-range'],
+  xtask: ['riri-node-lifecycle'],
+};
+
+const META: CargoMetadata = {
+  packages: Object.entries(DEPS).map(([name, deps]) => ({
+    name,
+    manifest_path: `/repo/crates/${name}/Cargo.toml`,
+    dependencies: deps.map(dep => ({ name: dep })),
+  })),
+};
+
+const affected = (...files: string[]): string[] => affectedBenchableCrates(files, META);
+
+test('data change in node-lifecycle affects only nce', () => {
+  assert.deepEqual(affected('crates/riri-node-lifecycle/data/node-versions.json'), ['nce']);
+});
+
+test('semver-range affects its dependents nce and ncd, not npd', () => {
+  assert.deepEqual(affected('crates/riri-semver-range/src/lib.rs'), ['nce', 'ncd', 'semver-range']);
+});
+
+test('workspace affects ncd and npd, not nce', () => {
+  assert.deepEqual(affected('crates/riri-workspace/src/lib.rs'), ['ncd', 'npd']);
+});
+
+test('common (transitively used everywhere) affects all binary crates', () => {
+  assert.deepEqual(affected('crates/riri-common/src/lib.rs'), ['nce', 'ncd', 'npd']);
+});
+
+test('find-up reaches every crate through common/pnpm/workspace', () => {
+  assert.deepEqual(affected('crates/riri-find-up/src/lib.rs'), ['nce', 'ncd', 'npd']);
+});
+
+test('a single binary crate affects only itself', () => {
+  assert.deepEqual(affected('crates/riri-npd/src/lib.rs'), ['npd']);
+});
+
+test('crates with no benchable dependents affect nothing', () => {
+  assert.deepEqual(affected('crates/xtask/src/main.rs'), []);
+  assert.deepEqual(affected('crates/riri-napi-nce/src/lib.rs'), []);
+});
+
+test('multiple changed crates union their affected sets', () => {
+  assert.deepEqual(affected('crates/riri-npd/src/lib.rs', 'crates/riri-node-lifecycle/src/data.rs'), ['nce', 'npd']);
+});
+
+test('non-crate paths force all benchable crates', () => {
+  const all = ['nce', 'ncd', 'npd', 'semver-range'];
+  assert.deepEqual(affected('Cargo.lock'), all);
+  assert.deepEqual(affected('fixtures/npm-v3-500-deps/package.json'), all);
+  assert.deepEqual(affected('.github/workflows/bench-run.yml'), all);
+  assert.deepEqual(affected('rustfmt.toml'), all);
+});
+
+test('an unknown crate path is treated conservatively as force-all', () => {
+  assert.deepEqual(affected('crates/riri-brand-new/src/lib.rs'), ['nce', 'ncd', 'npd', 'semver-range']);
+});

--- a/bench-js/lib/affected.ts
+++ b/bench-js/lib/affected.ts
@@ -1,0 +1,91 @@
+// bench-js/lib/affected.ts
+//
+// Resolve which benchable crates a diff affects, so pr-bench can skip the rest.
+// A benchable crate is affected when it (or any of its transitive workspace
+// path-dependencies) changed. Anything that is not a `crates/<pkg>/**` file
+// (Cargo.lock, root Cargo.toml, rustfmt.toml, fixtures, scripts, workflows)
+// touches the whole build or every bench fixture, so it forces all crates.
+
+export interface CargoDependency {
+  name: string;
+}
+export interface CargoPackage {
+  name: string;
+  manifest_path: string;
+  dependencies: CargoDependency[];
+}
+export interface CargoMetadata {
+  packages: CargoPackage[];
+}
+
+// Crates that own criterion benches. Everything resolved is a subset of these.
+const BENCHABLE = ['riri-nce', 'riri-ncd', 'riri-npd', 'riri-semver-range'];
+
+const shortName = (pkg: string): string => pkg.replace(/^riri-/, '');
+
+// `crates/<dir>` for the file, or undefined when it lives elsewhere.
+const crateDirOf = (file: string): string | undefined => {
+  if (!file.startsWith('crates/')) return undefined;
+  const segments = file.split('/');
+  return segments.length >= 2 ? `crates/${segments[1]}` : undefined;
+};
+
+// Map every `crates/<dir>` to its package name via the manifest path.
+const dirToPackage = (meta: CargoMetadata): Map<string, string> => {
+  const map = new Map<string, string>();
+  for (const pkg of meta.packages) {
+    const dir = pkg.manifest_path.replace(/\/Cargo\.toml$/, '');
+    map.set(dir, pkg.name);
+  }
+  return map;
+};
+
+// Adjacency of each package to its workspace path-dependencies only.
+const workspaceAdjacency = (meta: CargoMetadata): Map<string, string[]> => {
+  const members = new Set(meta.packages.map(pkg => pkg.name));
+  const adjacency = new Map<string, string[]>();
+  for (const pkg of meta.packages) {
+    const deps = pkg.dependencies.map(dep => dep.name).filter(name => members.has(name));
+    adjacency.set(pkg.name, [...new Set(deps)]);
+  }
+  return adjacency;
+};
+
+// Package + all its transitive workspace dependencies.
+const closure = (start: string, adjacency: Map<string, string[]>): Set<string> => {
+  const seen = new Set([start]);
+  const frontier = [start];
+  while (frontier.length > 0) {
+    const current = frontier.pop() as string;
+    for (const next of adjacency.get(current) ?? []) {
+      if (!seen.has(next)) {
+        seen.add(next);
+        frontier.push(next);
+      }
+    }
+  }
+  return seen;
+};
+
+export const affectedBenchableCrates = (changedFiles: string[], meta: CargoMetadata): string[] => {
+  const lookup = dirToPackage(meta);
+
+  let forceAll = false;
+  const changedPackages = new Set<string>();
+  for (const file of changedFiles) {
+    const dir = crateDirOf(file);
+    if (dir === undefined) {
+      forceAll = true;
+      continue;
+    }
+    // Manifest paths are absolute; match on the trailing `crates/<dir>`.
+    const pkg = [...lookup].find(([manifestDir]) => manifestDir === dir || manifestDir.endsWith(`/${dir}`))?.[1];
+    if (pkg === undefined) forceAll = true;
+    else changedPackages.add(pkg);
+  }
+
+  if (forceAll) return BENCHABLE.map(shortName);
+
+  const adjacency = workspaceAdjacency(meta);
+  return BENCHABLE.filter(crate => [...closure(crate, adjacency)].some(dep => changedPackages.has(dep))).map(shortName);
+};


### PR DESCRIPTION
## Motivation

`pr-bench` ran criterion + binary size + peak RSS for **all** crates on any change matching `crates/**`, `Cargo.*`, `fixtures/**`, `scripts/**`, `rustfmt.toml`. In #224 (a `node-versions.json` refresh under `riri-node-lifecycle`) every crate was benchmarked even though only `nce` depends on that data.

## Approach

Logic lives in **TypeScript** (shared with the existing `bench-compare` action and `bench-js/lib`), not inline shell — typed, unit-tested, and the gate runs `node` directly (node 22 strips types), so it needs **no `npm ci` and no bundle**.

- **`bench-js/lib/affected.ts`** — pure reverse path-dependency closure over `cargo metadata`. A benchable crate (`nce`/`ncd`/`npd`/`semver-range`) is affected when it or any transitive workspace dep changed; non-crate paths (`Cargo.lock`, `rustfmt.toml`, `fixtures/**`, `scripts/**`, workflows) force all. Self-maintaining as deps change.
- **`bench-js/lib/affected.test.ts`** — unit tests for every scenario (`node:test`).
- **`bench-js/affected-crates.ts`** — thin CI entry: `git diff` + `cargo metadata` → writes `crates` to `$GITHUB_OUTPUT`.
- **`pr-bench.yml`** — new `changes` gate runs `node bench-js/affected-crates.ts`; `bench-pr`/`bench-base` only run for the affected set (skipped entirely when nothing benchable is touched).
- **`bench-run.yml`** — new `crates` input gates build/size/RSS; bench discovery (`grep '[[bench]]'`) **removed** in favour of `cargo bench -p <pkg> --benches`, which is per-ref-safe. Empty input runs all, so `ci.yml` still produces a complete base baseline for the cache.
- **`bench-compare`** — new `crates` input narrows the base size/RSS maps to the PR set internally (typed), replacing a workflow-level `jq` filter.

The peak-RSS step stays a small isolated shell helper (`/usr/bin/time -v`) — a syscall concern that's ugly in both TS and bash; the remaining `bench-run.yml` shell is plain `cargo` plumbing.

### Effect on #224

`node-versions.json` → only `riri-node-lifecycle` changed → closure = `nce` alone. Only nce is built, sized, RSS-measured, benchmarked.

## Validation

- `affected.ts`: 10 unit tests, plus checked against the real `cargo metadata` graph — `node-lifecycle`→`nce`; `semver-range`→`nce ncd semver-range`; `workspace`→`ncd npd`; `common`/`find-up`→all; `xtask`/`napi-*`→none; shared paths→all
- full CLI run end-to-end on a real `node-versions.json` commit → `crates=nce`
- `bench-js` + `bench-compare`: typecheck, oxlint, oxfmt, `node --test` all clean
- `zizmor --offline` and `actionlint` (incl. shellcheck) clean