### PR TITLE
refactor: feature-gate single-consumer crate content & drop unused re-export

### DIFF
--- a/crates/riri-nce/Cargo.toml
+++ b/crates/riri-nce/Cargo.toml
@@ -20,7 +20,7 @@ riri-node-lifecycle = { path = "../riri-node-lifecycle", version = "0.1.1" }
 riri-npm = { path = "../riri-npm", version = "0.1.2" }
 riri-pnpm = { path = "../riri-pnpm", version = "0.1.2" }
 riri-semver-range = { path = "../riri-semver-range", version = "0.1.1" }
-riri-yarn = { path = "../riri-yarn", version = "0.1.2" }
+riri-yarn = { path = "../riri-yarn", version = "0.1.2", features = ["scan"] }
 riri-task-runner = { path = "../riri-task-runner", version = "0.1.0" }
 anyhow = { workspace = true }
 chrono = { workspace = true }

--- a/crates/riri-npd/Cargo.toml
+++ b/crates/riri-npd/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/bin/npm-pin-dependencies.rs"
 [dependencies]
 riri-common = { path = "../riri-common", version = "0.1.2", features = ["sort"] }
 riri-npm = { path = "../riri-npm", version = "0.1.2" }
-riri-pnpm = { path = "../riri-pnpm", version = "0.1.2" }
+riri-pnpm = { path = "../riri-pnpm", version = "0.1.2", features = ["catalog"] }
 riri-task-runner = { path = "../riri-task-runner", version = "0.1.0" }
 riri-workspace = { path = "../riri-workspace", version = "0.1.2" }
 riri-yarn = { path = "../riri-yarn", version = "0.1.2" }

--- a/crates/riri-pnpm/Cargo.toml
+++ b/crates/riri-pnpm/Cargo.toml
@@ -7,10 +7,11 @@ license.workspace = true
 
 [features]
 graph = ["riri-common/graph"]
+catalog = ["dep:riri-find-up"]
 
 [dependencies]
 riri-common = { path = "../riri-common", version = "0.1.2" }
-riri-find-up = { path = "../riri-find-up", version = "0.1.1" }
+riri-find-up = { path = "../riri-find-up", version = "0.1.1", optional = true }
 serde = { workspace = true }
 serde-saphyr = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/riri-pnpm/src/lib.rs
+++ b/crates/riri-pnpm/src/lib.rs
@@ -3,6 +3,7 @@
 //! Parses the lockfile and exposes engine constraints per dependency
 //! via the [`LockfileEngines`] trait.
 
+#[cfg(feature = "catalog")]
 pub mod catalog;
 
 use riri_common::{Engines, LockfileEngines, LockfileVersions};

--- a/crates/riri-semver-range/src/lib.rs
+++ b/crates/riri-semver-range/src/lib.rs
@@ -6,7 +6,8 @@ pub(crate) mod subset;
 
 pub use helpers::split_by_major;
 pub use intersection::restrictive_range;
-pub use parse::{ParsedRange, Parts};
+pub use parse::ParsedRange;
+pub(crate) use parse::Parts;
 pub use subset::{intersects, is_subset_of};
 
 use semver::Version;

--- a/crates/riri-yarn/Cargo.toml
+++ b/crates/riri-yarn/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 
 [features]
 graph = ["riri-common/graph"]
+scan = ["dep:walkdir"]
 
 [dependencies]
 riri-common = { path = "../riri-common", version = "0.1.2" }
@@ -14,7 +15,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde-saphyr = { workspace = true }
 thiserror = { workspace = true }
-walkdir = "2.5.0"
+walkdir = { version = "2.5.0", optional = true }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/riri-yarn/src/lib.rs
+++ b/crates/riri-yarn/src/lib.rs
@@ -6,12 +6,14 @@
 //! - [`YarnLock`] parses `yarn.lock` (v1 Classic and v2+ Berry) and resolves a
 //!   dependency's locked version by `name@range` descriptor — used by
 //!   `riri-npd` for version pinning. No `node_modules` required.
-//! - [`YarnProject`] scans `node_modules/<pkg>/package.json` to extract
+//! - `YarnProject` (feature `scan`) reads `node_modules/<pkg>/package.json` to extract
 //!   `engines` (via [`LockfileEngines`]) — used by `riri-nce`. Yarn lockfiles
 //!   (any version) do **not** store `engines`, so the install tree is the only
 //!   source.
 
