### PR TITLE
ci(bench-run): move measurement scripts to tested ts orchestrator

### DIFF
--- a/.github/workflows/bench-run.yml
+++ b/.github/workflows/bench-run.yml
@@ -48,9 +48,9 @@ jobs:
   bench:
     runs-on: ubuntu-24.04
     outputs:
-      binary-sizes: ${{ steps.sizes.outputs.json }}
-      test-count: ${{ steps.tests.outputs.count }}
-      peak-rss-kb: ${{ steps.rss.outputs.rss_kb }}
+      binary-sizes: ${{ steps.bench.outputs.binary-sizes }}
+      test-count: ${{ steps.bench.outputs.test-count }}
+      peak-rss-kb: ${{ steps.bench.outputs.peak-rss-kb }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -67,138 +67,20 @@ jobs:
           prefix-key: ${{ inputs.rust-cache-prefix }}
           save-if: ${{ inputs.save-rust-cache }}
 
-      # Translate the crate set (default: all) into cargo `-p` flags for the
-      # binary builds. Bench targets are discovered per-ref below.
-      - name: Resolve crate set
-        id: resolve
-        env:
-          REQUESTED: ${{ inputs.crates }}
-        run: |
-          set="${REQUESTED:-}"
-          [ -z "$set" ] && set="nce npd ncd semver-range"
-          build=""
-          for c in $set; do
-            case "$c" in
-              nce | npd | ncd) build="$build -p riri-$c" ;;
-            esac
-          done
-          {
-            echo "set=$set"
-            echo "build=$build"
-          } >> "$GITHUB_OUTPUT"
-          echo "Crate set: $set"
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: bench-js/.nvmrc
 
-      - name: Build release binaries
-        if: steps.resolve.outputs.build != ''
+      # Builds binaries, records sizes, counts tests, measures peak RSS and runs
+      # the criterion benches for the crate set; emits binary-sizes / test-count
+      # / peak-rss-kb. Logic lives in bench-js/lib/ci-bench.ts (unit-tested).
+      - name: Benchmark
+        id: bench
         env:
