### PR TITLE
chore(deps): bump pre-commit hooks & napi

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/oxc-project/mirrors-oxfmt
-    rev: "v0.56.0"
+    rev: "v0.58.0"
     hooks:
       - id: oxfmt
         types_or: [javascript, jsx, ts, tsx, json, yaml, markdown, css]
@@ -26,7 +26,7 @@ repos:
         exclude: '(^|/)(package-lock\.json|pnpm-lock\.yaml|CHANGELOG\.md)$'
 
   - repo: https://github.com/oxc-project/mirrors-oxlint
-    rev: "v1.71.0"
+    rev: "v1.73.0"
     hooks:
       - id: oxlint
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -969,9 +969,9 @@ checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
 
 [[package]]
 name = "napi"
-version = "3.10.4"
+version = "3.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b7fbd5f12adbf51ddec954d4ef9cecb3542a9d53bce2fe0653696c4cd06d73"
+checksum = "6826e5ddc15589b2d68c8ad5321c18e85d40488e93e32962f362e572669bccf6"
 dependencies = [
  "bitflags",
  "ctor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ tracing-subscriber = "0.3.23"
 ureq = "3.3.0"
 
 # napi
-napi = { version = "3.10.4", default-features = false, features = ["napi6", "serde-json"] }
+napi = { version = "3.10.5", default-features = false, features = ["napi6", "serde-json"] }
 napi-derive = { version = "3.5.10", features = ["type-def"] }
 napi-build = "2.3.2"
 

--- a/bench-js/package-lock.json
+++ b/bench-js/package-lock.json
@@ -7,9 +7,9 @@
       "name": "bench-js",
       "dependencies": {
         "@smarlhens/npm-check-engines-v0": "npm:@smarlhens/npm-check-engines@0.14.4",
-        "@smarlhens/npm-check-engines-v1": "npm:@smarlhens/npm-check-engines@1.2.4",
+        "@smarlhens/npm-check-engines-v1": "npm:@smarlhens/npm-check-engines@1.3.0",
         "@smarlhens/npm-pin-dependencies-v0": "npm:@smarlhens/npm-pin-dependencies@0.11.1",
-        "@smarlhens/npm-pin-dependencies-v1": "npm:@smarlhens/npm-pin-dependencies@1.0.2",
+        "@smarlhens/npm-pin-dependencies-v1": "npm:@smarlhens/npm-pin-dependencies@1.1.0",
         "markdown-table": "3.0.4",
         "pretty-bytes": "7.1.0",
         "tinybench": "6.0.2"
@@ -1002,9 +1002,9 @@
       }
     },
     "node_modules/@smarlhens/npm-check-engines-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@smarlhens/npm-check-engines-darwin-arm64/-/npm-check-engines-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-8TekkXo9lEceaCRylP5zNeCz2CwfrBPajb8HmOh9a6wV25FPwRVvUPrZtYfx5X8Zh607wH5aZ9rIoLcWG3YevQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@smarlhens/npm-check-engines-darwin-arm64/-/npm-check-engines-darwin-arm64-1.3.0.tgz",
+      "integrity": "sha512-vZoD+E4M3/mObTKSogr9acf8Xj5cR+6pb3ksEyI6YwCSZPir/wbCpxMxlRL9VxR8NNh8DIzSWMY/g0Cbq/E7VA==",
       "cpu": [
         "arm64"
       ],
@@ -1019,9 +1019,9 @@
       }
     },
     "node_modules/@smarlhens/npm-check-engines-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@smarlhens/npm-check-engines-darwin-x64/-/npm-check-engines-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-6VZDDOeItcHlkzLexDqr8FhXNl5zfnFc3Y56bIvezkrYn+bbteJ5Pw2lPUDNoz57gCDXXF01/LXJOctbzj7Pdg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@smarlhens/npm-check-engines-darwin-x64/-/npm-check-engines-darwin-x64-1.3.0.tgz",
+      "integrity": "sha512-7hOBwWlVqm3UwdSyrEXxe3xmyzc2yGCBMrL3jxN6QQCnk21j+0lHZkgPJ6A4mI2bDCS1LL6RZTl92zT49m+Izw==",
       "cpu": [
         "x64"
       ],
@@ -1036,9 +1036,9 @@
       }
     },
     "node_modules/@smarlhens/npm-check-engines-linux-arm64-gnu": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@smarlhens/npm-check-engines-linux-arm64-gnu/-/npm-check-engines-linux-arm64-gnu-1.2.4.tgz",
