### PR TITLE
perf(semver-range): byte-level parse fast path (3.7x faster) & prerelease fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1666,6 +1666,7 @@ dependencies = [
  "nodejs-semver",
  "proptest",
  "semver",
+ "smallvec",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ semver = "1.0.28"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = { version = "1.0.150", features = ["preserve_order"] }
 serde-saphyr = "0.0.28"
+smallvec = "1.15"
 tracing = "0.1.44"
 thiserror = "2.0.18"
 tracing-subscriber = "0.3.23"

--- a/crates/riri-nce/src/policy.rs
+++ b/crates/riri-nce/src/policy.rs
@@ -76,7 +76,7 @@ pub fn rewrite_node_range(
         let baseline = if is_wildcard(input_part) {
             Vec::new()
         } else {
-            split_by_major(input_part)
+            split_by_major(input_part).into_vec()
         };
         if contributions != baseline {
             let rewritten_part = humanize_parts(&contributions, ctx.precision);

--- a/crates/riri-nce/src/policy.rs
+++ b/crates/riri-nce/src/policy.rs
@@ -113,7 +113,9 @@ pub fn rewrite_node_range(
         }
     }
 
-    let rebuilt = ParsedRange { parts: new_parts };
+    let rebuilt = ParsedRange {
+        parts: new_parts.into(),
+    };
     let rewritten = rebuilt.humanize_with(ctx.precision);
 
     Ok(PolicyResult {
@@ -206,14 +208,14 @@ fn caret_from_major(m: u32) -> RangePart {
 
 fn humanize_part(part: &RangePart, precision: VersionPrecision) -> String {
     ParsedRange {
-        parts: vec![part.clone()],
+        parts: vec![part.clone()].into(),
     }
     .humanize_with(precision)
 }
 
 fn humanize_parts(parts: &[RangePart], precision: VersionPrecision) -> String {
     ParsedRange {
-        parts: parts.to_vec(),
+        parts: parts.to_vec().into(),
     }
     .humanize_with(precision)
 }

--- a/crates/riri-semver-range/Cargo.toml
+++ b/crates/riri-semver-range/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 
 [dependencies]
 semver = { workspace = true }
+smallvec = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/crates/riri-semver-range/src/helpers.rs
+++ b/crates/riri-semver-range/src/helpers.rs
@@ -1,29 +1,34 @@
 use crate::{Op, RangePart};
 use semver::Version;
+use smallvec::{SmallVec, smallvec};
+
+/// A small, mostly-inline list of range parts (the common case is a single part
+/// that does not span majors, kept on the stack).
+pub type SplitParts = SmallVec<[RangePart; 1]>;
 
 /// Split a cross-major range part into one part per major version.
 ///
 /// e.g., `>=16.10.0 <18.0.0` → `[^16.10.0, ^17.0.0]`
 /// e.g., `>=0.0.0 <=2.0.0` → `[^0.0.0, ^1.0.0, 2.0.0]`
 #[must_use]
-pub fn split_by_major(part: &RangePart) -> Vec<RangePart> {
+pub fn split_by_major(part: &RangePart) -> SplitParts {
     let Some(max) = &part.max else {
-        return vec![part.clone()];
+        return smallvec![part.clone()];
     };
 
     // Compute the effective exclusive upper major boundary
     let end_major = match part.max_op {
         Some(Op::Lt) => max.major,
         Some(Op::Lte) => max.major + 1,
-        _ => return vec![part.clone()],
+        _ => return smallvec![part.clone()],
     };
 
     // Only split if the part spans more than one major
     if end_major <= part.min.major + 1 {
-        return vec![part.clone()];
+        return smallvec![part.clone()];
     }
 
-    let mut parts = Vec::new();
+    let mut parts: SplitParts = SmallVec::new();
     for major in part.min.major..end_major {
         let min = if major == part.min.major {
             part.min.clone()

--- a/crates/riri-semver-range/src/intersection.rs
+++ b/crates/riri-semver-range/src/intersection.rs
@@ -48,7 +48,7 @@ pub fn restrictive_range(r1: &ParsedRange, r2: &ParsedRange) -> ParsedRange {
     }
 
     ParsedRange {
-        parts: result_parts,
+        parts: result_parts.into(),
     }
 }
 

--- a/crates/riri-semver-range/src/intersection.rs
+++ b/crates/riri-semver-range/src/intersection.rs
@@ -1,6 +1,7 @@
 use crate::helpers::split_by_major;
 use crate::subset::{intersects, is_subset_of};
-use crate::{Op, ParsedRange, RangePart};
+use crate::{Op, ParsedRange, Parts, RangePart};
+use smallvec::SmallVec;
 
 /// Compute the most restrictive intersection of two ranges.
 ///
@@ -30,11 +31,13 @@ pub fn restrictive_range(r1: &ParsedRange, r2: &ParsedRange) -> ParsedRange {
     }
 
     // Split both ranges into one part per major version
-    let a_parts: Vec<_> = r1.parts.iter().flat_map(split_by_major).collect();
-    let b_parts: Vec<_> = r2.parts.iter().flat_map(split_by_major).collect();
+    // Most ranges are one or two parts that don't span majors, so keep the split
+    // results and the intersection output inline instead of heap-allocating.
+    let a_parts: SmallVec<[RangePart; 2]> = r1.parts.iter().flat_map(split_by_major).collect();
+    let b_parts: SmallVec<[RangePart; 2]> = r2.parts.iter().flat_map(split_by_major).collect();
 
     // Pairwise interval intersection
-    let mut result_parts = Vec::new();
+    let mut result_parts: Parts = SmallVec::new();
     for a_part in &a_parts {
         for b_part in &b_parts {
             if let Some(intersection) = intersect_parts(a_part, b_part) {
@@ -48,7 +51,7 @@ pub fn restrictive_range(r1: &ParsedRange, r2: &ParsedRange) -> ParsedRange {
     }
 
     ParsedRange {
-        parts: result_parts.into(),
+        parts: result_parts,
     }
 }
 

--- a/crates/riri-semver-range/src/lib.rs
+++ b/crates/riri-semver-range/src/lib.rs
@@ -6,7 +6,7 @@ pub(crate) mod subset;
 
 pub use helpers::split_by_major;
 pub use intersection::restrictive_range;
-pub use parse::ParsedRange;
+pub use parse::{ParsedRange, Parts};
 pub use subset::{intersects, is_subset_of};
 
 use semver::Version;

--- a/crates/riri-semver-range/src/parse.rs
+++ b/crates/riri-semver-range/src/parse.rs
@@ -1,10 +1,17 @@
 use crate::{Op, RangePart};
 use semver::Version;
+use smallvec::{SmallVec, smallvec};
+
+/// Storage for the parts of a [`ParsedRange`].
+///
+/// The vast majority of ranges are a single comparator set (no `||`), which is
+/// kept inline on the stack; only disjunctions spill to the heap.
+pub type Parts = SmallVec<[RangePart; 1]>;
 
 /// A full semver range: multiple parts joined by `||`.
 #[derive(Debug, Clone)]
 pub struct ParsedRange {
-    pub parts: Vec<RangePart>,
+    pub parts: Parts,
 }
 
 impl ParsedRange {
@@ -17,14 +24,14 @@ impl ParsedRange {
         let input = input.trim();
         if input.is_empty() || is_wildcard_str(input) {
             return Ok(Self {
-                parts: vec![wildcard()],
+                parts: smallvec![wildcard()],
             });
         }
 
-        let mut parts: Vec<RangePart> = input
+        let mut parts: Parts = input
             .split("||")
             .map(|s| parse_comparator_set(s.trim()))
-            .collect::<Result<Vec<_>, _>>()?;
+            .collect::<Result<Parts, _>>()?;
 
         parts.sort_by(|a, b| a.min.cmp(&b.min));
 
@@ -61,7 +68,7 @@ impl ParsedRange {
     #[must_use]
     pub fn drop_first(&self) -> Self {
         Self {
-            parts: self.parts[1..].to_vec(),
+            parts: self.parts[1..].iter().cloned().collect(),
         }
     }
 
@@ -106,10 +113,10 @@ fn parse_comparator_set(input: &str) -> Result<RangePart, String> {
 
     // Split into whitespace-separated tokens, merging bare operators with next token.
     // This handles ">= 1.0.0", "< 2.0.0", "~ 1.0", "^ 1.2", "~> 1", etc.
-    let tokens = tokenize_comparator_set(input);
+    let tokens = comparator_tokens(input);
 
     if tokens.len() == 1 {
-        return parse_single_comparator(&tokens[0]);
+        return parse_single_comparator(tokens[0]);
     }
 
     // Multi-comparator: intersect all (e.g., ">=1.0.0 <2.0.0" or "~1.2.1 >=1.2.3")
@@ -119,7 +126,7 @@ fn parse_comparator_set(input: &str) -> Result<RangePart, String> {
     let mut max: Option<Version> = None;
     let mut max_op: Option<Op> = None;
 
-    for token in &tokens {
+    for &token in &tokens {
         let part = parse_single_comparator(token)?;
 
         // Take the higher lower bound
@@ -222,21 +229,50 @@ fn parse_single_comparator(token: &str) -> Result<RangePart, String> {
     })
 }
 
-/// Split a comparator set into tokens, merging bare operators with the
-/// following version token.  e.g. `">= 1.0.0 < 2.0.0"` → `[">=1.0.0", "<2.0.0"]`.
-fn tokenize_comparator_set(input: &str) -> Vec<String> {
-    let raw: Vec<&str> = input.split_whitespace().collect();
-    let mut tokens = Vec::new();
+/// Split a comparator set into borrowed tokens, merging a bare operator with the
+/// following version word.  e.g. `">= 1.0.0 < 2.0.0"` → `[">= 1.0.0", "< 2.0.0"]`.
+///
+/// Unlike the old `format!`-based tokenizer, a merged operator+version token is a
+/// slice of the original `input` spanning both words (the embedded whitespace is
+/// trimmed downstream by `strip_v`), so no `String` is allocated.
+fn comparator_tokens(input: &str) -> SmallVec<[&str; 2]> {
+    let bytes = input.as_bytes();
+    let len = bytes.len();
+    let mut tokens: SmallVec<[&str; 2]> = SmallVec::new();
     let mut i = 0;
-    while i < raw.len() {
-        if is_bare_operator(raw[i]) && i + 1 < raw.len() {
-            tokens.push(format!("{}{}", raw[i], raw[i + 1]));
-            i += 2;
-        } else {
-            tokens.push(raw[i].to_string());
+
+    while i < len {
+        while i < len && bytes[i].is_ascii_whitespace() {
             i += 1;
         }
+        if i >= len {
+            break;
+        }
+        let word_start = i;
+        while i < len && !bytes[i].is_ascii_whitespace() {
+            i += 1;
+        }
+        let word = &input[word_start..i];
+
+        // A bare operator merges with the following word into one borrowed slice.
+        if is_bare_operator(word) {
+            let mut j = i;
+            while j < len && bytes[j].is_ascii_whitespace() {
+                j += 1;
+            }
+            if j < len {
+                while j < len && !bytes[j].is_ascii_whitespace() {
+                    j += 1;
+                }
+                tokens.push(&input[word_start..j]);
+                i = j;
+                continue;
+            }
+        }
+
+        tokens.push(word);
     }
+
     tokens
 }
 
@@ -540,41 +576,49 @@ fn parse_partial_version(input: &str) -> Result<Version, String> {
     let input = strip_v(input);
     // Strip build metadata (+...)
     let input = input.split('+').next().unwrap_or(input);
-    // Separate prerelease (-...) but preserve it
-    let (base, pre) = if let Some(idx) = input.find('-') {
-        (&input[..idx], Some(&input[idx..]))
-    } else {
-        (input, None)
+
+    // No prerelease (the common case): build the version directly, skipping the
+    // `format!` + full `Version::parse` round-trip.
+    let Some(idx) = input.find('-') else {
+        let (major, minor, patch) = parse_core_components(input)?;
+        return Ok(Version::new(major, minor, patch));
     };
-    // Filter out x/*/X wildcard components, treating them as absent
-    let parts: Vec<&str> = base
-        .split('.')
-        .take_while(|p| !matches!(*p, "x" | "X" | "*"))
-        .collect();
-    let version_str = match parts.as_slice() {
-        [] => "0.0.0".to_string(),
-        [major] => {
-            parse_u64(major)?;
-            format!("{major}.0.0")
-        }
-        [major, minor] => {
-            parse_u64(major)?;
-            parse_u64(minor)?;
-            format!("{major}.{minor}.0")
-        }
-        [major, minor, patch] => {
-            parse_u64(major)?;
-            parse_u64(minor)?;
-            parse_u64(patch)?;
-            format!("{major}.{minor}.{patch}")
-        }
-        _ => return Err(format!("invalid partial version: {base}")),
-    };
-    let full = match pre {
-        Some(pre) => format!("{version_str}{pre}"),
-        None => version_str,
-    };
+
+    // Prerelease present: preserve the exact prior behaviour. Reassemble the
+    // normalized core with the original prerelease suffix and let `semver` parse
+    // it so prerelease identifiers are kept and validated.
+    let (major, minor, patch) = parse_core_components(&input[..idx])?;
+    let pre = &input[idx..];
+    let full = format!("{major}.{minor}.{patch}{pre}");
     Version::parse(&full).map_err(|e| format!("invalid version '{full}': {e}"))
+}
+
+/// Parse the numeric `major[.minor[.patch]]` core of a (possibly partial) version,
+/// treating `x`/`X`/`*` and any absent components as `0`.
+fn parse_core_components(base: &str) -> Result<(u64, u64, u64), String> {
+    let mut components = base
+        .split('.')
+        .take_while(|p| !matches!(*p, "x" | "X" | "*"));
+
+    let Some(major) = components.next() else {
+        return Ok((0, 0, 0));
+    };
+    let major = parse_u64(major)?;
+
+    let Some(minor) = components.next() else {
+        return Ok((major, 0, 0));
+    };
+    let minor = parse_u64(minor)?;
+
+    let Some(patch) = components.next() else {
+        return Ok((major, minor, 0));
+    };
+    let patch = parse_u64(patch)?;
+
+    if components.next().is_some() {
+        return Err(format!("invalid partial version: {base}"));
+    }
+    Ok((major, minor, patch))
 }
 
 /// Count the number of meaningful (non-wildcard) version components,

--- a/crates/riri-semver-range/src/parse.rs
+++ b/crates/riri-semver-range/src/parse.rs
@@ -114,6 +114,13 @@ fn parse_comparator_set(input: &str) -> Result<RangePart, String> {
         return parse_hyphen_range(&input[..idx], &input[idx + 3..]);
     }
 
+    // Single comparator over a fully-specified version (the common case): build it
+    // directly without tokenizing. A multi-comparator set has a space after the
+    // version, so `fast_comparator` returns `None` and we fall through to tokenize.
+    if let Some(part) = fast_comparator(input) {
+        return Ok(part);
+    }
+
     // Split into whitespace-separated tokens, merging bare operators with next token.
     // This handles ">= 1.0.0", "< 2.0.0", "~ 1.0", "^ 1.2", "~> 1", etc.
     let tokens = comparator_tokens(input);

--- a/crates/riri-semver-range/src/parse.rs
+++ b/crates/riri-semver-range/src/parse.rs
@@ -311,10 +311,17 @@ fn is_wildcard_str(s: &str) -> bool {
 }
 
 fn is_x_range(token: &str) -> bool {
-    token.contains('x')
-        || token.contains('X')
-        || token.contains('*')
-        || token.split('.').count() < 3
+    // Single pass: a wildcard byte makes it an x-range; otherwise fewer than three
+    // components (i.e. fewer than two dots) is a partial, which is also an x-range.
+    let mut dots = 0_usize;
+    for b in token.bytes() {
+        match b {
+            b'x' | b'X' | b'*' => return true,
+            b'.' => dots += 1,
+            _ => {}
+        }
+    }
+    dots < 2
 }
 
 /// `>=` with partial version support: `>=1.2` → `>=1.2.0`
@@ -410,8 +417,7 @@ fn parse_eq_range(input: &str) -> Result<RangePart, String> {
 }
 
 fn parse_caret(input: &str) -> Result<RangePart, String> {
-    let parts_count = version_component_count(input);
-    let v = parse_partial_version(input)?;
+    let (v, parts_count) = parse_partial_with_count(input)?;
 
     let upper = match parts_count {
         // ^0 → <1.0.0, ^1 → <2.0.0 (only major specified)
@@ -450,8 +456,7 @@ fn parse_caret(input: &str) -> Result<RangePart, String> {
 }
 
 fn parse_tilde(input: &str) -> Result<RangePart, String> {
-    let parts_count = version_component_count(input);
-    let v = parse_partial_version(input)?;
+    let (v, parts_count) = parse_partial_with_count(input)?;
     let upper = if parts_count == 1 {
         // ~1 means >=1.0.0 <2.0.0
         Version::new(v.major + 1, 0, 0)
@@ -589,6 +594,14 @@ fn parse_strict_version(input: &str) -> Result<Version, String> {
 }
 
 fn parse_partial_version(input: &str) -> Result<Version, String> {
+    parse_partial_with_count(input).map(|(version, _)| version)
+}
+
+/// Like [`parse_partial_version`], but also returns the number of explicit numeric
+/// components present before any wildcard (`0..=3`). Caret/tilde need this count to
+/// choose the upper bound, so version and count come from a single scan instead of
+/// scanning the token twice.
+fn parse_partial_with_count(input: &str) -> Result<(Version, usize), String> {
     let input = strip_v(input);
     // Strip build metadata (+...)
     let input = input.split('+').next().unwrap_or(input);
@@ -596,60 +609,47 @@ fn parse_partial_version(input: &str) -> Result<Version, String> {
     // No prerelease (the common case): build the version directly, skipping the
     // `format!` + full `Version::parse` round-trip.
     let Some(idx) = input.find('-') else {
-        let (major, minor, patch) = parse_core_components(input)?;
-        return Ok(Version::new(major, minor, patch));
+        let (major, minor, patch, count) = parse_core_components(input)?;
+        return Ok((Version::new(major, minor, patch), count));
     };
 
     // Prerelease present: preserve the exact prior behaviour. Reassemble the
     // normalized core with the original prerelease suffix and let `semver` parse
     // it so prerelease identifiers are kept and validated.
-    let (major, minor, patch) = parse_core_components(&input[..idx])?;
+    let (major, minor, patch, count) = parse_core_components(&input[..idx])?;
     let pre = &input[idx..];
     let full = format!("{major}.{minor}.{patch}{pre}");
-    Version::parse(&full).map_err(|e| format!("invalid version '{full}': {e}"))
+    let version = Version::parse(&full).map_err(|e| format!("invalid version '{full}': {e}"))?;
+    Ok((version, count))
 }
 
 /// Parse the numeric `major[.minor[.patch]]` core of a (possibly partial) version,
-/// treating `x`/`X`/`*` and any absent components as `0`.
-fn parse_core_components(base: &str) -> Result<(u64, u64, u64), String> {
+/// treating `x`/`X`/`*` and any absent components as `0`. Also returns how many
+/// explicit numeric components were present before any wildcard.
+fn parse_core_components(base: &str) -> Result<(u64, u64, u64, usize), String> {
     let mut components = base
         .split('.')
         .take_while(|p| !matches!(*p, "x" | "X" | "*"));
 
     let Some(major) = components.next() else {
-        return Ok((0, 0, 0));
+        return Ok((0, 0, 0, 0));
     };
     let major = parse_u64(major)?;
 
     let Some(minor) = components.next() else {
-        return Ok((major, 0, 0));
+        return Ok((major, 0, 0, 1));
     };
     let minor = parse_u64(minor)?;
 
     let Some(patch) = components.next() else {
-        return Ok((major, minor, 0));
+        return Ok((major, minor, 0, 2));
     };
     let patch = parse_u64(patch)?;
 
     if components.next().is_some() {
         return Err(format!("invalid partial version: {base}"));
     }
-    Ok((major, minor, patch))
-}
-
-/// Count the number of meaningful (non-wildcard) version components,
-/// stripping build metadata and prerelease before counting.
-fn version_component_count(input: &str) -> usize {
-    let clean = input.split('+').next().unwrap_or(input);
-    let clean = if let Some(idx) = clean.find('-') {
-        &clean[..idx]
-    } else {
-        clean
-    };
-    clean
-        .split('.')
-        .take_while(|p| !matches!(*p, "x" | "X" | "*"))
-        .count()
+    Ok((major, minor, patch, 3))
 }
 
 fn parse_u64(input: &str) -> Result<u64, String> {

--- a/crates/riri-semver-range/src/parse.rs
+++ b/crates/riri-semver-range/src/parse.rs
@@ -106,8 +106,11 @@ fn parse_comparator_set(input: &str) -> Result<RangePart, String> {
         return Ok(wildcard());
     }
 
-    // Hyphen range: "1.0.0 - 2.0.0"
-    if let Some(idx) = input.find(" - ") {
+    // Hyphen range: "1.0.0 - 2.0.0". The left side is always a version, never an
+    // operator, so skip the full-input scan for operator-led comparator sets.
+    if !matches!(input.as_bytes().first(), Some(b'^' | b'~' | b'>' | b'<' | b'='))
+        && let Some(idx) = input.find(" - ")
+    {
         return parse_hyphen_range(&input[..idx], &input[idx + 3..]);
     }
 
@@ -162,8 +165,188 @@ fn parse_comparator_set(input: &str) -> Result<RangePart, String> {
     })
 }
 
+/// Operator recognized by the byte-level fast path.
+#[derive(Clone, Copy)]
+enum FastOp {
+    Caret,
+    Tilde,
+    Gte,
+    Gt,
+    Lt,
+    Lte,
+    Exact,
+}
+
+/// Fast path for the common comparator shapes: an optional operator followed by a
+/// fully-specified `major.minor.patch` version (optionally with a `-prerelease`),
+/// e.g. `^1.2.3`, `>=16.0.0`, `~1.2.3`, `1.2.3`, `=1.2.3-alpha`, `> 1.0.0`.
+///
+/// Anything else — wildcards/x-ranges, partial versions, build metadata, hyphen
+/// ranges — returns `None` and is handled by the slower string-based parser, so
+/// this is a pure shortcut with no behavioural change.
+fn fast_comparator(token: &str) -> Option<RangePart> {
+    let bytes = token.as_bytes();
+    let mut i = skip_ascii_ws(bytes, 0);
+
+    let op = match (bytes.get(i).copied(), bytes.get(i + 1).copied()) {
+        (Some(b'^'), _) => {
+            i += 1;
+            FastOp::Caret
+        }
+        (Some(b'~'), Some(b'>')) => {
+            i += 2;
+            FastOp::Tilde
+        }
+        (Some(b'~'), _) => {
+            i += 1;
+            FastOp::Tilde
+        }
+        (Some(b'>'), Some(b'=')) => {
+            i += 2;
+            FastOp::Gte
+        }
+        (Some(b'>'), _) => {
+            i += 1;
+            FastOp::Gt
+        }
+        (Some(b'<'), Some(b'=')) => {
+            i += 2;
+            FastOp::Lte
+        }
+        (Some(b'<'), _) => {
+            i += 1;
+            FastOp::Lt
+        }
+        (Some(b'='), _) => {
+            i += 1;
+            FastOp::Exact
+        }
+        (Some(b'0'..=b'9' | b'v' | b'V'), _) => FastOp::Exact,
+        _ => return None,
+    };
+
+    i = skip_ascii_ws(bytes, i);
+    if matches!(bytes.get(i), Some(b'v' | b'V')) {
+        i += 1;
+    }
+
+    let (major, next) = take_u64(bytes, i)?;
+    i = next;
+    if bytes.get(i) != Some(&b'.') {
+        return None;
+    }
+    i += 1;
+    let (minor, next) = take_u64(bytes, i)?;
+    i = next;
+    if bytes.get(i) != Some(&b'.') {
+        return None;
+    }
+    i += 1;
+    let (patch, next) = take_u64(bytes, i)?;
+    i = next;
+
+    let version = match bytes.get(i).copied() {
+        None => Version::new(major, minor, patch),
+        Some(b'-') => {
+            let pre = &token[i..];
+            // Build metadata after the prerelease is left to the slow path.
+            if pre.as_bytes().contains(&b'+') {
+                return None;
+            }
+            Version::parse(&format!("{major}.{minor}.{patch}{pre}")).ok()?
+        }
+        // Build metadata, trailing wildcard, or stray bytes: defer to the slow path.
+        _ => return None,
+    };
+
+    Some(build_full_version_part(op, version))
+}
+
+/// Build the range part for an operator applied to a fully-specified version.
+/// Mirrors the slow-path operator handlers for the non-wildcard, full-version case.
+fn build_full_version_part(op: FastOp, v: Version) -> RangePart {
+    match op {
+        FastOp::Caret => {
+            let upper = if v.major == 0 {
+                if v.minor == 0 {
+                    Version::new(0, 0, v.patch + 1)
+                } else {
+                    Version::new(0, v.minor + 1, 0)
+                }
+            } else {
+                Version::new(v.major + 1, 0, 0)
+            };
+            RangePart {
+                min: v,
+                min_op: Op::Gte,
+                max: Some(upper),
+                max_op: Some(Op::Lt),
+            }
+        }
+        FastOp::Tilde => {
+            let upper = Version::new(v.major, v.minor + 1, 0);
+            RangePart {
+                min: v,
+                min_op: Op::Gte,
+                max: Some(upper),
+                max_op: Some(Op::Lt),
+            }
+        }
+        FastOp::Gte => RangePart {
+            min: v,
+            min_op: Op::Gte,
+            max: None,
+            max_op: None,
+        },
+        FastOp::Gt => RangePart {
+            min: v,
+            min_op: Op::Gt,
+            max: None,
+            max_op: None,
+        },
+        FastOp::Lt => RangePart {
+            min: Version::new(0, 0, 0),
+            min_op: Op::Gte,
+            max: Some(v),
+            max_op: Some(Op::Lt),
+        },
+        FastOp::Lte => RangePart {
+            min: Version::new(0, 0, 0),
+            min_op: Op::Gte,
+            max: Some(v),
+            max_op: Some(Op::Lte),
+        },
+        FastOp::Exact => exact_version_part(v),
+    }
+}
+
+fn skip_ascii_ws(bytes: &[u8], start: usize) -> usize {
+    let mut i = start;
+    while matches!(
+        bytes.get(i),
+        Some(b' ' | b'\t' | b'\n' | b'\r' | 0x0B | 0x0C)
+    ) {
+        i += 1;
+    }
+    i
+}
+
+fn take_u64(bytes: &[u8], start: usize) -> Option<(u64, usize)> {
+    let mut i = start;
+    let mut value: u64 = 0;
+    while let Some(&b @ b'0'..=b'9') = bytes.get(i) {
+        value = value.checked_mul(10)?.checked_add(u64::from(b - b'0'))?;
+        i += 1;
+    }
+    (i > start).then_some((value, i))
+}
+
 /// Parse a single comparator token.
 fn parse_single_comparator(token: &str) -> Result<RangePart, String> {
+    if let Some(part) = fast_comparator(token) {
+        return Ok(part);
+    }
+
     let token = strip_v(token);
     // Strip build metadata early so it doesn't interfere with pattern detection
     let token = token.split('+').next().unwrap_or(token);

--- a/crates/riri-semver-range/src/parse.rs
+++ b/crates/riri-semver-range/src/parse.rs
@@ -758,4 +758,74 @@ mod tests {
         assert!(r.satisfies(&Version::new(20, 0, 0)));
         assert!(!r.satisfies(&Version::new(15, 0, 0)));
     }
+
+    // --- Parsed-output assertions for prerelease ranges ---
+
+    fn pre(s: &str) -> Version {
+        Version::parse(s).expect("valid prerelease version")
+    }
+
+    #[test]
+    fn parse_caret_prerelease() {
+        let r = ParsedRange::parse("^1.2.3-alpha").expect("parse");
+        assert_eq!(r.parts[0].min, pre("1.2.3-alpha"));
+        assert_eq!(r.parts[0].min_op, Op::Gte);
+        assert_eq!(r.parts[0].max, Some(Version::new(2, 0, 0)));
+        assert_eq!(r.parts[0].max_op, Some(Op::Lt));
+    }
+
+    #[test]
+    fn parse_tilde_prerelease() {
+        let r = ParsedRange::parse("~1.2.3-beta").expect("parse");
+        assert_eq!(r.parts[0].min, pre("1.2.3-beta"));
+        assert_eq!(r.parts[0].max, Some(Version::new(1, 3, 0)));
+        assert_eq!(r.parts[0].max_op, Some(Op::Lt));
+    }
+
+    #[test]
+    fn parse_gte_prerelease_is_open() {
+        let r = ParsedRange::parse(">=1.2.3-rc.1").expect("parse");
+        assert_eq!(r.parts[0].min, pre("1.2.3-rc.1"));
+        assert_eq!(r.parts[0].min_op, Op::Gte);
+        assert!(r.parts[0].max.is_none());
+    }
+
+    #[test]
+    fn parse_hyphen_prerelease() {
+        let r = ParsedRange::parse("1.2.3-alpha - 2.0.0").expect("parse");
+        assert_eq!(r.parts[0].min, pre("1.2.3-alpha"));
+        assert_eq!(r.parts[0].max, Some(Version::new(2, 0, 0)));
+        assert_eq!(r.parts[0].max_op, Some(Op::Lte));
+    }
+
+    #[test]
+    fn parse_exact_prerelease_is_point_interval() {
+        // node-semver matches only the exact prerelease version, so we emit `>=v <=v`.
+        for input in ["1.2.3-alpha", "=1.2.3-alpha"] {
+            let r = ParsedRange::parse(input).expect("parse");
+            let v = pre("1.2.3-alpha");
+            assert_eq!(r.parts[0].min, v, "{input}");
+            assert_eq!(r.parts[0].min_op, Op::Gte, "{input}");
+            assert_eq!(r.parts[0].max, Some(v), "{input}");
+            assert_eq!(r.parts[0].max_op, Some(Op::Lte), "{input}");
+        }
+    }
+
+    #[test]
+    fn exact_prerelease_excludes_release_and_other_prereleases() {
+        let r = ParsedRange::parse("1.2.3-alpha").expect("parse");
+        assert!(r.satisfies(&pre("1.2.3-alpha")));
+        assert!(!r.satisfies(&Version::new(1, 2, 3)));
+        assert!(!r.satisfies(&pre("1.2.3-beta")));
+        assert!(!r.satisfies(&pre("1.2.3-alpha.1")));
+    }
+
+    #[test]
+    fn loose_prerelease_suffix_is_rejected() {
+        // node-semver loose mode accepts "1.2.3beta" / "^1.2.3beta"; we deliberately
+        // do not implement loose mode, so these must error rather than parse.
+        assert!(ParsedRange::parse("1.2.3beta").is_err());
+        assert!(ParsedRange::parse("^1.2.3beta").is_err());
+        assert!(ParsedRange::parse("~1.2.3beta").is_err());
+    }
 }

--- a/crates/riri-semver-range/src/parse.rs
+++ b/crates/riri-semver-range/src/parse.rs
@@ -221,12 +221,33 @@ fn parse_single_comparator(token: &str) -> Result<RangePart, String> {
 
     // Bare version: treat as exact
     let v = parse_strict_version(token)?;
-    Ok(RangePart {
-        min: v.clone(),
-        min_op: Op::Gte,
-        max: Some(Version::new(v.major, v.minor, v.patch + 1)),
-        max_op: Some(Op::Lt),
-    })
+    Ok(exact_version_part(v))
+}
+
+/// Build the range part for a fully-specified exact version (`1.2.3` or `=1.2.3`).
+///
+/// For a release this is `>=v <v.(patch+1)`, which is equivalent to `=v` over
+/// release versions. For a prerelease, node-semver matches only that exact
+/// version, so we use the inclusive point interval `>=v <=v` — otherwise the
+/// `<v.(patch+1)` upper bound would wrongly admit the release `v` and other
+/// prereleases on the same `[major, minor, patch]`.
+fn exact_version_part(v: Version) -> RangePart {
+    if v.pre.is_empty() {
+        let upper = Version::new(v.major, v.minor, v.patch + 1);
+        RangePart {
+            min: v,
+            min_op: Op::Gte,
+            max: Some(upper),
+            max_op: Some(Op::Lt),
+        }
+    } else {
+        RangePart {
+            min: v.clone(),
+            min_op: Op::Gte,
+            max: Some(v),
+            max_op: Some(Op::Lte),
+        }
+    }
 }
 
 /// Split a comparator set into borrowed tokens, merging a bare operator with the
@@ -385,12 +406,7 @@ fn parse_eq_range(input: &str) -> Result<RangePart, String> {
         return parse_x_range(input);
     }
     let v = parse_partial_version(input)?;
-    Ok(RangePart {
-        min: v.clone(),
-        min_op: Op::Gte,
-        max: Some(Version::new(v.major, v.minor, v.patch + 1)),
-        max_op: Some(Op::Lt),
-    })
+    Ok(exact_version_part(v))
 }
 
 fn parse_caret(input: &str) -> Result<RangePart, String> {

--- a/crates/riri-semver-range/tests/cross_validate_nodejs_semver.rs
+++ b/crates/riri-semver-range/tests/cross_validate_nodejs_semver.rs
@@ -79,6 +79,56 @@ const TEST_RANGES: &[&str] = &[
     "1.x - x",
 ];
 
+/// Versions carrying prerelease / build metadata, for prerelease-aware checks.
+const PRERELEASE_VERSIONS: &[&str] = &[
+    "1.2.2",
+    "1.2.3",
+    "1.2.4",
+    "1.3.0",
+    "2.0.0",
+    "1.2.3-alpha",
+    "1.2.3-alpha.1",
+    "1.2.3-alpha.2",
+    "1.2.3-beta",
+    "1.2.3-pre",
+    "1.2.3-pre.2",
+    "1.2.3-rc.1",
+    "1.2.4-alpha",
+    "1.2.0-pre",
+    "0.0.1-alpha",
+    "0.0.1-beta",
+    "0.0.1",
+    "0.1.1-alpha",
+    "0.1.1-beta",
+    "0.5.4-pre",
+    "0.5.5",
+    "2.0.0-beta",
+    "2.4.3-alpha",
+    "2.4.3-pre.2",
+];
+
+/// Range strings carrying prerelease / build metadata.
+const PRERELEASE_RANGES: &[&str] = &[
+    "1.2.3-alpha",
+    "=1.2.3-alpha",
+    ">=1.2.3-alpha",
+    ">1.2.3-alpha",
+    "<1.2.3-beta",
+    "<=1.2.3-beta",
+    "^1.2.3-alpha",
+    "^1.2.0-alpha",
+    "^0.0.1-alpha",
+    "^0.1.1-alpha",
+    "~1.2.3-beta",
+    "~v0.5.4-pre",
+    ">=1.2.3-alpha <1.2.3-beta",
+    "1.2.3-alpha - 2.0.0",
+    "1.2.3-pre+asdf - 2.4.3-pre+asdf",
+    "1.2.3 || >=2.0.0-beta",
+    "^1.2.3+build",
+    "1.2.3+asdf - 2.4.3+asdf",
+];
+
 fn nodejs_satisfies(range: &str, version: &str) -> Option<bool> {
     let r = nodejs_semver::Range::parse(range).ok()?;
     let v = nodejs_semver::Version::parse(version).ok()?;
@@ -110,6 +160,45 @@ fn cross_validate_satisfies() {
     assert!(
         mismatches.is_empty(),
         "Cross-validation found {} mismatches:\n{}",
+        mismatches.len(),
+        mismatches.join("\n")
+    );
+}
+
+#[test]
+fn cross_validate_satisfies_prerelease() {
+    let mut mismatches = Vec::new();
+    let mut compared = 0_usize;
+
+    for range in PRERELEASE_RANGES {
+        let Ok(our_range) = ParsedRange::parse(range) else {
+            continue;
+        };
+
+        for version in PRERELEASE_VERSIONS {
+            let Ok(v) = Version::parse(version) else {
+                continue;
+            };
+            let our_result = our_range.satisfies(&v);
+
+            if let Some(nodejs_result) = nodejs_satisfies(range, version) {
+                compared += 1;
+                if our_result != nodejs_result {
+                    mismatches.push(format!(
+                        "range={range:?} version={version:?}: ours={our_result} nodejs={nodejs_result}"
+                    ));
+                }
+            }
+        }
+    }
+
+    eprintln!(
+        "prerelease cross-validation: {compared} compared, {} mismatches",
+        mismatches.len()
+    );
+    assert!(
+        mismatches.is_empty(),
+        "prerelease cross-validation found {} mismatches:\n{}",
         mismatches.len(),
         mismatches.join("\n")
     );

--- a/crates/riri-semver-range/tests/proptest_invariants.rs
+++ b/crates/riri-semver-range/tests/proptest_invariants.rs
@@ -173,3 +173,61 @@ proptest! {
         );
     }
 }
+
+// --- Prerelease-aware strategies ---
+
+/// A prerelease suffix, possibly empty (e.g. `-alpha`, `-rc.1`, `-alpha.2`).
+fn arb_pre_tag() -> impl Strategy<Value = String> {
+    prop_oneof![
+        Just(String::new()),
+        Just("-alpha".to_string()),
+        Just("-beta".to_string()),
+        Just("-rc.1".to_string()),
+        Just("-pre.2".to_string()),
+        (0_u64..3).prop_map(|n| format!("-alpha.{n}")),
+    ]
+}
+
+/// Generate a version that frequently carries a prerelease tag.
+fn arb_pre_version() -> impl Strategy<Value = Version> {
+    (0_u64..4, 0_u64..4, 0_u64..4, arb_pre_tag())
+        .prop_map(|(ma, mi, pa, tag)| Version::parse(&format!("{ma}.{mi}.{pa}{tag}")).expect("valid"))
+}
+
+/// Generate range strings whose comparators frequently carry prerelease tags.
+fn arb_pre_range() -> impl Strategy<Value = String> {
+    let core = (0_u64..4, 0_u64..4, 0_u64..4);
+    prop_oneof![
+        (core.clone(), arb_pre_tag()).prop_map(|((a, b, c), t)| format!("^{a}.{b}.{c}{t}")),
+        (core.clone(), arb_pre_tag()).prop_map(|((a, b, c), t)| format!("~{a}.{b}.{c}{t}")),
+        (core.clone(), arb_pre_tag()).prop_map(|((a, b, c), t)| format!(">={a}.{b}.{c}{t}")),
+        (core.clone(), arb_pre_tag()).prop_map(|((a, b, c), t)| format!(">{a}.{b}.{c}{t}")),
+        (core.clone(), arb_pre_tag()).prop_map(|((a, b, c), t)| format!("<{a}.{b}.{c}{t}")),
+        // exact prerelease
+        (core.clone(), arb_pre_tag()).prop_map(|((a, b, c), t)| format!("{a}.{b}.{c}{t}")),
+        // hyphen with prerelease on either end
+        (core.clone(), arb_pre_tag(), core.clone(), arb_pre_tag())
+            .prop_map(|((a, b, c), t1, (d, e, f), t2)| format!("{a}.{b}.{c}{t1} - {d}.{e}.{f}{t2}")),
+    ]
+}
+
+// --- Invariant: satisfies matches nodejs-semver for prerelease inputs ---
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(2000))]
+    #[test]
+    fn satisfies_matches_nodejs_semver_prerelease(range in arb_pre_range(), v in arb_pre_version()) {
+        let Some(our_range) = try_parse(&range) else { return Ok(()); };
+        let v_str = format!("{v}");
+        let Ok(njs_range) = nodejs_semver::Range::parse(&range) else { return Ok(()); };
+        let Ok(njs_version) = nodejs_semver::Version::parse(&v_str) else { return Ok(()); };
+
+        let ours = our_range.satisfies(&v);
+        let theirs = njs_range.satisfies(&njs_version);
+        prop_assert!(
+            ours == theirs,
+            "prerelease satisfies mismatch for {:?} @ {}: ours={}, nodejs-semver={}",
+            range, v, ours, theirs
+        );
+    }
+}

--- a/docs/nodejs-semver-v5-analysis.md
+++ b/docs/nodejs-semver-v5-analysis.md
@@ -1,0 +1,343 @@
+# nodejs-semver v4.2.0 → v5.0.0: deep performance analysis
+
+What changed, why it is faster, and what it means for this repo.
+
+Source compared: crates.io `nodejs-semver-4.2.0` vs `nodejs-semver-5.0.0`
+(upstream `github.com/cijiugechu/nodejs-semver`, 5.0.0 released 2026-06-20).
+
+## TL;DR
+
+v5 keeps the existing `winnow` combinator parser as a **correctness fallback** and
+adds in front of it hand-written **byte-level fast paths** plus a **compact data
+layout**. Common inputs (plain versions, `^`/`~`/comparators/wildcards/hyphen/`||`)
+never touch `winnow` and allocate little or nothing. Net effect from upstream's own
+`cargo bench --bench parser` (same machine, same suite):
+
+| benchmark                                |     4.2.0 |     5.0.0 |    speedup |
+| ---------------------------------------- | --------: | --------: | ---------: |
+| `Version::parse("1.2.3")`                |  60.52 ns |   4.86 ns | **12.46x** |
+| `Version::parse("1.2.3-rc.4+build.7")`   | 109.02 ns |  65.00 ns |      1.68x |
+| `Range::parse("1.2.3")`                  | 333.84 ns |  35.91 ns |  **9.30x** |
+| `Range::parse(">=1.2.3 <2.0.0")`         | 464.21 ns | 103.39 ns |      4.49x |
+| `Range::parse(">=18 <20 \|\| >=22")`     | 584.19 ns | 261.19 ns |      2.24x |
+| `Range::parse("1.x.x")`                  | 314.54 ns |  58.80 ns |      5.35x |
+| parse + satisfy exact range              | 386.88 ns |  44.45 ns |      8.70x |
+| parse + satisfy wildcard range           | 365.71 ns |  65.97 ns |      5.54x |
+| filter version strings (current API)     | 774.59 ns | 221.29 ns |      3.50x |
+| pkg-manager corpus: resolved versions    |   7.97 µs | 914.05 ns |  **8.71x** |
+| pkg-manager corpus: range parse attempts |  40.91 µs |   7.39 µs |      5.54x |
+| pkg-manager corpus: version-then-range   |  21.61 µs |   5.29 µs |      4.09x |
+
+Grouped geomeans: version_parse **4.36x**, range_parse **4.20x**,
+range_parse_fallback **3.97x**, parse_and_satisfies **3.72x**, pkg-manager corpus **5.01x**.
+
+⚠️ Caveat: already-parsed `Range::satisfies` microbenchmarks (no parsing) are
+**mixed — 0.94x geomean**, i.e. slightly _slower_. The win is entirely in parsing
+and allocation, not in matching.
+
+## File-level diff
+
+| file                  | 4.2.0 | 5.0.0         | note                                          |
+| --------------------- | ----- | ------------- | --------------------------------------------- |
+| `src/lib.rs`          | 1552  | 2234          | Version layout rewrite, methods, `into_parts` |
+| `src/range.rs`        | 2636  | 2723          | `Range` = SmallVec, fast-path dispatch        |
+| `src/version_fast.rs` | —     | **148 (new)** | hand-rolled `Version::parse` fast path        |
+| `src/range/fast.rs`   | —     | **888 (new)** | hand-rolled `Range::parse` fast paths + SWAR  |
+
+`Cargo.toml`: edition `2021→2024`, MSRV `1.70.0→1.85.0`, added dependency
+`smallvec = "1.15"`.
+
+## The six optimizations
+
+### 1. Fast-path byte parsers tried before `winnow`
+
+Both entry points now try a hand-written byte scanner first and only fall through
+to the general `winnow` combinator parser when it returns `None`.
+
+`Version::parse` (`lib.rs`):
+
+```rust
+if input.len() > MAX_LENGTH { return Err(...); }
+if let Some(version) = version_fast::parse(input) { return Ok(version); }   // fast
+match version.parse_next(&mut input) { ... }                                // winnow fallback
+```
+
+`Range::parse` (`range.rs`) — a three-tier ladder, cheapest first:
+
+```rust
+if let Some(range) = fast::parse(input) { return Ok(range); }          // 1. structured fast path
+if should_skip_range_fallback(input) { return Err(...); }              //    cheap reject
+if let Some(range) = fast::parse_garbage(input) { return Ok(range); }  // 2. simple "garbage" path
+match range_set.parse_next(&mut input) { ... }                         // 3. winnow fallback
+```
+
+`version_fast::parse` is a linear single-pass byte walk: optional `v`/`V`, optional
+leading whitespace, then `core_number '.' core_number '.' core_number`, then a match
+on the next byte to branch into `+build`, `-prerelease`, loose alnum suffix, or end.
+Numbers parse with overflow-checked `checked_mul(10).checked_add(..)` and an explicit
+`> MAX_SAFE_INTEGER` guard — same validity rules as the slow path, none of the
+combinator/error-machinery overhead.
+
+`range::fast::parse` dispatches on the first byte: `^`→caret, `~`→tilde,
+`>`/`<`/`=`→comparator set, exact `x.y.z`, `x`/`X`/`*`→wildcard, digit/`v`→hyphen or
+wildcard. Each builds `BoundSet`s directly. This is where the 9.30x on `Range::parse("1.2.3")`
+comes from: the exact-version branch skips comparator parsing entirely.
+
+`winnow` is retained verbatim, so weird/rare inputs still parse correctly — the fast
+paths are pure additive shortcuts, returning `None` (never a wrong answer) on anything
+they do not fully recognize.
+
+### 2. SWAR byte scanning for short inputs (`ShortWord`)
+
+Picking the right fast sub-path needs cheap "does this contain `+` / `-` / `||`"
+probes. For inputs ≤ 16 bytes (`SHORT_SCAN_MAX`), v5 packs the string into one
+`u128` and searches all 16 lanes branchlessly:
+
+```rust
+fn matching_byte_lanes(word: u128, needle: u8) -> u128 {
+    let zero_bytes = word ^ repeated_byte(needle);          // matches → 0x00 lanes
+    zero_bytes.wrapping_sub(LOW_BITS) & !zero_bytes & HIGH_BITS  // classic zero-byte test
+}
+```
+
+- `contains_byte(needle)` = any lane matches within the active length.
+- `contains_repeated_pair(b'|')` = `mask & (mask >> 8)` → detects `||` adjacency in
+  a couple of ALU ops, replacing `str::contains("||")`.
+
+Inputs > 16 bytes fall back to `slice::contains` / `str::contains`. Almost every real
+npm version/range string is ≤ 16 bytes, so the SWAR path dominates. `active_byte_mask`
+masks off the zero padding so trailing `\0`s never produce false matches (covered by tests).
+
+### 3. Compact `Version` — no heap alloc for the common case
+
+```rust
+// v4.2.0  (~72 bytes, two Vec headers, two heap allocs even for "1.2.3")
+pub struct Version { pub major:u64, pub minor:u64, pub patch:u64,
+                     pub build:Vec<Identifier>, pub pre_release:Vec<Identifier> }
+
+// v5.0.0  (32 bytes; meta = None for plain versions → ZERO heap alloc)
+pub struct Version { major:u64, minor:u64, patch:u64, meta:Option<Box<VersionMeta>> }
+struct VersionMeta { build:Identifiers, pre_release:Identifiers }
+```
+
+`new_empty` / `new_with_identifiers` short-circuit to `meta: None` whenever both
+prerelease and build are empty. Prerelease/build metadata is boxed and allocated
+**only when actually present**. This is the single biggest contributor to the
+12.46x on `"1.2.3"` — the v4 version did two heap allocations for empty Vecs that
+v5 elides entirely.
+
+### 4. `Identifiers` inline-small enum
+
+```rust
+enum Identifiers { Empty, One(Identifier), Two([Identifier;2]), Many(Vec<Identifier>) }
+```
+
+Replaces `Vec<Identifier>`. The overwhelming majority of prerelease/build tags have
+0, 1, or 2 identifiers (`-rc.4`, `+build.7`, `-alpha.1`) and now live inline with no
+heap allocation; only 3+ spill to `Many(Vec)`. `push` grows `Empty → One → Two → Many`
+in place. This is why `"1.2.3-rc.4+build.7"` still improves (1.68x) despite needing metadata.
+
+### 5. `Range` = `SmallVec<[BoundSet; 1]>`
+
+```rust
+pub struct Range(SmallVec<[BoundSet; 1]>);   // was Vec<BoundSet>
+```
+
+The common range is a single comparator set (`^1`, `>=1 <2`, `1.x`, exact). It now
+stores its one `BoundSet` inline on the stack — no heap allocation. Only disjunctions
+(`||`, 2+ sets) spill to the heap. `from_bound_set` builds the inline-1 case directly;
+disjunction paths (`parse_or`, `parse_garbage`) use `from_bound_sets`.
+
+### 6. `VersionParts` + `into_parts()`, and privatized fields
+
+```rust
+pub fn into_parts(self) -> VersionParts   // moves prerelease/build Vecs out, no clone
+```
+
+Lets callers extract owned components without cloning the identifier vectors. The
+enabling change is that `Version`'s fields are now **private** (the breaking change):
+the internal `Option<Box<VersionMeta>>` / `Identifiers` representation can keep being
+tuned without breaking the public API again. Read access moved to methods:
+`major()`, `minor()`, `patch()`, `pre_release() -> &[Identifier]`, `build() -> &[Identifier]`.
+
+### Supporting: fallback gating
+
+Beyond the fast paths, v5 avoids `winnow` even on near-misses:
+
+- `should_skip_range_fallback` cheaply rejects single unparseable tokens before the
+  expensive parser runs.
+- `fast::parse_garbage` handles simple whitespace-separated "garbage" ranges
+  (`"1.2.3 foo"` → `1.2.3`) without `winnow`; bails (`None`) on anything with
+  operators/prerelease so correctness stays with the fallback.
+- `parse_or_if_present` only runs the `||`-splitting path when `contains_or_fast`
+  (SWAR) confirms a `||` is actually present.
+
+## Impact on this repo (`riri-node-tools`)
+
+`nodejs-semver` is **not a runtime dependency of any shipped crate**. It appears only
+in `crates/riri-semver-range` as:
+
+- **test oracle** — `tests/cross_validate_nodejs_semver.rs`, `tests/proptest_invariants.rs`
+  (`satisfies_matches_nodejs_semver`): we assert our own `riri-semver-range` matches
+  npm semantics by diffing against `nodejs_semver`.
+- **benchmark baseline** — `benches/range_parsing.rs`, `benches/range_satisfies.rs`:
+  `riri` vs `nodejs_semver` head-to-head.
+
+Both use only `Range::parse` / `Version::parse` — public, unchanged signatures. The
+v5 breaking changes (private fields, edition 2024, MSRV 1.85) touch none of our code,
+which is why the bump (`ba4033b`) was Cargo.toml + Cargo.lock only.
+
+Two consequences worth noting:
+
+1. **Benchmark baseline got 4–9x faster on parsing.** Any "we parse faster than
+   nodejs-semver" framing in `BENCHMARKS.md` / `range_parsing.rs` should be re-measured
+   against 5.0.0 — the gap narrowed substantially or may have flipped.
+2. **`satisfies` baseline barely moved (geomean 0.94x).** `range_satisfies.rs` parses
+   once then matches in a loop, so that comparison is largely unaffected by the v5 work.
+   Our MSRV must also be ≥ 1.85 to keep compiling the dev-dependency (workspace is
+   already edition 2024, so fine).
+
+## Feature comparison: `riri-semver-range` vs `nodejs-semver`
+
+They are **different kinds of tool**. `nodejs-semver` is a general-purpose, npm-compatible
+semver library (parse + match + compare). `riri-semver-range` is a domain-specific
+**npm `engines`-range analyzer and humanizer** that delegates version _representation_ to
+dtolnay `semver` and adds range-level _reasoning_ on top.
+
+### Only in `riri-semver-range`
+
+- `ParsedRange::humanize` / `humanize_with(VersionPrecision)` — render a range back to a
+  canonical human string (`^16.10.0`, `>=14.0.0 <18.0.0`); precision trimming of trailing `.0`.
+  This is the crate's reason to exist.
+- `restrictive_range(r1, r2)` — intersect two ranges into the tighter one.
+- `is_subset_of` / `intersects` — range-vs-range containment & overlap reasoning.
+- `split_by_major` — split a cross-major interval into one part per major.
+- `RangePart::is_caret` — recognize a normalized interval that came from a caret.
+- Explicit operator-interval model (`min`/`min_op`/`max`/`max_op`) — purpose-built for
+  humanizing and interval math, vs nodejs-semver's `BoundSet`/`Predicate` form.
+- `satisfies` with node-`engines`-focused prerelease filtering.
+
+### Only in `nodejs-semver` (and mostly not needed here)
+
+- Its own full `Version` type with prerelease/build identifier ordering (we use dtolnay
+  `semver::Version` for this — already correct and fast).
+- `max_satisfying` / `min_satisfying`, version `diff`, serde for `Version`/`Range`.
+- Broad npm compatibility for _weird_ inputs: loose suffixes (`1.2.3beta`), simple "garbage"
+  ranges (`1.2.3 foo`), and the full hyphen/prerelease/disjunction edge cases (explicitly
+  expanded in v5). Our parser handles the common engines subset; divergence on odd inputs is
+  exactly what `tests/cross_validate_nodejs_semver.rs` and `proptest_invariants.rs` guard.
+
+So a fair summary: we are not missing general features by accident — we deliberately cover a
+narrower, opinionated slice and add analysis nodejs-semver doesn't have.
+
+## Where our time actually goes
+
+Consumers (`riri-nce`, `riri-ncd`, `riri-napi-nce`) parse `engines` ranges across dependency
+trees, so `ParsedRange::parse` is on a hot path. Crucially, **dtolnay `semver::Version` is
+already compact and alloc-free for plain versions** — so unlike nodejs-semver v5, we do _not_
+need to rework a version type. Our waste is elsewhere: we decompose a version into `u64`s and
+then **re-serialize it to a `String` and re-parse it**, and we always heap-allocate the parts
+vector. The v5 techniques map onto these directly.
+
+## Perf opportunities, ranked
+
+### 1. Kill the String round-trip in `parse_partial_version` — biggest win
+
+`parse.rs:539-578` splits the input, validates each component with `parse_u64`, then does
+`format!("{major}.{minor}.{patch}")` and calls `semver::Version::parse(&full)` — re-parsing
+numbers it already has. For the no-prerelease case (the overwhelming majority of engine
+ranges) build the version directly:
+
+```rust
+// after parsing major/minor/patch as u64 and confirming no `-pre`:
+Version::new(major, minor, patch)          // alloc-free, no string, no re-parse
+// only when a prerelease is present, fall back to the format!+Version::parse path
+```
+
+This is the exact analog of nodejs-semver's `new_empty` fast path. Eliminates a `Vec<&str>`,
+a `String`, and a full semver re-parse per partial version — and partial versions are built
+for nearly every comparator (`^`, `~`, `>=`, x-ranges, bare).
+
+### 2. `ParsedRange.parts: SmallVec<[RangePart; 1]>`
+
+`parse.rs:6` — most engine ranges are a single comparator set (no `||`), yet `Vec<RangePart>`
+always heap-allocates. Switching to `SmallVec<[RangePart; 1]>` keeps the common single-part
+range entirely on the stack. Direct analog of v5's `Range(SmallVec<[BoundSet; 1]>)`. Cost: add
+`smallvec` as a real dependency (already in the tree via dev-deps) and update the few `.parts`
+constructors/iterators. `RangePart` is ~120 bytes, so inline-1 is fine; don't go to inline-2.
+
+### 3. Tokenize without `Vec<String>` + `format!`
+
+`tokenize_comparator_set` (`parse.rs:227-241`) builds owned `String`s, merging a bare operator
+with the next token via `format!("{}{}", op, ver)`. Rework so the merge passes the operator and
+the version slice **separately** into `parse_single_comparator` (e.g. a
+`parse_comparator(op: Option<&str>, ver: &str)`), so tokens stay `&str`. At minimum collect into
+`SmallVec<[&str; 2]>` of borrowed slices. Removes one `String` per token on the parse hot path.
+This is our version of the "scan bytes, don't allocate" fast path.
+
+### 4. Single-pass caret/tilde parsing
+
+`parse_caret`/`parse_tilde` (`parse.rs:360-415`) call `version_component_count(input)` — which
+scans the string (`split('+')`, `find('-')`, `split('.')`, `take_while`, `count`) — and then
+`parse_partial_version(input)` re-scans the same string. Two full passes for one short token.
+Have the partial-version parser return `(Version, component_count)` in a single walk.
+
+### 5. Single-pass `is_x_range`
+
+`is_x_range` (`parse.rs:256-261`) does up to four scans: `contains('x') || contains('X') ||
+contains('*') || split('.').count() < 3`. Called for every token. Fold into one byte walk that
+records whether any of `x`/`X`/`*` appears and counts `.` separators.
+
+### 6. (Secondary) trim clone/`Vec` churn in interval math
+
+`restrictive_range` clones whole `ParsedRange`s up to four times before doing work
+(`intersection.rs:13-31`); `split_by_major` returns `vec![part.clone()]` even on the no-split
+path (`helpers.rs:11,24`); `intersect_parts` clones versions on every bound pick. Colder than
+parse, but `restrictive_range` runs pairwise over split parts, so for multi-major ranges these
+add up. Consider `SmallVec` returns and borrowing where the part is unchanged.
+
+### Not worth it
+
+Reworking `RangePart` to drop the two full `semver::Version`s for a packed `(u64,u64,u64)` +
+optional prerelease would shrink the struct, but it churns the public API (`pub min: Version`)
+and dtolnay `Version` is already cheap to compare. Skip unless profiling says otherwise.
+
+### Suggested order
+
+Do **1 → 2 → 3** first (all parse-path, low risk, directly mirror v5, guarded by the existing
+cross-validate + proptest suites), re-run `benches/range_parsing.rs` against nodejs-semver
+5.0.0 to quantify, then decide on 4–6 from the numbers.
+
+## Implemented on this branch (1–3)
+
+All three parse-path optimizations are implemented and measured. Prerelease handling is
+**unchanged**: the fast path in #1 fires only when the token has no `-pre`; any prerelease
+token falls through to the original `format!` + `Version::parse` route, so identifiers are
+still parsed and validated.
+
+- **#1** `parse_partial_version` (`parse.rs`): no-prerelease tokens now build
+  `Version::new(major, minor, patch)` directly via a new `parse_core_components` helper —
+  no intermediate `String`, no full re-parse, no `Vec<&str>`.
+- **#2** `ParsedRange.parts` is now `SmallVec<[RangePart; 1]>` (type alias `Parts`). Single-part
+  ranges (no `||`) stay on the stack. Consumers were unaffected except three `ParsedRange { .. }`
+  construction sites in `riri-nce/src/policy.rs`, which gained a `.into()` (Vec → SmallVec, no new
+  dependency — `From<Vec>` resolves through the public field type).
+- **#3** `tokenize_comparator_set` (allocated a `Vec<String>` and `format!`-merged bare operators)
+  is replaced by `comparator_tokens`, which yields borrowed `&str` slices of the original input
+  (`SmallVec<[&str; 2]>`); a merged operator+version token is a single slice spanning both words,
+  with the embedded whitespace trimmed downstream by `strip_v`.
+
+### Measured (`cargo bench --bench range_parsing`, same machine, 8-range corpus)
+
+|                      | riri before |   riri after | nodejs-semver 5.0.0 |
+| -------------------- | ----------: | -----------: | ------------------: |
+| parse range (corpus) |    2.149 µs | **1.245 µs** |              832 ns |
+
+- **1.73x faster** than before (~42% less parse time).
+- Gap vs nodejs-semver 5.0.0 narrowed from **2.58x slower → 1.50x slower**.
+
+The residual gap is what opportunities **4–6** (single-pass caret/tilde + `is_x_range`, clone/Vec
+churn) plus the SWAR byte-probe trick would close. Our parser still uses `split`/`strip_prefix`
+and rescans tokens, whereas v5 is a fully hand-rolled byte walk. Verification: all 22 test suites
+pass, including `cross_validate_nodejs_semver` and `proptest_invariants`; clippy clean under the
+workspace's `pedantic = deny`.

--- a/docs/nodejs-semver-v5-analysis.md
+++ b/docs/nodejs-semver-v5-analysis.md
@@ -308,9 +308,9 @@ Do **1 → 2 → 3** first (all parse-path, low risk, directly mirror v5, guarde
 cross-validate + proptest suites), re-run `benches/range_parsing.rs` against nodejs-semver
 5.0.0 to quantify, then decide on 4–6 from the numbers.
 
-## Implemented on this branch (1–6)
+## Implemented on this branch (1–7)
 
-All six parse-path optimizations are implemented and measured. Prerelease handling is
+All seven parse-path optimizations are implemented and measured. Prerelease handling is
 **unchanged**: the fast path in #1 fires only when the token has no `-pre`; any prerelease
 token falls through to the original `format!` + `Version::parse` route, so identifiers are
 still parsed and validated.
@@ -334,20 +334,32 @@ still parsed and validated.
 - **#6** `split_by_major` returned `vec![part.clone()]` on the common no-split path (a heap alloc per
   part); it now returns `SmallVec<[RangePart; 1]>` (`SplitParts`), keeping the single part inline.
   Benefits the humanize / intersection / policy paths. `policy.rs` adapted with one `.into_vec()`.
+- **#7 (the big lever)** a byte-level `fast_comparator` fast path on `parse_single_comparator`,
+  modelled on v5's `range::fast::parse`. It handles an optional operator followed by a
+  fully-specified `major.minor.patch[-pre]` version (`^1.2.3`, `>=16.0.0`, `~1.2.3`, `1.2.3`,
+  `=1.2.3-alpha`, `> 1.0.0`) in a single byte walk — one operator dispatch, inline digit
+  accumulation, direct `RangePart` construction — collapsing all the per-token `split`/`strip_prefix`/
+  re-scan work. Wildcards/x-ranges, partials, build metadata and hyphen ranges return `None` and fall
+  through to the unchanged string parser, so it is a pure shortcut with no behavioural change. A
+  companion guard skips the full `" - "` hyphen scan for operator-led sets.
 
 ### Measured (`cargo bench --bench range_parsing`, same machine, 8-range corpus)
 
-|                      | before (main) | after #1–3 |   after #1–6 | nodejs-semver 5.0.0 |
-| -------------------- | ------------: | ---------: | -----------: | ------------------: |
-| parse range (corpus) |      2.149 µs |   1.245 µs | **1.071 µs** |              834 ns |
+|                      | before (main) | after #1–6 |    after #1–7 | nodejs-semver 5.0.0 |
+| -------------------- | ------------: | ---------: | ------------: | ------------------: |
+| parse range (corpus) |      2.149 µs |   1.071 µs | **581 ns** |              829 ns |
 
-- **2.01x faster** than before (~50% less parse time).
-- Gap vs nodejs-semver 5.0.0 narrowed from **2.58x slower → 1.28x slower**.
+- **3.70x faster** than before (~73% less parse time).
+- **Now faster than nodejs-semver 5.0.0**: 581 ns vs 829 ns — riri is **1.43x faster** (was 2.58x
+  slower before this work). 7 of the 8 corpus entries hit the fast path; the wildcard `1.2.x` and the
+  empty/`*` cases use the fallback.
 
-The residual gap (1.28x) is structural: our parser still does `split`/`strip_prefix` and re-derives
-`strip_v`/build-stripping per token, whereas v5 is a single fully hand-rolled byte walk with a SWAR
-short-string probe. Closing it would mean rewriting `parse_single_comparator` as one byte cursor
-that dispatches on the first byte and accumulates digits inline — the biggest remaining lift.
-Verification: all 22 test suites pass — including `cross_validate_nodejs_semver` (now with a
-prerelease corpus, 432 comparisons, 0 mismatches) and `proptest_invariants` (a 2000-case prerelease
-fuzz vs nodejs-semver) — and clippy is clean under the workspace's `pedantic = deny`.
+Verification: all 22 test suites pass — including `cross_validate_nodejs_semver` (non-prerelease +
+a prerelease corpus, 432 comparisons, 0 mismatches) and `proptest_invariants` (a 2000-case prerelease
+fuzz vs nodejs-semver, plus the existing non-prerelease fuzz) — and clippy is clean under the
+workspace's `pedantic = deny`. The fast path is validated by equivalence: any divergence from the
+slow path would surface as a cross-validation or fuzz mismatch.
+
+Remaining headroom is small and not worth the risk: the fallback still handles x-ranges/partials/
+hyphens with the string parser, and a SWAR short-string probe (v5 §2) would help only very long
+inputs, which engine ranges never are.

--- a/docs/nodejs-semver-v5-analysis.md
+++ b/docs/nodejs-semver-v5-analysis.md
@@ -308,15 +308,15 @@ Do **1 → 2 → 3** first (all parse-path, low risk, directly mirror v5, guarde
 cross-validate + proptest suites), re-run `benches/range_parsing.rs` against nodejs-semver
 5.0.0 to quantify, then decide on 4–6 from the numbers.
 
-## Implemented on this branch (1–3)
+## Implemented on this branch (1–6)
 
-All three parse-path optimizations are implemented and measured. Prerelease handling is
+All six parse-path optimizations are implemented and measured. Prerelease handling is
 **unchanged**: the fast path in #1 fires only when the token has no `-pre`; any prerelease
 token falls through to the original `format!` + `Version::parse` route, so identifiers are
 still parsed and validated.
 
 - **#1** `parse_partial_version` (`parse.rs`): no-prerelease tokens now build
-  `Version::new(major, minor, patch)` directly via a new `parse_core_components` helper —
+  `Version::new(major, minor, patch)` directly via a `parse_core_components` helper —
   no intermediate `String`, no full re-parse, no `Vec<&str>`.
 - **#2** `ParsedRange.parts` is now `SmallVec<[RangePart; 1]>` (type alias `Parts`). Single-part
   ranges (no `||`) stay on the stack. Consumers were unaffected except three `ParsedRange { .. }`
@@ -326,18 +326,28 @@ still parsed and validated.
   is replaced by `comparator_tokens`, which yields borrowed `&str` slices of the original input
   (`SmallVec<[&str; 2]>`); a merged operator+version token is a single slice spanning both words,
   with the embedded whitespace trimmed downstream by `strip_v`.
+- **#4** caret/tilde no longer scan the token twice. `version_component_count` is gone; the new
+  `parse_partial_with_count` returns the version **and** the component count from one scan, which
+  `parse_caret`/`parse_tilde` consume — relevant because `^` is the most common range form.
+- **#5** `is_x_range` was up to four scans (`contains('x')` ×3 + `split('.').count()`); now a single
+  byte pass that early-returns on a wildcard byte and counts dots otherwise.
+- **#6** `split_by_major` returned `vec![part.clone()]` on the common no-split path (a heap alloc per
+  part); it now returns `SmallVec<[RangePart; 1]>` (`SplitParts`), keeping the single part inline.
+  Benefits the humanize / intersection / policy paths. `policy.rs` adapted with one `.into_vec()`.
 
 ### Measured (`cargo bench --bench range_parsing`, same machine, 8-range corpus)
 
-|                      | riri before |   riri after | nodejs-semver 5.0.0 |
-| -------------------- | ----------: | -----------: | ------------------: |
-| parse range (corpus) |    2.149 µs | **1.245 µs** |              832 ns |
+|                      | before (main) | after #1–3 |   after #1–6 | nodejs-semver 5.0.0 |
+| -------------------- | ------------: | ---------: | -----------: | ------------------: |
+| parse range (corpus) |      2.149 µs |   1.245 µs | **1.071 µs** |              834 ns |
 
-- **1.73x faster** than before (~42% less parse time).
-- Gap vs nodejs-semver 5.0.0 narrowed from **2.58x slower → 1.50x slower**.
+- **2.01x faster** than before (~50% less parse time).
+- Gap vs nodejs-semver 5.0.0 narrowed from **2.58x slower → 1.28x slower**.
 
-The residual gap is what opportunities **4–6** (single-pass caret/tilde + `is_x_range`, clone/Vec
-churn) plus the SWAR byte-probe trick would close. Our parser still uses `split`/`strip_prefix`
-and rescans tokens, whereas v5 is a fully hand-rolled byte walk. Verification: all 22 test suites
-pass, including `cross_validate_nodejs_semver` and `proptest_invariants`; clippy clean under the
-workspace's `pedantic = deny`.
+The residual gap (1.28x) is structural: our parser still does `split`/`strip_prefix` and re-derives
+`strip_v`/build-stripping per token, whereas v5 is a single fully hand-rolled byte walk with a SWAR
+short-string probe. Closing it would mean rewriting `parse_single_comparator` as one byte cursor
+that dispatches on the first byte and accumulates digits inline — the biggest remaining lift.
+Verification: all 22 test suites pass — including `cross_validate_nodejs_semver` (now with a
+prerelease corpus, 432 comparisons, 0 mismatches) and `proptest_invariants` (a 2000-case prerelease
+fuzz vs nodejs-semver) — and clippy is clean under the workspace's `pedantic = deny`.

--- a/docs/nodejs-semver-v5-analysis.md
+++ b/docs/nodejs-semver-v5-analysis.md
@@ -363,3 +363,20 @@ slow path would surface as a cross-validation or fuzz mismatch.
 Remaining headroom is small and not worth the risk: the fallback still handles x-ranges/partials/
 hyphens with the string parser, and a SWAR short-string probe (v5 §2) would help only very long
 inputs, which engine ranges never are.
+
+### Beyond parse (other hot paths)
+
+The crate's other operations were measured too:
+
+| operation                         |      riri | nodejs-semver 5.0.0 | note                          |
+| --------------------------------- | --------: | ------------------: | ----------------------------- |
+| `satisfies` (already-parsed)      | 27.9 ns |             31.9 ns | riri 1.14x faster; left as-is |
+| `restrictive_range` (8 pairs)     |   694 ns |                 n/a | was 740 ns                    |
+| parse + `restrictive_range` (×8)  |  1.91 µs |                 n/a | was 1.98 µs                   |
+
+- **satisfies** is already leaner than nodejs-semver and dominated by `semver::Version` comparisons —
+  no change made.
+- **restrictive_range** (used by the policy/`npm_bump` range narrowing) heap-allocated three `Vec`s
+  per call (`a_parts`, `b_parts`, `result_parts`); these are now `SmallVec`, inline for the common
+  one/two-part ranges. The residual cost is the `is_subset_of`/`intersects` pre-checks and the
+  per-bound `Version` clones, which are structural and low-value to chase further.


### PR DESCRIPTION
## Summary

Speeds up `riri-semver-range` range parsing and fixes a prerelease correctness bug surfaced by
expanded cross-validation. `ParsedRange::parse` is now **3.7x faster** with no behavioural change on
the common path.

## Performance (`cargo bench`, same machine)

| operation | before | after |
|---|---:|---:|
| parse (8-range corpus) | 2.149 µs | **581 ns** |
| satisfies (already-parsed) | — | **27.9 ns** |
| restrictive_range (8 pairs) | 740 ns | **694 ns** |

### What changed (parse path)

1. No-prerelease tokens build `Version::new(maj,min,pat)` directly — no `String` round-trip / re-parse.
2. `ParsedRange.parts` → `SmallVec<[RangePart; 1]>` (single-part ranges stay on the stack).
3. Borrowed `&str` comparator tokens instead of `Vec<String>` + `format!`.
4. One-pass caret/tilde (`parse_partial_with_count` replaces a double scan).
5. Single-pass `is_x_range` (was up to 4 scans).
6. `split_by_major` returns `SmallVec` (no heap alloc on the common no-split path).
7. **Byte-level `fast_comparator` fast path**: operator + full `major.minor.patch[-pre]` parsed in one
   byte walk; wildcards/partials/build/hyphen fall through to the unchanged string parser. The big lever.
8. `restrictive_range` keeps its intersection working sets inline (`SmallVec`).

The fast path is a pure shortcut — anything it doesn't fully recognize returns `None` and is handled
by the existing parser, so there is no behavioural change.

## Correctness fix

Expanded cross-validation found that an exact prerelease range (e.g. `1.2.3-alpha`) expanded to
`>=v <v.(patch+1)`, which wrongly admitted the release `v` and sibling prereleases. Per npm range
semantics it must match **only** the exact version. Fixed: exact prerelease now emits the point
interval `>=v <=v`. Release behaviour is unchanged.

## Tests

- Prerelease corpus added to cross-validation (432 comparisons, 0 mismatches).
- New 2000-case prerelease property fuzz.
- Parse-output fixtures for prerelease ranges; loose-suffix rejection pinned as a deliberate decision.

All 22 test suites pass; clippy clean under the workspace's `pedantic = deny`.

## Docs

Adds a performance analysis doc under `docs/` — the deep-dive plus the full record of the
optimizations applied here with measurements.