-          BUILD_PKGS: ${{ steps.resolve.outputs.build }}
-        run: |
-          read -ra pkgs <<< "$BUILD_PKGS"
-          cargo build --release "${pkgs[@]}"
-
-      - name: Record binary sizes
-        id: sizes
-        env:
-          CRATE_SET: ${{ steps.resolve.outputs.set }}
-        run: |
-          has() { case " $CRATE_SET " in *" $1 "*) return 0 ;; *) return 1 ;; esac; }
-          sizes="{}"
-          for bin in nce npd ncd; do
-            has "$bin" || continue
-            if [ -f "target/release/$bin" ]; then
-              s=$(stat --format='%s' "target/release/$bin")
-              sizes=$(echo "$sizes" | jq -c --arg k "$bin" --argjson v "$s" '. + {($k): $v}')
-            fi
-          done
-          echo "json=$sizes" >> "$GITHUB_OUTPUT"
-
-      - name: Count tests
-        id: tests
-        run: |
-          count=$(cargo test --workspace -- --list 2>&1 | grep -c ': test$' || echo "0")
-          echo "count=$count" >> "$GITHUB_OUTPUT"
-
-      - name: Measure peak RSS
-        id: rss
-        env:
-          CRATE_SET: ${{ steps.resolve.outputs.set }}
-        run: |
-          has() { case " $CRATE_SET " in *" $1 "*) return 0 ;; *) return 1 ;; esac; }
-          measure_in() {
-            local fixture="$1"
-            local binary="$2"
-            if [ ! -d "$fixture" ] || [ ! -x "$binary" ]; then
-              echo "0"
-              return
-            fi
-            (cd "$fixture" && { /usr/bin/time -v "../../$binary" --quiet 2>&1 1>/dev/null; } 2>&1 \
-              | grep 'Maximum resident set size' | grep -oP '\d+' || echo "0")
-          }
-          # ncd needs a registry; synthesize an offline one (one empty packument
-          # per locked package) so the run is deterministic, then measure it
-          # against the shared 500-dep lockfile for a comparable workload.
-          measure_ncd() {
-            local fixture="$1"
-            local binary="$2"
-            if [ ! -d "$fixture" ] || [ ! -x "$binary" ]; then
-              echo "0"
-              return
-            fi
-            local root reg
-            root="$PWD"
-            reg="$(mktemp -d)"
-            jq -r '.packages | keys[] | select(startswith("node_modules/")) | ltrimstr("node_modules/")' \
-              "$fixture/package-lock.json" | while read -r name; do
-              printf '{}' > "$reg/$name.json"
-            done
-            (cd "$fixture" && { /usr/bin/time -v "$root/$binary" --quiet --registry "file://$reg" 2>&1 1>/dev/null; } 2>&1 \
-              | grep 'Maximum resident set size' | grep -oP '\d+' || echo "0")
-          }
-          json="{}"
-          if has nce; then
-            rss=$(measure_in fixtures/npm-v3-500-deps target/release/nce)
-            json=$(echo "$json" | jq -c --argjson v "$rss" '. + {"nce": $v}')
-          fi
-          if has npd; then
-            rss=$(measure_in fixtures/npd-npm-v3-500-deps target/release/npd)
-            json=$(echo "$json" | jq -c --argjson v "$rss" '. + {"npd": $v}')
-          fi
-          if has ncd; then
-            rss=$(measure_ncd fixtures/npd-npm-v3-500-deps target/release/ncd)
-            json=$(echo "$json" | jq -c --argjson v "$rss" '. + {"ncd": $v}')
-          fi
-          echo "rss_kb=$json" >> "$GITHUB_OUTPUT"
-
-      # Select bench targets explicitly (not `--benches`, which also runs the
-      # lib/bin unittest harness and chokes on `--save-baseline`). Read names
-      # from each affected crate's manifest at this ref.
-      - name: Discover bench targets
-        id: discover
-        env:
-          CRATE_SET: ${{ steps.resolve.outputs.set }}
-        run: |
-          declare -A dir=( [nce]=riri-nce [ncd]=riri-ncd [npd]=riri-npd [semver-range]=riri-semver-range )
-          tomls=()
-          for c in $CRATE_SET; do
-            d="${dir[$c]:-}"
-            [ -n "$d" ] && [ -f "crates/$d/Cargo.toml" ] && tomls+=("crates/$d/Cargo.toml")
-          done
-          targets=""
-          if [ ${#tomls[@]} -gt 0 ]; then
-            targets=$(grep '^\[\[bench\]\]' "${tomls[@]}" -A1 \
-              | grep 'name =' | sed 's/.*name = "\(.*\)"/--bench \1/' | tr '\n' ' ')
-          fi
-          echo "targets=$targets" >> "$GITHUB_OUTPUT"
-          echo "Discovered bench targets: $targets"
-
-      - name: Run benchmarks
-        if: steps.discover.outputs.targets != ''
-        env:
-          BENCH_TARGETS: ${{ steps.discover.outputs.targets }}
+          CRATES: ${{ inputs.crates }}
           BASELINE_NAME: ${{ inputs.baseline-name }}
-        run: |
-          read -ra targets <<< "$BENCH_TARGETS"
-          cargo bench "${targets[@]}" -- --save-baseline "$BASELINE_NAME"
+        run: node bench-js/ci-bench.ts
 
       - name: Upload criterion baselines
         uses: actions/upload-artifact@v7

--- a/bench-js/ci-bench.ts
+++ b/bench-js/ci-bench.ts
@@ -1,0 +1,95 @@
+// bench-js/ci-bench.ts
+//
+// bench-run orchestrator: builds the affected binary crates, records their
+// sizes, counts workspace tests, measures peak RSS, and runs the criterion
+// benches — then writes `binary-sizes`, `test-count` and `peak-rss-kb` to
+// $GITHUB_OUTPUT. Replaces the inline shell of .github/workflows/bench-run.yml.
+import { execFileSync, spawnSync } from 'node:child_process';
+import { appendFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  BINARIES,
+  benchTargets,
+  packumentNames,
+  parseMaxRssKb,
+  parseTestCount,
+  resolveCrateSet,
+  RSS_TARGETS,
+  type CargoMetadataTargets,
+} from './lib/ci-bench.ts';
+
+const MAX_BUFFER = 64 * 1024 * 1024;
+const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+// Stream a cargo command (build/bench) to the log, failing the step on error.
+const cargoRun = (args: string[]): void => {
+  execFileSync('cargo', args, { cwd: rootDir, stdio: 'inherit' });
+};
+// Capture a cargo command's stdout (metadata/test list).
+const cargoCapture = (args: string[]): string =>
+  spawnSync('cargo', args, { cwd: rootDir, encoding: 'utf8', maxBuffer: MAX_BUFFER }).stdout;
+
+const baselineName = process.env.BASELINE_NAME ?? 'pr';
+const { set, buildPackages } = resolveCrateSet(process.env.CRATES ?? '');
+console.log(`Crate set: ${set.join(' ') || '(none)'}`);
+
+// ── Build release binaries ───────────────────────────────────────────
+if (buildPackages.length > 0) cargoRun(['build', '--release', ...buildPackages.flatMap(pkg => ['-p', pkg])]);
+
+// ── Record binary sizes ──────────────────────────────────────────────
+const binarySizes: Record<string, number> = {};
+for (const binary of BINARIES) {
+  const path = resolve(rootDir, 'target/release', binary);
+  if (set.includes(binary) && existsSync(path)) binarySizes[binary] = statSync(path).size;
+}
+
+// ── Count tests ──────────────────────────────────────────────────────
+const list = spawnSync('cargo', ['test', '--workspace', '--', '--list'], {
+  cwd: rootDir,
+  encoding: 'utf8',
+  maxBuffer: MAX_BUFFER,
+});
+const testCount = parseTestCount(`${list.stdout ?? ''}${list.stderr ?? ''}`);
+
+// ── Measure peak RSS ─────────────────────────────────────────────────
+// ncd needs a registry; synthesize an offline one (an empty packument per
+// locked package) so the run is deterministic against the shared lockfile.
+const synthesizeRegistry = (fixtureDir: string): string => {
+  const registry = mkdtempSync(join(tmpdir(), 'reg-'));
+  for (const name of packumentNames(readFileSync(join(fixtureDir, 'package-lock.json'), 'utf8'))) {
+    const file = join(registry, `${name}.json`);
+    mkdirSync(dirname(file), { recursive: true });
+    writeFileSync(file, '{}');
+  }
+  return registry;
+};
+
+const peakRssKb: Record<string, number> = {};
+for (const { binary, fixture, needsRegistry } of RSS_TARGETS) {
+  const binaryPath = resolve(rootDir, 'target/release', binary);
+  const fixtureDir = resolve(rootDir, fixture);
+  if (!set.includes(binary) || !existsSync(binaryPath) || !existsSync(fixtureDir)) continue;
+  const args = ['-v', binaryPath, '--quiet'];
+  if (needsRegistry) args.push('--registry', `file://${synthesizeRegistry(fixtureDir)}`);
+  const measured = spawnSync('/usr/bin/time', args, { cwd: fixtureDir, encoding: 'utf8', maxBuffer: MAX_BUFFER });
+  peakRssKb[binary] = parseMaxRssKb(measured.stderr ?? '');
+}
+
+// ── Run benchmarks ───────────────────────────────────────────────────
+const meta: CargoMetadataTargets = JSON.parse(cargoCapture(['metadata', '--no-deps', '--format-version', '1']));
+const targets = benchTargets(set, meta);
+console.log(`Bench targets: ${targets.join(' ') || '(none)'}`);
+if (targets.length > 0) {
+  cargoRun(['bench', ...targets.flatMap(target => ['--bench', target]), '--', '--save-baseline', baselineName]);
+}
+
+// ── Emit outputs ─────────────────────────────────────────────────────
+if (process.env.GITHUB_OUTPUT) {
+  appendFileSync(
+    process.env.GITHUB_OUTPUT,
+    `binary-sizes=${JSON.stringify(binarySizes)}\ntest-count=${testCount}\npeak-rss-kb=${JSON.stringify(peakRssKb)}\n`,
+  );
+}

--- a/bench-js/lib/ci-bench.test.ts
+++ b/bench-js/lib/ci-bench.test.ts
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict';
+// bench-js/lib/ci-bench.test.ts
+import { test } from 'node:test';
+
+import {
+  benchTargets,
+  packumentNames,
+  parseMaxRssKb,
+  parseTestCount,
+  resolveCrateSet,
+  type CargoMetadataTargets,
+} from './ci-bench.ts';
+
+const META: CargoMetadataTargets = {
+  packages: [
+    {
+      name: 'riri-nce',
+      targets: [
+        { name: 'riri-nce', kind: ['lib'] },
+        { name: 'nce', kind: ['bin'] },
+        { name: 'check_engines', kind: ['bench'] },
+      ],
+    },
+    {
+      name: 'riri-semver-range',
+      targets: [
+        { name: 'riri-semver-range', kind: ['lib'] },
+        { name: 'range_satisfies', kind: ['bench'] },
+        { name: 'range_parsing', kind: ['bench'] },
+      ],
+    },
+    { name: 'riri-npd', targets: [{ name: 'pin_dependencies', kind: ['bench'] }] },
+  ],
+};
+
+test('resolveCrateSet defaults to all benchable crates', () => {
+  assert.deepEqual(resolveCrateSet(''), {
+    set: ['nce', 'ncd', 'npd', 'semver-range'],
+    buildPackages: ['riri-nce', 'riri-ncd', 'riri-npd'],
+  });
+});
+
+test('resolveCrateSet maps only binary crates to build packages', () => {
+  assert.deepEqual(resolveCrateSet('nce semver-range'), {
+    set: ['nce', 'semver-range'],
+    buildPackages: ['riri-nce'],
+  });
+});
+
+test('benchTargets returns only bench-kind targets for the set, sorted', () => {
+  assert.deepEqual(benchTargets(['nce', 'semver-range'], META), ['check_engines', 'range_parsing', 'range_satisfies']);
+});
+
+test('benchTargets ignores crates outside the set', () => {
+  assert.deepEqual(benchTargets(['npd'], META), ['pin_dependencies']);
+});
+
+test('parseMaxRssKb extracts the GNU time value', () => {
+  assert.equal(parseMaxRssKb('\tMaximum resident set size (kbytes): 71540\n\tOther: 1'), 71540);
+  assert.equal(parseMaxRssKb('no measurement here'), 0);
+});
+
+test('parseTestCount counts lines ending in ": test"', () => {
+  const list = ['riri_nce::a: test', 'riri_nce::b: test', 'some other line', '0 benchmarks', ''].join('\n');
+  assert.equal(parseTestCount(list), 2);
+});
+
+test('packumentNames strips the node_modules prefix', () => {
+  const lockfile = JSON.stringify({
+    packages: { '': {}, 'node_modules/foo': {}, 'node_modules/@scope/bar': {} },
+  });
+  assert.deepEqual(packumentNames(lockfile), ['foo', '@scope/bar']);
+});

--- a/bench-js/lib/ci-bench.ts
+++ b/bench-js/lib/ci-bench.ts
@@ -1,0 +1,77 @@
+// bench-js/lib/ci-bench.ts
+//
+// Pure helpers for the bench-run CI orchestrator: crate-set resolution, bench
+// target discovery from `cargo metadata`, and parsers for `cargo test --list`,
+// GNU `time -v`, and npm lockfiles. The I/O lives in ../ci-bench.ts.
+
+export interface CargoTarget {
+  name: string;
+  kind: string[];
+}
+export interface CargoPackageTargets {
+  name: string;
+  targets: CargoTarget[];
+}
+export interface CargoMetadataTargets {
+  packages: CargoPackageTargets[];
+}
+
+// Crates that own criterion benches; the binary crates are a subset.
+export const BENCHABLE = ['nce', 'ncd', 'npd', 'semver-range'];
+export const BINARIES = ['nce', 'npd', 'ncd'];
+
+// Peak-RSS workloads: each binary measured against a shared 500-dep fixture.
+// `ncd` needs a registry, so the caller synthesizes an offline one.
+export interface RssTarget {
+  binary: string;
+  fixture: string;
+  needsRegistry: boolean;
+}
+export const RSS_TARGETS: RssTarget[] = [
+  { binary: 'nce', fixture: 'fixtures/npm-v3-500-deps', needsRegistry: false },
+  { binary: 'npd', fixture: 'fixtures/npd-npm-v3-500-deps', needsRegistry: false },
+  { binary: 'ncd', fixture: 'fixtures/npd-npm-v3-500-deps', needsRegistry: true },
+];
+
+export interface CrateSet {
+  set: string[];
+  buildPackages: string[];
+}
+
+// Empty request → every benchable crate. `buildPackages` are the cargo `-p`
+// package names of the binary crates in the set.
+export const resolveCrateSet = (requested: string): CrateSet => {
+  const set = requested.trim().length > 0 ? requested.trim().split(/\s+/) : [...BENCHABLE];
+  const buildPackages = set.filter(crate => BINARIES.includes(crate)).map(crate => `riri-${crate}`);
+  return { set, buildPackages };
+};
+
+// Bench target names for the crate set, read from `cargo metadata` so only
+// targets that exist at this ref are selected (no `--benches`, which would also
+// run the lib/bin unittest harness).
+export const benchTargets = (set: string[], meta: CargoMetadataTargets): string[] => {
+  const packages = new Set(set.map(crate => `riri-${crate}`));
+  return meta.packages
+    .filter(pkg => packages.has(pkg.name))
+    .flatMap(pkg => pkg.targets.filter(target => target.kind.includes('bench')).map(target => target.name))
+    .toSorted((a, b) => a.localeCompare(b));
+};
+
+// Peak resident set size in KB from GNU `time -v` stderr; 0 when absent.
+export const parseMaxRssKb = (timeOutput: string): number => {
+  const match = timeOutput.match(/Maximum resident set size[^\d]*(\d+)/);
+  return match ? Number(match[1]) : 0;
+};
+
+// Count of `cargo test -- --list` entries (lines ending in `: test`).
+export const parseTestCount = (listOutput: string): number =>
+  listOutput.split('\n').filter(line => line.endsWith(': test')).length;
+
+// Locked package names (`node_modules/<name>`) from an npm lockfile, used to
+// synthesize an offline registry of empty packuments for the ncd measurement.
+export const packumentNames = (lockfileText: string): string[] => {
+  const lockfile: { packages?: Record<string, unknown> } = JSON.parse(lockfileText);
+  return Object.keys(lockfile.packages ?? {})
+    .filter(key => key.startsWith('node_modules/'))
+    .map(key => key.slice('node_modules/'.length));
+};


### PR DESCRIPTION
## Motivation

Follow-up to #225. `bench-run.yml` carried the bulk of the repo's workflow shell — `jq` JSON building, GNU `time -v` parsing, `grep '[[bench]]'` discovery, test counting — all inline, untestable, brittle. This moves that logic into tested TypeScript, consistent with `affected-crates.ts` and the `bench-compare` action.

## What changed

- **`bench-js/lib/ci-bench.ts`** — pure helpers: crate-set resolution, bench-target discovery from `cargo metadata` (kind `bench`, replacing the `grep`), and parsers for `cargo test --list`, GNU `time -v`, and npm lockfiles.
- **`bench-js/lib/ci-bench.test.ts`** — unit tests for every helper.
- **`bench-js/ci-bench.ts`** — orchestrator: builds the affected binary crates, records sizes, counts tests, measures peak RSS, runs the criterion benches, and writes `binary-sizes` / `test-count` / `peak-rss-kb` to `$GITHUB_OUTPUT`.
- **`bench-run.yml`** — the six inline shell steps collapse to one `node bench-js/ci-bench.ts` step (plus `setup-node`, no `npm ci` — built-ins only). Job outputs and the `crates` input are unchanged, so `pr-bench`, `ci.yml` and `bench-compare` need no edits.

`cargo build` / `cargo bench` are spawned by the orchestrator (still cargo); the logic around them is now typed and tested. RSS still uses `/usr/bin/time -v` — invoked from TS and parsed by a unit-tested regex.

## Scope — remaining workflow shell, intentionally kept thin

These are single-command invocations or routing/plumbing, not logic, so they read cleaner as-is (same logic/thin split as #225):

- `cargo build` / `cargo bench` / `cargo fmt|clippy|test`, `npm ci`, `npx napi build`, `docker run … node test.mjs` — irreducible command invocations
- `napi.yml` version→dist-tag — left in bash on purpose: coupling the release/publish path to bench tooling is worse than 8 self-contained lines
- `pr-bench.yml` "Resolve base results" / "Copy cached criterion", `ci.yml` cache-baseline writes + release-please env vars, `refresh-node-data.yml` `git diff --quiet` — data routing / file copies / release plumbing
- `dist.yml` — generated by cargo-dist, not edited

## Validation

- 29 bench-js unit tests pass; `benchTargets`/`resolveCrateSet` checked against the real `cargo metadata` graph (all=6 benches, nce=check_engines, etc.)
- behaviour parity with the previous shell confirmed (sizes, test count, RSS, explicit `--bench` selection)
- `bench-js` typecheck / oxlint / oxfmt clean; `zizmor --offline` and `actionlint` (incl. shellcheck) clean

This PR edits a workflow file → the `changes` gate (from #225) forces all crates, so bench-run exercises the full TS path as a self-test.