-      "integrity": "sha512-FDQN0IPzolSU7HMbPpViDxpp9ORvUwAXbUBXRzxxWBUIg6ym/hk3pUENAFkBGiZr9e9qDx8XCAoqueUqnKDe5A==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@smarlhens/npm-check-engines-linux-arm64-gnu/-/npm-check-engines-linux-arm64-gnu-1.3.0.tgz",
+      "integrity": "sha512-wsa0Ub6No79gsZHyJtNMk6HG0IYTTIRpvE3aItmt4/7ERCo3QRcxvWdLgDnxzjc/967WnpXHXboRFT7Mq9RQEg==",
       "cpu": [
         "arm64"
       ],
@@ -1053,9 +1053,9 @@
       }
     },
     "node_modules/@smarlhens/npm-check-engines-linux-arm64-musl": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@smarlhens/npm-check-engines-linux-arm64-musl/-/npm-check-engines-linux-arm64-musl-1.2.4.tgz",
-      "integrity": "sha512-SFNxKQQkbPp83UqvH/3V064er9KzviJJoetDDc0yOcU3kbnYE7jpaTjHJ3T8Nc6bok/k00ZlwHc0RdHAsij9vw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@smarlhens/npm-check-engines-linux-arm64-musl/-/npm-check-engines-linux-arm64-musl-1.3.0.tgz",
+      "integrity": "sha512-M8Chn9oy5LpQeXREoPuzGDaG9JDZf4QOh0Vb5U52N/XumQOK5O4K4UIdXTsTV8osF8mbQj8wxMaNA6Kx16UzUQ==",
       "cpu": [
         "arm64"
       ],
@@ -1070,9 +1070,9 @@
       }
     },
     "node_modules/@smarlhens/npm-check-engines-linux-x64-gnu": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@smarlhens/npm-check-engines-linux-x64-gnu/-/npm-check-engines-linux-x64-gnu-1.2.4.tgz",
-      "integrity": "sha512-ii/99BqEbm/uuvfdNEw1eWwW0vEy1nS8GStqldtF3L9ddLaarc07iOUjPU29d/szih+zmUbfarSA2CrqbnN4Hw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@smarlhens/npm-check-engines-linux-x64-gnu/-/npm-check-engines-linux-x64-gnu-1.3.0.tgz",
+      "integrity": "sha512-xGnNK3x6c/N3QenX4gHY9X9Fy+9KFn6/NnIpsUEx2qKynAvCD3H8JS2f18zTAbd/SVgH8Fu8huEZWGtEISZ78A==",
       "cpu": [
         "x64"
       ],
@@ -1087,9 +1087,9 @@
       }
     },
     "node_modules/@smarlhens/npm-check-engines-linux-x64-musl": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@smarlhens/npm-check-engines-linux-x64-musl/-/npm-check-engines-linux-x64-musl-1.2.4.tgz",
-      "integrity": "sha512-VxK+0A7kmwR6kO40Lbdsu0d0Z/56LjPOOSuxWY8BOUK8LgKUP6FmOnC5mGXiot3uT51j/FmCQchD4MV7D2zAtQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@smarlhens/npm-check-engines-linux-x64-musl/-/npm-check-engines-linux-x64-musl-1.3.0.tgz",
+      "integrity": "sha512-x7WenIcgJQUG9983cyVEBKW1i++z5p4eJPJ75Vei2ULV07fdjOTntqg+tH8l72c1/3dlxnLoK9sq8LRD+mkbkw==",
       "cpu": [
         "x64"
       ],
