### PR TITLE
perf(semver-range): byte-level parse fast path & exact-prerelease fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1666,6 +1666,7 @@ dependencies = [
  "nodejs-semver",
  "proptest",
  "semver",
+ "smallvec",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,10 +29,11 @@ semver = "1.0.28"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = { version = "1.0.150", features = ["preserve_order"] }
 serde-saphyr = "0.0.28"
+smallvec = "1.15.2"
 tracing = "0.1.44"
 thiserror = "2.0.18"
 tracing-subscriber = "0.3.23"
-ureq = "3.3"
+ureq = "3.3.0"
 
 # napi
 napi = { version = "3.9.3", default-features = false, features = ["napi6", "serde-json"] }

--- a/crates/riri-nce/src/policy.rs
+++ b/crates/riri-nce/src/policy.rs
@@ -76,7 +76,7 @@ pub fn rewrite_node_range(
         let baseline = if is_wildcard(input_part) {
             Vec::new()
         } else {
-            split_by_major(input_part)
+            split_by_major(input_part).into_vec()
         };
         if contributions != baseline {
             let rewritten_part = humanize_parts(&contributions, ctx.precision);
@@ -113,7 +113,9 @@ pub fn rewrite_node_range(
         }
     }
 
-    let rebuilt = ParsedRange { parts: new_parts };
+    let rebuilt = ParsedRange {
+        parts: new_parts.into(),
+    };
     let rewritten = rebuilt.humanize_with(ctx.precision);
 
     Ok(PolicyResult {
@@ -206,14 +208,14 @@ fn caret_from_major(m: u32) -> RangePart {
 
 fn humanize_part(part: &RangePart, precision: VersionPrecision) -> String {
     ParsedRange {
-        parts: vec![part.clone()],
+        parts: vec![part.clone()].into(),
     }
     .humanize_with(precision)
 }
 
 fn humanize_parts(parts: &[RangePart], precision: VersionPrecision) -> String {
     ParsedRange {
-        parts: parts.to_vec(),
+        parts: parts.to_vec().into(),
     }
     .humanize_with(precision)
 }

--- a/crates/riri-semver-range/Cargo.toml
+++ b/crates/riri-semver-range/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 
 [dependencies]
 semver = { workspace = true }
+smallvec = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
@@ -18,11 +19,19 @@ name = "range_parsing"
 harness = false
 
 [[bench]]
+name = "range_parsing_breakdown"
+harness = false
+
+[[bench]]
 name = "range_satisfies"
 harness = false
 
 [[bench]]
 name = "range_intersection"
+harness = false
+
+[[bench]]
+name = "range_humanize"
 harness = false
 
 [lints]

--- a/crates/riri-semver-range/benches/range_humanize.rs
+++ b/crates/riri-semver-range/benches/range_humanize.rs
@@ -1,0 +1,41 @@
+use criterion::{Criterion, criterion_group, criterion_main};
+use riri_semver_range::{ParsedRange, VersionPrecision};
+use std::hint::black_box;
+
+const RANGES: &[&str] = &[
+    "^1.2.3",
+    ">=16.0.0",
+    ">=14.0.0 <18.0.0",
+    "^14.17.0 || ^16.10.0 || >=17.0.0",
+    "1.2.x",
+    "*",
+    "~1.2.3",
+    ">=1.0.0 <2.0.0 || >=3.0.0",
+    "1.0.0",
+];
+
+fn bench_humanize(c: &mut Criterion) {
+    let parsed: Vec<_> = RANGES
+        .iter()
+        .map(|r| ParsedRange::parse(r).expect("parse range"))
+        .collect();
+
+    c.bench_function("riri: humanize (full)", |b| {
+        b.iter(|| {
+            for r in &parsed {
+                black_box(r.humanize());
+            }
+        });
+    });
+
+    c.bench_function("riri: humanize (major)", |b| {
+        b.iter(|| {
+            for r in &parsed {
+                black_box(r.humanize_with(VersionPrecision::Major));
+            }
+        });
+    });
+}
+
+criterion_group!(benches, bench_humanize);
+criterion_main!(benches);

--- a/crates/riri-semver-range/benches/range_parsing_breakdown.rs
+++ b/crates/riri-semver-range/benches/range_parsing_breakdown.rs
@@ -1,0 +1,25 @@
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
+
+const RANGES: &[(&str, &str)] = &[
+    ("or3_caret", "^14.17.0 || ^16.10.0 || >=17.0.0"),
+    ("single_gte", ">=16.0.0"),
+    ("or2_caret", "^18.0.0 || ^20.0.0"),
+    ("multi_cmp", ">=14.0.0 <18.0.0"),
+    ("wildcard", "*"),
+    ("tilde", "~1.2.3"),
+    ("xrange", "1.2.x"),
+    ("or_multi", ">=1.0.0 <2.0.0 || >=3.0.0"),
+    ("caret_full", "^1.2.3"),
+];
+
+fn bench(c: &mut Criterion) {
+    for (name, range) in RANGES {
+        c.bench_function(name, |b| {
+            b.iter(|| black_box(riri_semver_range::ParsedRange::parse(black_box(range))));
+        });
+    }
+}
+
+criterion_group!(benches, bench);
+criterion_main!(benches);

--- a/crates/riri-semver-range/src/helpers.rs
+++ b/crates/riri-semver-range/src/helpers.rs
@@ -1,29 +1,30 @@
-use crate::{Op, RangePart};
+use crate::{Op, Parts, RangePart};
 use semver::Version;
+use smallvec::{SmallVec, smallvec};
 
 /// Split a cross-major range part into one part per major version.
 ///
 /// e.g., `>=16.10.0 <18.0.0` → `[^16.10.0, ^17.0.0]`
 /// e.g., `>=0.0.0 <=2.0.0` → `[^0.0.0, ^1.0.0, 2.0.0]`
 #[must_use]
-pub fn split_by_major(part: &RangePart) -> Vec<RangePart> {
+pub fn split_by_major(part: &RangePart) -> Parts {
     let Some(max) = &part.max else {
-        return vec![part.clone()];
+        return smallvec![part.clone()];
     };
 
     // Compute the effective exclusive upper major boundary
     let end_major = match part.max_op {
         Some(Op::Lt) => max.major,
         Some(Op::Lte) => max.major + 1,
-        _ => return vec![part.clone()],
+        _ => return smallvec![part.clone()],
     };
 
     // Only split if the part spans more than one major
     if end_major <= part.min.major + 1 {
-        return vec![part.clone()];
+        return smallvec![part.clone()];
     }
 
-    let mut parts = Vec::new();
+    let mut parts: Parts = SmallVec::new();
     for major in part.min.major..end_major {
         let min = if major == part.min.major {
             part.min.clone()

--- a/crates/riri-semver-range/src/intersection.rs
+++ b/crates/riri-semver-range/src/intersection.rs
@@ -1,6 +1,7 @@
 use crate::helpers::split_by_major;
 use crate::subset::{intersects, is_subset_of};
-use crate::{Op, ParsedRange, RangePart};
+use crate::{Op, ParsedRange, Parts, RangePart};
+use smallvec::SmallVec;
 
 /// Compute the most restrictive intersection of two ranges.
 ///
@@ -29,12 +30,12 @@ pub fn restrictive_range(r1: &ParsedRange, r2: &ParsedRange) -> ParsedRange {
         return r1.clone();
     }
 
-    // Split both ranges into one part per major version
-    let a_parts: Vec<_> = r1.parts.iter().flat_map(split_by_major).collect();
-    let b_parts: Vec<_> = r2.parts.iter().flat_map(split_by_major).collect();
+    // Split each range into one part per major (inline for the common 1–2 part case).
+    let a_parts: SmallVec<[RangePart; 2]> = r1.parts.iter().flat_map(split_by_major).collect();
+    let b_parts: SmallVec<[RangePart; 2]> = r2.parts.iter().flat_map(split_by_major).collect();
 
     // Pairwise interval intersection
-    let mut result_parts = Vec::new();
+    let mut result_parts: Parts = SmallVec::new();
     for a_part in &a_parts {
         for b_part in &b_parts {
             if let Some(intersection) = intersect_parts(a_part, b_part) {

--- a/crates/riri-semver-range/src/lib.rs
+++ b/crates/riri-semver-range/src/lib.rs
@@ -6,7 +6,7 @@ pub(crate) mod subset;
 
 pub use helpers::split_by_major;
 pub use intersection::restrictive_range;
-pub use parse::ParsedRange;
+pub use parse::{ParsedRange, Parts};
 pub use subset::{intersects, is_subset_of};
 
 use semver::Version;

--- a/crates/riri-semver-range/src/parse.rs
+++ b/crates/riri-semver-range/src/parse.rs
@@ -1,10 +1,17 @@
 use crate::{Op, RangePart};
 use semver::Version;
+use smallvec::{SmallVec, smallvec};
+
+/// Storage for the parts of a [`ParsedRange`].
+///
+/// The vast majority of ranges are a single comparator set (no `||`), which is
+/// kept inline on the stack; only disjunctions spill to the heap.
+pub type Parts = SmallVec<[RangePart; 1]>;
 
 /// A full semver range: multiple parts joined by `||`.
 #[derive(Debug, Clone)]
 pub struct ParsedRange {
-    pub parts: Vec<RangePart>,
+    pub parts: Parts,
 }
 
 impl ParsedRange {
@@ -17,14 +24,14 @@ impl ParsedRange {
         let input = input.trim();
         if input.is_empty() || is_wildcard_str(input) {
             return Ok(Self {
-                parts: vec![wildcard()],
+                parts: smallvec![wildcard()],
             });
         }
 
-        let mut parts: Vec<RangePart> = input
+        let mut parts: Parts = input
             .split("||")
             .map(|s| parse_comparator_set(s.trim()))
-            .collect::<Result<Vec<_>, _>>()?;
+            .collect::<Result<Parts, _>>()?;
 
         parts.sort_by(|a, b| a.min.cmp(&b.min));
 
@@ -61,7 +68,7 @@ impl ParsedRange {
     #[must_use]
     pub fn drop_first(&self) -> Self {
         Self {
-            parts: self.parts[1..].to_vec(),
+            parts: self.parts[1..].iter().cloned().collect(),
         }
     }
 
@@ -99,17 +106,26 @@ fn parse_comparator_set(input: &str) -> Result<RangePart, String> {
         return Ok(wildcard());
     }
 
-    // Hyphen range: "1.0.0 - 2.0.0"
-    if let Some(idx) = input.find(" - ") {
+    // Hyphen range: "1.0.0 - 2.0.0" (never operator-led).
+    if !matches!(
+        input.as_bytes().first(),
+        Some(b'^' | b'~' | b'>' | b'<' | b'=')
+    ) && let Some(idx) = input.find(" - ")
+    {
         return parse_hyphen_range(&input[..idx], &input[idx + 3..]);
+    }
+
+    // Single fully-specified comparator: built directly; others fall through to tokenize.
+    if let Some(part) = fast_comparator(input) {
+        return Ok(part);
     }
 
     // Split into whitespace-separated tokens, merging bare operators with next token.
     // This handles ">= 1.0.0", "< 2.0.0", "~ 1.0", "^ 1.2", "~> 1", etc.
-    let tokens = tokenize_comparator_set(input);
+    let tokens = comparator_tokens(input);
 
     if tokens.len() == 1 {
-        return parse_single_comparator(&tokens[0]);
+        return parse_single_comparator(tokens[0]);
     }
 
     // Multi-comparator: intersect all (e.g., ">=1.0.0 <2.0.0" or "~1.2.1 >=1.2.3")
@@ -119,7 +135,7 @@ fn parse_comparator_set(input: &str) -> Result<RangePart, String> {
     let mut max: Option<Version> = None;
     let mut max_op: Option<Op> = None;
 
-    for token in &tokens {
+    for &token in &tokens {
         let part = parse_single_comparator(token)?;
 
         // Take the higher lower bound
@@ -155,8 +171,162 @@ fn parse_comparator_set(input: &str) -> Result<RangePart, String> {
     })
 }
 
+/// Operator recognized by the byte-level fast path.
+#[derive(Clone, Copy)]
+enum FastOp {
+    Caret,
+    Tilde,
+    Gte,
+    Gt,
+    Lt,
+    Lte,
+    Exact,
+}
+
+/// Fast path for an optional operator + fully-specified `major.minor.patch[-pre]`
+/// version. Returns `None` for anything else (wildcards, partials, build metadata,
+/// hyphen ranges) so the string parser handles it — a pure shortcut, no behaviour change.
+fn fast_comparator(token: &str) -> Option<RangePart> {
+    let bytes = token.as_bytes();
+    let mut i = skip_ascii_ws(bytes, 0);
+
+    let op = match (bytes.get(i).copied(), bytes.get(i + 1).copied()) {
+        (Some(b'^'), _) => {
+            i += 1;
+            FastOp::Caret
+        }
+        (Some(b'~'), Some(b'>')) => {
+            i += 2;
+            FastOp::Tilde
+        }
+        (Some(b'~'), _) => {
+            i += 1;
+            FastOp::Tilde
+        }
+        (Some(b'>'), Some(b'=')) => {
+            i += 2;
+            FastOp::Gte
+        }
+        (Some(b'>'), _) => {
+            i += 1;
+            FastOp::Gt
+        }
+        (Some(b'<'), Some(b'=')) => {
+            i += 2;
+            FastOp::Lte
+        }
+        (Some(b'<'), _) => {
+            i += 1;
+            FastOp::Lt
+        }
+        (Some(b'='), _) => {
+            i += 1;
+            FastOp::Exact
+        }
+        (Some(b'0'..=b'9' | b'v' | b'V'), _) => FastOp::Exact,
+        _ => return None,
+    };
+
+    i = skip_ascii_ws(bytes, i);
+    if matches!(bytes.get(i), Some(b'v' | b'V')) {
+        i += 1;
+    }
+
+    let (major, next) = take_u64(bytes, i)?;
+    i = next;
+    if bytes.get(i) != Some(&b'.') {
+        return None;
+    }
+    i += 1;
+    let (minor, next) = take_u64(bytes, i)?;
+    i = next;
+    if bytes.get(i) != Some(&b'.') {
+        return None;
+    }
+    i += 1;
+    let (patch, next) = take_u64(bytes, i)?;
+    i = next;
+
+    let version = match bytes.get(i).copied() {
+        None => Version::new(major, minor, patch),
+        Some(b'-') => {
+            let pre = &token[i..];
+            if pre.as_bytes().contains(&b'+') {
+                return None;
+            }
+            Version::parse(&format!("{major}.{minor}.{patch}{pre}")).ok()?
+        }
+        _ => return None,
+    };
+
+    Some(build_full_version_part(op, version))
+}
+
+/// Upper bound (exclusive) for a caret over a fully-specified version.
+fn caret_upper_bound(v: &Version) -> Version {
+    if v.major == 0 {
+        if v.minor == 0 {
+            Version::new(0, 0, v.patch + 1)
+        } else {
+            Version::new(0, v.minor + 1, 0)
+        }
+    } else {
+        Version::new(v.major + 1, 0, 0)
+    }
+}
+
+/// Build the range part for an operator applied to a fully-specified version.
+fn build_full_version_part(op: FastOp, v: Version) -> RangePart {
+    let (min, min_op, max, max_op) = match op {
+        FastOp::Caret => {
+            let upper = caret_upper_bound(&v);
+            (v, Op::Gte, Some(upper), Some(Op::Lt))
+        }
+        FastOp::Tilde => {
+            let upper = Version::new(v.major, v.minor + 1, 0);
+            (v, Op::Gte, Some(upper), Some(Op::Lt))
+        }
+        FastOp::Gte => (v, Op::Gte, None, None),
+        FastOp::Gt => (v, Op::Gt, None, None),
+        FastOp::Lt => (Version::new(0, 0, 0), Op::Gte, Some(v), Some(Op::Lt)),
+        FastOp::Lte => (Version::new(0, 0, 0), Op::Gte, Some(v), Some(Op::Lte)),
+        FastOp::Exact => return exact_version_part(v),
+    };
+    RangePart {
+        min,
+        min_op,
+        max,
+        max_op,
+    }
+}
+
+fn skip_ascii_ws(bytes: &[u8], start: usize) -> usize {
+    let mut i = start;
+    while matches!(
+        bytes.get(i),
+        Some(b' ' | b'\t' | b'\n' | b'\r' | 0x0B | 0x0C)
+    ) {
+        i += 1;
+    }
+    i
+}
+
+fn take_u64(bytes: &[u8], start: usize) -> Option<(u64, usize)> {
+    let mut i = start;
+    let mut value: u64 = 0;
+    while let Some(&b @ b'0'..=b'9') = bytes.get(i) {
+        value = value.checked_mul(10)?.checked_add(u64::from(b - b'0'))?;
+        i += 1;
+    }
+    (i > start).then_some((value, i))
+}
+
 /// Parse a single comparator token.
 fn parse_single_comparator(token: &str) -> Result<RangePart, String> {
+    if let Some(part) = fast_comparator(token) {
+        return Ok(part);
+    }
+
     let token = strip_v(token);
     // Strip build metadata early so it doesn't interfere with pattern detection
     let token = token.split('+').next().unwrap_or(token);
@@ -214,29 +384,66 @@ fn parse_single_comparator(token: &str) -> Result<RangePart, String> {
 
     // Bare version: treat as exact
     let v = parse_strict_version(token)?;
-    Ok(RangePart {
-        min: v.clone(),
-        min_op: Op::Gte,
-        max: Some(Version::new(v.major, v.minor, v.patch + 1)),
-        max_op: Some(Op::Lt),
-    })
+    Ok(exact_version_part(v))
 }
 
-/// Split a comparator set into tokens, merging bare operators with the
-/// following version token.  e.g. `">= 1.0.0 < 2.0.0"` → `[">=1.0.0", "<2.0.0"]`.
-fn tokenize_comparator_set(input: &str) -> Vec<String> {
-    let raw: Vec<&str> = input.split_whitespace().collect();
-    let mut tokens = Vec::new();
+/// Build the range part for a fully-specified exact version (`1.2.3` or `=1.2.3`).
+///
+/// Release → `>=v <v.(patch+1)` (equivalent to `=v`). Prerelease → the point
+/// interval `>=v <=v`, since node-semver matches only that exact prerelease.
+fn exact_version_part(v: Version) -> RangePart {
+    let (max, max_op) = if v.pre.is_empty() {
+        (Version::new(v.major, v.minor, v.patch + 1), Op::Lt)
+    } else {
+        (v.clone(), Op::Lte)
+    };
+    RangePart {
+        min: v,
+        min_op: Op::Gte,
+        max: Some(max),
+        max_op: Some(max_op),
+    }
+}
+
+/// Split a comparator set into borrowed tokens; a bare operator merges with the
+/// following word as one slice (e.g. `">= 1.0.0"`), so no `String` is allocated.
+fn comparator_tokens(input: &str) -> SmallVec<[&str; 2]> {
+    let bytes = input.as_bytes();
+    let len = bytes.len();
+    let mut tokens: SmallVec<[&str; 2]> = SmallVec::new();
     let mut i = 0;
-    while i < raw.len() {
-        if is_bare_operator(raw[i]) && i + 1 < raw.len() {
-            tokens.push(format!("{}{}", raw[i], raw[i + 1]));
-            i += 2;
-        } else {
-            tokens.push(raw[i].to_string());
+
+    while i < len {
+        while i < len && bytes[i].is_ascii_whitespace() {
             i += 1;
         }
+        if i >= len {
+            break;
+        }
+        let word_start = i;
+        while i < len && !bytes[i].is_ascii_whitespace() {
+            i += 1;
+        }
+        let word = &input[word_start..i];
+
+        if is_bare_operator(word) {
+            let mut j = i;
+            while j < len && bytes[j].is_ascii_whitespace() {
+                j += 1;
+            }
+            if j < len {
+                while j < len && !bytes[j].is_ascii_whitespace() {
+                    j += 1;
+                }
+                tokens.push(&input[word_start..j]);
+                i = j;
+                continue;
+            }
+        }
+
+        tokens.push(word);
     }
+
     tokens
 }
 
@@ -254,10 +461,15 @@ fn is_wildcard_str(s: &str) -> bool {
 }
 
 fn is_x_range(token: &str) -> bool {
-    token.contains('x')
-        || token.contains('X')
-        || token.contains('*')
-        || token.split('.').count() < 3
+    let mut dots = 0_usize;
+    for b in token.bytes() {
+        match b {
+            b'x' | b'X' | b'*' => return true,
+            b'.' => dots += 1,
+            _ => {}
+        }
+    }
+    dots < 2
 }
 
 /// `>=` with partial version support: `>=1.2` → `>=1.2.0`
@@ -349,17 +561,11 @@ fn parse_eq_range(input: &str) -> Result<RangePart, String> {
         return parse_x_range(input);
     }
     let v = parse_partial_version(input)?;
-    Ok(RangePart {
-        min: v.clone(),
-        min_op: Op::Gte,
-        max: Some(Version::new(v.major, v.minor, v.patch + 1)),
-        max_op: Some(Op::Lt),
-    })
+    Ok(exact_version_part(v))
 }
 
 fn parse_caret(input: &str) -> Result<RangePart, String> {
-    let parts_count = version_component_count(input);
-    let v = parse_partial_version(input)?;
+    let (v, parts_count) = parse_partial_with_count(input)?;
 
     let upper = match parts_count {
         // ^0 → <1.0.0, ^1 → <2.0.0 (only major specified)
@@ -373,21 +579,7 @@ fn parse_caret(input: &str) -> Result<RangePart, String> {
                 Version::new(v.major + 1, 0, 0)
             }
         }
-        _ => {
-            // Full version: standard caret rules
-            if v.major == 0 {
-                if v.minor == 0 {
-                    // ^0.0.1 → <0.0.2
-                    Version::new(0, 0, v.patch + 1)
-                } else {
-                    // ^0.1.2 → <0.2.0
-                    Version::new(0, v.minor + 1, 0)
-                }
-            } else {
-                // ^1.2.3 → <2.0.0
-                Version::new(v.major + 1, 0, 0)
-            }
-        }
+        _ => caret_upper_bound(&v),
     };
     Ok(RangePart {
         min: v,
@@ -398,8 +590,7 @@ fn parse_caret(input: &str) -> Result<RangePart, String> {
 }
 
 fn parse_tilde(input: &str) -> Result<RangePart, String> {
-    let parts_count = version_component_count(input);
-    let v = parse_partial_version(input)?;
+    let (v, parts_count) = parse_partial_with_count(input)?;
     let upper = if parts_count == 1 {
         // ~1 means >=1.0.0 <2.0.0
         Version::new(v.major + 1, 0, 0)
@@ -537,59 +728,55 @@ fn parse_strict_version(input: &str) -> Result<Version, String> {
 }
 
 fn parse_partial_version(input: &str) -> Result<Version, String> {
-    let input = strip_v(input);
-    // Strip build metadata (+...)
-    let input = input.split('+').next().unwrap_or(input);
-    // Separate prerelease (-...) but preserve it
-    let (base, pre) = if let Some(idx) = input.find('-') {
-        (&input[..idx], Some(&input[idx..]))
-    } else {
-        (input, None)
-    };
-    // Filter out x/*/X wildcard components, treating them as absent
-    let parts: Vec<&str> = base
-        .split('.')
-        .take_while(|p| !matches!(*p, "x" | "X" | "*"))
-        .collect();
-    let version_str = match parts.as_slice() {
-        [] => "0.0.0".to_string(),
-        [major] => {
-            parse_u64(major)?;
-            format!("{major}.0.0")
-        }
-        [major, minor] => {
-            parse_u64(major)?;
-            parse_u64(minor)?;
-            format!("{major}.{minor}.0")
-        }
-        [major, minor, patch] => {
-            parse_u64(major)?;
-            parse_u64(minor)?;
-            parse_u64(patch)?;
-            format!("{major}.{minor}.{patch}")
-        }
-        _ => return Err(format!("invalid partial version: {base}")),
-    };
-    let full = match pre {
-        Some(pre) => format!("{version_str}{pre}"),
-        None => version_str,
-    };
-    Version::parse(&full).map_err(|e| format!("invalid version '{full}': {e}"))
+    parse_partial_with_count(input).map(|(version, _)| version)
 }
 
-/// Count the number of meaningful (non-wildcard) version components,
-/// stripping build metadata and prerelease before counting.
-fn version_component_count(input: &str) -> usize {
-    let clean = input.split('+').next().unwrap_or(input);
-    let clean = if let Some(idx) = clean.find('-') {
-        &clean[..idx]
-    } else {
-        clean
+/// Like [`parse_partial_version`], but also returns how many explicit numeric
+/// components precede any wildcard (`0..=3`) — caret/tilde need it, from one scan.
+fn parse_partial_with_count(input: &str) -> Result<(Version, usize), String> {
+    let input = strip_v(input);
+    let input = input.split('+').next().unwrap_or(input);
+
+    let Some(idx) = input.find('-') else {
+        let (major, minor, patch, count) = parse_core_components(input)?;
+        return Ok((Version::new(major, minor, patch), count));
     };
-    clean
+
+    // Prerelease: reassemble core + suffix and parse via `semver` to keep identifiers.
+    let (major, minor, patch, count) = parse_core_components(&input[..idx])?;
+    let pre = &input[idx..];
+    let full = format!("{major}.{minor}.{patch}{pre}");
+    let version = Version::parse(&full).map_err(|e| format!("invalid version '{full}': {e}"))?;
+    Ok((version, count))
+}
+
+/// Parse the numeric `major[.minor[.patch]]` core of a (possibly partial) version,
+/// treating `x`/`X`/`*` and any absent components as `0`. Also returns how many
+/// explicit numeric components were present before any wildcard.
+fn parse_core_components(base: &str) -> Result<(u64, u64, u64, usize), String> {
+    let mut components = base
         .split('.')
-        .take_while(|p| !matches!(*p, "x" | "X" | "*"))
-        .count()
+        .take_while(|p| !matches!(*p, "x" | "X" | "*"));
+
+    let Some(major) = components.next() else {
+        return Ok((0, 0, 0, 0));
+    };
+    let major = parse_u64(major)?;
+
+    let Some(minor) = components.next() else {
+        return Ok((major, 0, 0, 1));
+    };
+    let minor = parse_u64(minor)?;
+
+    let Some(patch) = components.next() else {
+        return Ok((major, minor, 0, 2));
+    };
+    let patch = parse_u64(patch)?;
+
+    if components.next().is_some() {
+        return Err(format!("invalid partial version: {base}"));
+    }
+    Ok((major, minor, patch, 3))
 }
 
 fn parse_u64(input: &str) -> Result<u64, String> {
@@ -697,5 +884,124 @@ mod tests {
         assert!(r.satisfies(&Version::new(16, 14, 0)));
         assert!(r.satisfies(&Version::new(20, 0, 0)));
         assert!(!r.satisfies(&Version::new(15, 0, 0)));
+    }
+
+    // --- Parsed-output assertions for prerelease ranges ---
+
+    fn pre(s: &str) -> Version {
+        Version::parse(s).expect("valid prerelease version")
+    }
+
+    #[test]
+    fn parse_caret_prerelease() {
+        let r = ParsedRange::parse("^1.2.3-alpha").expect("parse");
+        assert_eq!(r.parts[0].min, pre("1.2.3-alpha"));
+        assert_eq!(r.parts[0].min_op, Op::Gte);
+        assert_eq!(r.parts[0].max, Some(Version::new(2, 0, 0)));
+        assert_eq!(r.parts[0].max_op, Some(Op::Lt));
+    }
+
+    #[test]
+    fn parse_tilde_prerelease() {
+        let r = ParsedRange::parse("~1.2.3-beta").expect("parse");
+        assert_eq!(r.parts[0].min, pre("1.2.3-beta"));
+        assert_eq!(r.parts[0].max, Some(Version::new(1, 3, 0)));
+        assert_eq!(r.parts[0].max_op, Some(Op::Lt));
+    }
+
+    #[test]
+    fn parse_gte_prerelease_is_open() {
+        let r = ParsedRange::parse(">=1.2.3-rc.1").expect("parse");
+        assert_eq!(r.parts[0].min, pre("1.2.3-rc.1"));
+        assert_eq!(r.parts[0].min_op, Op::Gte);
+        assert!(r.parts[0].max.is_none());
+    }
+
+    #[test]
+    fn parse_hyphen_prerelease() {
+        let r = ParsedRange::parse("1.2.3-alpha - 2.0.0").expect("parse");
+        assert_eq!(r.parts[0].min, pre("1.2.3-alpha"));
+        assert_eq!(r.parts[0].max, Some(Version::new(2, 0, 0)));
+        assert_eq!(r.parts[0].max_op, Some(Op::Lte));
+    }
+
+    #[test]
+    fn parse_exact_prerelease_is_point_interval() {
+        // node-semver matches only the exact prerelease version, so we emit `>=v <=v`.
+        for input in ["1.2.3-alpha", "=1.2.3-alpha"] {
+            let r = ParsedRange::parse(input).expect("parse");
+            let v = pre("1.2.3-alpha");
+            assert_eq!(r.parts[0].min, v, "{input}");
+            assert_eq!(r.parts[0].min_op, Op::Gte, "{input}");
+            assert_eq!(r.parts[0].max, Some(v), "{input}");
+            assert_eq!(r.parts[0].max_op, Some(Op::Lte), "{input}");
+        }
+    }
+
+    #[test]
+    fn exact_prerelease_excludes_release_and_other_prereleases() {
+        let r = ParsedRange::parse("1.2.3-alpha").expect("parse");
+        assert!(r.satisfies(&pre("1.2.3-alpha")));
+        assert!(!r.satisfies(&Version::new(1, 2, 3)));
+        assert!(!r.satisfies(&pre("1.2.3-beta")));
+        assert!(!r.satisfies(&pre("1.2.3-alpha.1")));
+    }
+
+    #[test]
+    fn loose_prerelease_suffix_is_rejected() {
+        // node-semver loose mode accepts "1.2.3beta" / "^1.2.3beta"; we deliberately
+        // do not implement loose mode, so these must error rather than parse.
+        assert!(ParsedRange::parse("1.2.3beta").is_err());
+        assert!(ParsedRange::parse("^1.2.3beta").is_err());
+        assert!(ParsedRange::parse("~1.2.3beta").is_err());
+    }
+
+    // --- Operator + x-range / whitespace / build-metadata edge cases ---
+
+    #[test]
+    fn parse_gt_x_range_bumps_to_next_major() {
+        // >1.x means >=2.0.0
+        let r = ParsedRange::parse(">1.x").expect("parse");
+        assert_eq!(r.parts[0].min, Version::new(2, 0, 0));
+        assert_eq!(r.parts[0].min_op, Op::Gte);
+        assert!(r.parts[0].max.is_none());
+    }
+
+    #[test]
+    fn parse_lte_x_range() {
+        // <=1.x means <2.0.0
+        let r = ParsedRange::parse("<=1.x").expect("parse");
+        assert_eq!(r.parts[0].max, Some(Version::new(2, 0, 0)));
+        assert_eq!(r.parts[0].max_op, Some(Op::Lt));
+    }
+
+    #[test]
+    fn parse_spaced_tilde_gt_alias() {
+        let r = ParsedRange::parse("~> 1.2.3").expect("parse");
+        assert_eq!(r.parts[0].min, Version::new(1, 2, 3));
+        assert_eq!(r.parts[0].max, Some(Version::new(1, 3, 0)));
+    }
+
+    #[test]
+    fn parse_spaced_caret_partial() {
+        let r = ParsedRange::parse("^ 1.2").expect("parse");
+        assert_eq!(r.parts[0].min, Version::new(1, 2, 0));
+        assert_eq!(r.parts[0].max, Some(Version::new(2, 0, 0)));
+    }
+
+    #[test]
+    fn parse_build_metadata_stripped_on_exact() {
+        let r = ParsedRange::parse("1.2.3+build.7").expect("parse");
+        assert_eq!(r.parts[0].min, Version::new(1, 2, 3));
+        assert_eq!(r.parts[0].max, Some(Version::new(1, 2, 4)));
+        assert_eq!(r.parts[0].max_op, Some(Op::Lt));
+    }
+
+    #[test]
+    fn parse_hyphen_full_range() {
+        let r = ParsedRange::parse("1.0.0 - 2.0.0").expect("parse");
+        assert_eq!(r.parts[0].min, Version::new(1, 0, 0));
+        assert_eq!(r.parts[0].max, Some(Version::new(2, 0, 0)));
+        assert_eq!(r.parts[0].max_op, Some(Op::Lte));
     }
 }

--- a/crates/riri-semver-range/tests/cross_validate_nodejs_semver.rs
+++ b/crates/riri-semver-range/tests/cross_validate_nodejs_semver.rs
@@ -79,6 +79,56 @@ const TEST_RANGES: &[&str] = &[
     "1.x - x",
 ];
 
+/// Versions carrying prerelease / build metadata, for prerelease-aware checks.
+const PRERELEASE_VERSIONS: &[&str] = &[
+    "1.2.2",
+    "1.2.3",
+    "1.2.4",
+    "1.3.0",
+    "2.0.0",
+    "1.2.3-alpha",
+    "1.2.3-alpha.1",
+    "1.2.3-alpha.2",
+    "1.2.3-beta",
+    "1.2.3-pre",
+    "1.2.3-pre.2",
+    "1.2.3-rc.1",
+    "1.2.4-alpha",
+    "1.2.0-pre",
+    "0.0.1-alpha",
+    "0.0.1-beta",
+    "0.0.1",
+    "0.1.1-alpha",
+    "0.1.1-beta",
+    "0.5.4-pre",
+    "0.5.5",
+    "2.0.0-beta",
+    "2.4.3-alpha",
+    "2.4.3-pre.2",
+];
+
+/// Range strings carrying prerelease / build metadata.
+const PRERELEASE_RANGES: &[&str] = &[
+    "1.2.3-alpha",
+    "=1.2.3-alpha",
+    ">=1.2.3-alpha",
+    ">1.2.3-alpha",
+    "<1.2.3-beta",
+    "<=1.2.3-beta",
+    "^1.2.3-alpha",
+    "^1.2.0-alpha",
+    "^0.0.1-alpha",
+    "^0.1.1-alpha",
+    "~1.2.3-beta",
+    "~v0.5.4-pre",
+    ">=1.2.3-alpha <1.2.3-beta",
+    "1.2.3-alpha - 2.0.0",
+    "1.2.3-pre+asdf - 2.4.3-pre+asdf",
+    "1.2.3 || >=2.0.0-beta",
+    "^1.2.3+build",
+    "1.2.3+asdf - 2.4.3+asdf",
+];
+
 fn nodejs_satisfies(range: &str, version: &str) -> Option<bool> {
     let r = nodejs_semver::Range::parse(range).ok()?;
     let v = nodejs_semver::Version::parse(version).ok()?;
@@ -110,6 +160,45 @@ fn cross_validate_satisfies() {
     assert!(
         mismatches.is_empty(),
         "Cross-validation found {} mismatches:\n{}",
+        mismatches.len(),
+        mismatches.join("\n")
+    );
+}
+
+#[test]
+fn cross_validate_satisfies_prerelease() {
+    let mut mismatches = Vec::new();
+    let mut compared = 0_usize;
+
+    for range in PRERELEASE_RANGES {
+        let Ok(our_range) = ParsedRange::parse(range) else {
+            continue;
+        };
+
+        for version in PRERELEASE_VERSIONS {
+            let Ok(v) = Version::parse(version) else {
+                continue;
+            };
+            let our_result = our_range.satisfies(&v);
+
+            if let Some(nodejs_result) = nodejs_satisfies(range, version) {
+                compared += 1;
+                if our_result != nodejs_result {
+                    mismatches.push(format!(
+                        "range={range:?} version={version:?}: ours={our_result} nodejs={nodejs_result}"
+                    ));
+                }
+            }
+        }
+    }
+
+    eprintln!(
+        "prerelease cross-validation: {compared} compared, {} mismatches",
+        mismatches.len()
+    );
+    assert!(
+        mismatches.is_empty(),
+        "prerelease cross-validation found {} mismatches:\n{}",
         mismatches.len(),
         mismatches.join("\n")
     );

--- a/crates/riri-semver-range/tests/proptest_invariants.rs
+++ b/crates/riri-semver-range/tests/proptest_invariants.rs
@@ -173,3 +173,63 @@ proptest! {
         );
     }
 }
+
+// --- Prerelease-aware strategies ---
+
+/// A prerelease suffix, possibly empty (e.g. `-alpha`, `-rc.1`, `-alpha.2`).
+fn arb_pre_tag() -> impl Strategy<Value = String> {
+    prop_oneof![
+        Just(String::new()),
+        Just("-alpha".to_string()),
+        Just("-beta".to_string()),
+        Just("-rc.1".to_string()),
+        Just("-pre.2".to_string()),
+        (0_u64..3).prop_map(|n| format!("-alpha.{n}")),
+    ]
+}
+
+/// Generate a version that frequently carries a prerelease tag.
+fn arb_pre_version() -> impl Strategy<Value = Version> {
+    (0_u64..4, 0_u64..4, 0_u64..4, arb_pre_tag()).prop_map(|(ma, mi, pa, tag)| {
+        Version::parse(&format!("{ma}.{mi}.{pa}{tag}")).expect("valid")
+    })
+}
+
+/// Generate range strings whose comparators frequently carry prerelease tags.
+fn arb_pre_range() -> impl Strategy<Value = String> {
+    let core = (0_u64..4, 0_u64..4, 0_u64..4);
+    prop_oneof![
+        (core.clone(), arb_pre_tag()).prop_map(|((a, b, c), t)| format!("^{a}.{b}.{c}{t}")),
+        (core.clone(), arb_pre_tag()).prop_map(|((a, b, c), t)| format!("~{a}.{b}.{c}{t}")),
+        (core.clone(), arb_pre_tag()).prop_map(|((a, b, c), t)| format!(">={a}.{b}.{c}{t}")),
+        (core.clone(), arb_pre_tag()).prop_map(|((a, b, c), t)| format!(">{a}.{b}.{c}{t}")),
+        (core.clone(), arb_pre_tag()).prop_map(|((a, b, c), t)| format!("<{a}.{b}.{c}{t}")),
+        // exact prerelease
+        (core.clone(), arb_pre_tag()).prop_map(|((a, b, c), t)| format!("{a}.{b}.{c}{t}")),
+        // hyphen with prerelease on either end
+        (core.clone(), arb_pre_tag(), core.clone(), arb_pre_tag()).prop_map(
+            |((a, b, c), t1, (d, e, f), t2)| format!("{a}.{b}.{c}{t1} - {d}.{e}.{f}{t2}")
+        ),
+    ]
+}
+
+// --- Invariant: satisfies matches nodejs-semver for prerelease inputs ---
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(2000))]
+    #[test]
+    fn satisfies_matches_nodejs_semver_prerelease(range in arb_pre_range(), v in arb_pre_version()) {
+        let Some(our_range) = try_parse(&range) else { return Ok(()); };
+        let v_str = format!("{v}");
+        let Ok(njs_range) = nodejs_semver::Range::parse(&range) else { return Ok(()); };
+        let Ok(njs_version) = nodejs_semver::Version::parse(&v_str) else { return Ok(()); };
+
+        let ours = our_range.satisfies(&v);
+        let theirs = njs_range.satisfies(&njs_version);
+        prop_assert!(
+            ours == theirs,
+            "prerelease satisfies mismatch for {:?} @ {}: ours={}, nodejs-semver={}",
+            range, v, ours, theirs
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Speeds up `riri-semver-range` range parsing and fixes a prerelease correctness bug surfaced by
expanded cross-validation. No behavioural change on the common path.

## Performance (`cargo bench`, same machine)

| operation | before | after |
|---|---:|---:|
| parse (8-range corpus) | 2.149 µs | **581 ns** |
| satisfies (already-parsed) | — | **27.9 ns** |
| restrictive_range (8 pairs) | 740 ns | **694 ns** |

### What changed (parse path)

1. No-prerelease tokens build `Version::new(maj,min,pat)` directly — no `String` round-trip / re-parse.
2. `ParsedRange.parts` → `SmallVec<[RangePart; 1]>` (single-part ranges stay on the stack).
3. Borrowed `&str` comparator tokens instead of `Vec<String>` + `format!`.
4. One-pass caret/tilde (`parse_partial_with_count` replaces a double scan).
5. Single-pass `is_x_range` (was up to 4 scans).
6. `split_by_major` returns `SmallVec` (no heap alloc on the common no-split path).
7. **Byte-level `fast_comparator` fast path**: operator + full `major.minor.patch[-pre]` parsed in one
   byte walk; wildcards/partials/build/hyphen fall through to the unchanged string parser. The big lever.
8. `restrictive_range` keeps its intersection working sets inline (`SmallVec`).

The fast path is a pure shortcut — anything it doesn't fully recognize returns `None` and is handled
by the existing parser, so there is no behavioural change.

## Correctness fix

Expanded cross-validation found that an exact prerelease range (e.g. `1.2.3-alpha`) expanded to
`>=v <v.(patch+1)`, which wrongly admitted the release `v` and sibling prereleases. Per npm range
semantics it must match **only** the exact version. Fixed: exact prerelease now emits the point
interval `>=v <=v`. Release behaviour is unchanged.

## Tests

- Prerelease corpus added to cross-validation (432 comparisons, 0 mismatches).
- New 2000-case prerelease property fuzz.
- Parse-output fixtures for prerelease ranges; loose-suffix rejection pinned as a deliberate decision.

All 22 test suites pass; clippy clean under the workspace's `pedantic = deny`. Adds per-shape
parsing and humanize benchmarks.