-use riri_common::{Engines, LockfileEngines, LockfileVersions};
+use riri_common::LockfileVersions;
+#[cfg(feature = "scan")]
+use riri_common::{Engines, LockfileEngines};
 #[cfg(feature = "graph")]
 use riri_common::{
     GraphError, LockGraph, LockGraphEdge, LockGraphNode, LockGraphRoot, LockfileGraph, PackageJson,
@@ -19,9 +21,11 @@ use riri_common::{
 };
 use serde::Deserialize;
 use std::collections::HashMap;
+#[cfg(feature = "scan")]
 use std::path::Path;
 
 /// Errors that can occur when scanning a yarn project.
+#[cfg(feature = "scan")]
 #[derive(Debug, thiserror::Error)]
 pub enum YarnScanError {
     #[error("node_modules directory not found at {0}")]
@@ -39,6 +43,7 @@ pub enum YarnScanError {
 }
 
 /// Minimal package.json representation for engine + version extraction.
+#[cfg(feature = "scan")]
 #[derive(Debug, Clone, Deserialize)]
 struct NodeModulePackageJson {
     #[serde(default)]
@@ -48,6 +53,7 @@ struct NodeModulePackageJson {
 }
 
 /// One scanned `node_modules/<pkg>/package.json` entry.
+#[cfg(feature = "scan")]
 #[derive(Debug, Clone, Default)]
 struct ScannedPackage {
     version: Option<String>,
@@ -55,11 +61,13 @@ struct ScannedPackage {
 }
 
 /// Scanned yarn project with engine + version data from `node_modules`.
+#[cfg(feature = "scan")]
 #[derive(Debug, Clone)]
 pub struct YarnProject {
     packages: HashMap<String, ScannedPackage>,
 }
 
+#[cfg(feature = "scan")]
 impl YarnProject {
     /// Scan `node_modules/` under the given project directory to extract engine
     /// constraints from each installed package's `package.json`.
@@ -144,6 +152,7 @@ impl YarnProject {
     }
 }
 
+#[cfg(feature = "scan")]
 impl LockfileEngines for YarnProject {
     fn engines_iter(&self) -> Box<dyn Iterator<Item = (&str, &Engines)> + '_> {
         Box::new(
@@ -154,6 +163,7 @@ impl LockfileEngines for YarnProject {
     }
 }
 
+#[cfg(feature = "scan")]
 impl LockfileVersions for YarnProject {
     fn version_for(&self, name: &str) -> Option<&str> {
         self.packages.get(name)?.version.as_deref()
@@ -177,7 +187,7 @@ pub enum YarnParseError {
 /// Resolution mirrors the legacy JS `@smarlhens/npm-pin-dependencies`: a
 /// dependency's locked version is looked up by the descriptor built from its
 /// `package.json` specifier — `name@range` for classic v1, `name@npm:range`
-/// for berry v2+. Unlike [`YarnProject`] this needs no `node_modules`, works
+/// for berry v2+. Unlike `YarnProject` this needs no `node_modules`, works
 /// under `PnP`, and distinguishes multiple ranges of the same package.
 #[derive(Debug, Clone)]
 pub struct YarnLock {

--- a/crates/riri-yarn/tests/error_tests.rs
+++ b/crates/riri-yarn/tests/error_tests.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "scan")]
 #![allow(clippy::tests_outside_test_module)]
 #![allow(clippy::unwrap_used)]
 

--- a/crates/riri-yarn/tests/scan_fixtures.rs
+++ b/crates/riri-yarn/tests/scan_fixtures.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "scan")]
 #![allow(clippy::tests_outside_test_module)]
 #![allow(clippy::unwrap_used)]
 //! Scan all yarn fixtures and snapshot the engine entries.


### PR DESCRIPTION
## Summary

De-shares content that lives in shared crates but is consumed by only one crate, found via a
workspace over-sharing audit. The two substantial single-consumer modules are now feature-gated so
crates that don't need them no longer compile them (or their dependencies), and one unused public
re-export is dropped.

One commit per scope.

## Changes

**`refactor(pnpm): gate catalog module behind catalog feature`**
`PnpmCatalog` + `find_workspace_yaml` are used only by `riri-npd`. The `catalog` module is now behind
a `catalog` feature, and `riri-find-up` (used only by catalog within pnpm) is an optional dependency
enabled by it. `riri-ncd` / `riri-nce` / `riri-napi-nce` no longer compile catalog or pull `riri-find-up`.

**`refactor(yarn): gate node_modules scan behind scan feature`**
`YarnProject` (the `node_modules` scanner, used for engine extraction) is used only by `riri-nce`.
It's now behind a `scan` feature, and `walkdir` (used only by the scanner) is an optional dependency
enabled by it. `riri-ncd` / `riri-npd` (which use `YarnLock` for version resolution) skip the scanner
and `walkdir`.

**`refactor(semver-range): drop unused public Parts re-export`**
The `Parts` type alias had no external consumers; it's now `pub(crate)` (still used internally).

## Verification

- `cargo fmt --all --check` clean
- `cargo clippy --workspace --all-targets` clean under the workspace's `pedantic = deny`
- `cargo test --workspace` — 64 test suites pass
- Both feature states checked: crates compile with the new features off (default) and on (via the
  enabling consumer), with no unused-import warnings.