@@ -1133,9 +1133,9 @@
     },
     "node_modules/@smarlhens/npm-check-engines-v1": {
       "name": "@smarlhens/npm-check-engines",
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@smarlhens/npm-check-engines/-/npm-check-engines-1.2.4.tgz",
-      "integrity": "sha512-AgNv9k0PtdYtkirDSu/RXzAJRnN6iIJrzSLyLF47+vGpywGpNONDxtHY0z4yfFN6jOyI2C1CHUUUsJDzArFX8Q==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@smarlhens/npm-check-engines/-/npm-check-engines-1.3.0.tgz",
+      "integrity": "sha512-+vRXCDOTN14gHmOSNnu8G9CTs/HQ/gG27SoNlK4zPs/W534wWcnlKtk6mKQy99rir0TtDwop7m9mOx41KeIdFA==",
       "license": "BlueOak-1.0.0",
       "bin": {
         "nce": "bin/nce.js",
@@ -1146,19 +1146,19 @@
         "npm": ">=10.9.7"
       },
       "optionalDependencies": {
-        "@smarlhens/npm-check-engines-darwin-arm64": "1.2.4",
-        "@smarlhens/npm-check-engines-darwin-x64": "1.2.4",
-        "@smarlhens/npm-check-engines-linux-arm64-gnu": "1.2.4",
-        "@smarlhens/npm-check-engines-linux-arm64-musl": "1.2.4",
-        "@smarlhens/npm-check-engines-linux-x64-gnu": "1.2.4",
-        "@smarlhens/npm-check-engines-linux-x64-musl": "1.2.4",
-        "@smarlhens/npm-check-engines-win32-x64-msvc": "1.2.4"
+        "@smarlhens/npm-check-engines-darwin-arm64": "1.3.0",
+        "@smarlhens/npm-check-engines-darwin-x64": "1.3.0",
+        "@smarlhens/npm-check-engines-linux-arm64-gnu": "1.3.0",
+        "@smarlhens/npm-check-engines-linux-arm64-musl": "1.3.0",
+        "@smarlhens/npm-check-engines-linux-x64-gnu": "1.3.0",
+        "@smarlhens/npm-check-engines-linux-x64-musl": "1.3.0",
+        "@smarlhens/npm-check-engines-win32-x64-msvc": "1.3.0"
       }
     },
     "node_modules/@smarlhens/npm-check-engines-win32-x64-msvc": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@smarlhens/npm-check-engines-win32-x64-msvc/-/npm-check-engines-win32-x64-msvc-1.2.4.tgz",
-      "integrity": "sha512-uCR1ch0AatN42BgHQXN8bQttAI/9RTTHBeiYRwLMHEJqv5ErY3/cdqtlBIDBR+ggiPZ46HoNfHhJwacB+cRCnA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@smarlhens/npm-check-engines-win32-x64-msvc/-/npm-check-engines-win32-x64-msvc-1.3.0.tgz",
+      "integrity": "sha512-m7ATDBAxO/Xh/gRm6019MdWJfffmDuPEOM1ILzhUwBRN6/29j+W5qGWb7Ju60isrWdAGh+5zopEzLuzLonlZJQ==",
       "cpu": [
         "x64"
       ],
@@ -1173,9 +1173,9 @@
       }
     },
     "node_modules/@smarlhens/npm-pin-dependencies-darwin-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smarlhens/npm-pin-dependencies-darwin-arm64/-/npm-pin-dependencies-darwin-arm64-1.0.2.tgz",
-      "integrity": "sha512-N26CV+crbzpPXqwqSGquSYUUyvZ71ESD9w/6x6Bp9Yo7m9QwShK7jBlKb27rEUCarkSzBB9oDeztAYi2pDd27A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smarlhens/npm-pin-dependencies-darwin-arm64/-/npm-pin-dependencies-darwin-arm64-1.1.0.tgz",
+      "integrity": "sha512-2GzIuT0lFjukPWszJ2JwoL62waM9s7FLUbe1OgXmXFsHwVi6blWnUcXU0Ud4apfzaPKkGhyJDsiEUJDFJBpkeQ==",
       "cpu": [
         "arm64"
       ],
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/@smarlhens/npm-pin-dependencies-darwin-x64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smarlhens/npm-pin-dependencies-darwin-x64/-/npm-pin-dependencies-darwin-x64-1.0.2.tgz",
-      "integrity": "sha512-RjTdRG7PinVhDA9nfHC7YHGzmItSF2M1zxis45qQhokuZCIZUHrpcn4mNRaziURe/VmaeFMDhp6uBY1JUUNG9w==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smarlhens/npm-pin-dependencies-darwin-x64/-/npm-pin-dependencies-darwin-x64-1.1.0.tgz",
+      "integrity": "sha512-8ugrSe1Zf9gLT+z25y39UvHeF9zwXKz8DYzEM1XUF0sD+gQ8e7IgJx91j7IZu7l7UFs9TtAOuFYBhTVEwk+Iyw==",
       "cpu": [
         "x64"
       ],
@@ -1207,9 +1207,9 @@
       }
     },
     "node_modules/@smarlhens/npm-pin-dependencies-linux-arm64-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smarlhens/npm-pin-dependencies-linux-arm64-gnu/-/npm-pin-dependencies-linux-arm64-gnu-1.0.2.tgz",
-      "integrity": "sha512-QaXA5oPlHi5PdH0T2ibXQSzIfZFro3KNwbTO2e+mq7dafo2ImryCWorcxpwwWQNpfUyvpvk5KHCb9GWX9e1Sdg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smarlhens/npm-pin-dependencies-linux-arm64-gnu/-/npm-pin-dependencies-linux-arm64-gnu-1.1.0.tgz",
+      "integrity": "sha512-SnFj+8D2y6+sMHlMGsn/XQdeDUrbi0yJTa46H1eTD1mSV/tmLUHftaDV/RdBe6LIUli/tWcVVWttq2AT+LUXwg==",
       "cpu": [
         "arm64"
       ],
@@ -1224,9 +1224,9 @@
       }
     },
     "node_modules/@smarlhens/npm-pin-dependencies-linux-arm64-musl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smarlhens/npm-pin-dependencies-linux-arm64-musl/-/npm-pin-dependencies-linux-arm64-musl-1.0.2.tgz",
-      "integrity": "sha512-4zJdJ5ozyH5V3Ti6fQlv49LNIb8DfN7HYi6Knm0CGTj6TPMR1tfMxCXOp54n+az7NsQBbzBvGv2ABnxCIMCing==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smarlhens/npm-pin-dependencies-linux-arm64-musl/-/npm-pin-dependencies-linux-arm64-musl-1.1.0.tgz",
+      "integrity": "sha512-/MlV74OJxG56jAyVkunqkoDRoZg/gPYCpT/RGJo07pci7CJiRLXmYWReK6TqUA6cdZFdKXXNJt/kqsW82Ro8iQ==",
       "cpu": [
         "arm64"
       ],
@@ -1241,9 +1241,9 @@
       }
     },
     "node_modules/@smarlhens/npm-pin-dependencies-linux-x64-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smarlhens/npm-pin-dependencies-linux-x64-gnu/-/npm-pin-dependencies-linux-x64-gnu-1.0.2.tgz",
-      "integrity": "sha512-DmEJrjkFgQeyvGsar+9L4HUMt63AxfpGuq3Eh/uBzn+UH8gpdGFispczLCjYBQC45FSI183a1eYbmh2jfDsH1A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smarlhens/npm-pin-dependencies-linux-x64-gnu/-/npm-pin-dependencies-linux-x64-gnu-1.1.0.tgz",
+      "integrity": "sha512-d6OovNBozu3Z8tq43WjLsMpQexS3y/ARjqO4PfOfrDRk5qczZimOtJOIc2hgjNmYXYXroeMa2A9lvzBp6N+8Og==",
       "cpu": [
         "x64"
       ],
@@ -1258,9 +1258,9 @@
       }
     },
     "node_modules/@smarlhens/npm-pin-dependencies-linux-x64-musl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smarlhens/npm-pin-dependencies-linux-x64-musl/-/npm-pin-dependencies-linux-x64-musl-1.0.2.tgz",
-      "integrity": "sha512-5VPAWtDHD5t/n00/5PaXJhc9cEKfLDSBQyBXHgdE2evJR1Q5lF3SukfPVHIOiVmc3wBmNo98EpOFQzRseRPJ1w==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smarlhens/npm-pin-dependencies-linux-x64-musl/-/npm-pin-dependencies-linux-x64-musl-1.1.0.tgz",
+      "integrity": "sha512-xKeMdlZPftmCQIxO3hxtYxl0mgb1nP8Q8e1Hl0BtIjQ7tdMJc7kVrvI+sZRf5O7Ps9tmNHbNrS/LYoWPFQt+rA==",
       "cpu": [
         "x64"
       ],
@@ -1306,9 +1306,9 @@
     },
     "node_modules/@smarlhens/npm-pin-dependencies-v1": {
       "name": "@smarlhens/npm-pin-dependencies",
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smarlhens/npm-pin-dependencies/-/npm-pin-dependencies-1.0.2.tgz",
-      "integrity": "sha512-11HJFPF6sJbu8LV3h4na0H/0EzxjG2Gd+5P/mwNsRU0Pj8IUYEJV6shjIumEQYtgmvSigKL4VYMe6bo2mBnAcA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smarlhens/npm-pin-dependencies/-/npm-pin-dependencies-1.1.0.tgz",
+      "integrity": "sha512-u9HkDXAZW+lr21bl5ZZwVpeaI9jyVgfMXl+QlKDQOXr7aBAT3Hadc2M89BuKQBvhi/8j2pZikhERehRCmrhxjw==",
       "license": "BlueOak-1.0.0",
       "bin": {
         "npd": "bin/npd.js",
@@ -1319,19 +1319,19 @@
         "npm": ">=10.9.7"
       },
       "optionalDependencies": {
-        "@smarlhens/npm-pin-dependencies-darwin-arm64": "1.0.2",
-        "@smarlhens/npm-pin-dependencies-darwin-x64": "1.0.2",
-        "@smarlhens/npm-pin-dependencies-linux-arm64-gnu": "1.0.2",
-        "@smarlhens/npm-pin-dependencies-linux-arm64-musl": "1.0.2",
-        "@smarlhens/npm-pin-dependencies-linux-x64-gnu": "1.0.2",
-        "@smarlhens/npm-pin-dependencies-linux-x64-musl": "1.0.2",
-        "@smarlhens/npm-pin-dependencies-win32-x64-msvc": "1.0.2"
+        "@smarlhens/npm-pin-dependencies-darwin-arm64": "1.1.0",
+        "@smarlhens/npm-pin-dependencies-darwin-x64": "1.1.0",
+        "@smarlhens/npm-pin-dependencies-linux-arm64-gnu": "1.1.0",
+        "@smarlhens/npm-pin-dependencies-linux-arm64-musl": "1.1.0",
+        "@smarlhens/npm-pin-dependencies-linux-x64-gnu": "1.1.0",
+        "@smarlhens/npm-pin-dependencies-linux-x64-musl": "1.1.0",
+        "@smarlhens/npm-pin-dependencies-win32-x64-msvc": "1.1.0"
       }
     },
     "node_modules/@smarlhens/npm-pin-dependencies-win32-x64-msvc": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smarlhens/npm-pin-dependencies-win32-x64-msvc/-/npm-pin-dependencies-win32-x64-msvc-1.0.2.tgz",
-      "integrity": "sha512-ORZuh9jOvn9dMg4g9SQBCKKMH33uXFXe3vYDPKTn8JpCjq07rqX+Ts6/7B11PcABTKemzKPhgA4K4d+YnXSybQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smarlhens/npm-pin-dependencies-win32-x64-msvc/-/npm-pin-dependencies-win32-x64-msvc-1.1.0.tgz",
+      "integrity": "sha512-fOA/YiDeYwxsGdq3pXKqMiMnHi+lb8t7yZO66+McZVqO34ZG02MZ2rdzeO0xuSG+9shpMTbeNIsla//9SM7yGA==",
       "cpu": [
         "x64"
       ],

--- a/bench-js/package.json
+++ b/bench-js/package.json
@@ -23,9 +23,9 @@
   },
   "dependencies": {
     "@smarlhens/npm-check-engines-v0": "npm:@smarlhens/npm-check-engines@0.14.4",
-    "@smarlhens/npm-check-engines-v1": "npm:@smarlhens/npm-check-engines@1.2.4",
+    "@smarlhens/npm-check-engines-v1": "npm:@smarlhens/npm-check-engines@1.3.0",
     "@smarlhens/npm-pin-dependencies-v0": "npm:@smarlhens/npm-pin-dependencies@0.11.1",
-    "@smarlhens/npm-pin-dependencies-v1": "npm:@smarlhens/npm-pin-dependencies@1.0.2",
+    "@smarlhens/npm-pin-dependencies-v1": "npm:@smarlhens/npm-pin-dependencies@1.1.0",
     "markdown-table": "3.0.4",
     "pretty-bytes": "7.1.0",
     "tinybench": "6.0.2"


### PR DESCRIPTION
## Summary

Follow-up dependency bumps after #245.

## pre-commit hooks

- oxfmt `v0.56.0` → `v0.58.0`
- oxlint `v1.71.0` → `v1.73.0`

Syncs the pre-commit hook versions with the oxfmt/oxlint devDependencies bumped in #245, so local hooks and the projects format/lint with the same version. `pre-commit-hooks` (v6.0.0), `actionlint` (v1.7.12) and `whittle` (v0.1.2) are already latest.

## napi

- `napi` 3.10.4 → 3.10.5 (new release since #245). `napi-derive`, `napi-build` and `@napi-rs/cli` are already at their latest.

## Validation

`cargo clippy --workspace --all-targets -- -D warnings` and `cargo test --workspace` pass under Rust 1.97.0. The bumped oxfmt/oxlint pre-commit hooks install and pass `--all-files`.
