### PR TITLE
feat!: make the riri crates consumable as libraries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,8 @@ jobs:
         run: cargo check --workspace
       - name: Lint
         run: cargo clippy --workspace --all-targets
+      - name: Check the library-only configuration
+        run: cargo check -p riri-nce -p riri-npd --no-default-features
       - name: Test
         run: cargo test --workspace --verbose
       - name: Set release-please variables

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,8 @@ jobs:
         run: cargo clippy --workspace --all-targets
       - name: Check the library-only configuration
         run: cargo check -p riri-nce -p riri-npd --no-default-features
+      - name: Lint the refresh path
+        run: cargo clippy -p riri-nce --features refresh --all-targets
       - name: Test
         run: cargo test --workspace --verbose
       - name: Set release-please variables

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -53,6 +53,8 @@ jobs:
         run: cargo check --workspace
       - name: Lint
         run: cargo clippy --workspace --all-targets
+      - name: Check the library-only configuration
+        run: cargo check -p riri-nce -p riri-npd --no-default-features
       - name: Test
         run: cargo test --workspace --verbose
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -55,6 +55,8 @@ jobs:
         run: cargo clippy --workspace --all-targets
       - name: Check the library-only configuration
         run: cargo check -p riri-nce -p riri-npd --no-default-features
+      - name: Lint the refresh path
+        run: cargo clippy -p riri-nce --features refresh --all-targets
       - name: Test
         run: cargo test --workspace --verbose
 

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,7 @@
 {
   "crates/riri-common": "0.1.4",
   "crates/riri-find-up": "0.1.1",
+  "crates/riri-lockfile": "0.1.0",
   "crates/riri-nce": "0.1.5",
   "crates/riri-ncd": "0.1.2",
   "crates/riri-node-lifecycle": "0.1.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1383,6 +1383,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "riri-lockfile"
+version = "0.1.0"
+dependencies = [
+ "riri-common",
+ "riri-npm",
+ "riri-pnpm",
+ "riri-yarn",
+ "rstest",
+ "thiserror",
+]
+
+[[package]]
 name = "riri-napi-ncd"
 version = "0.1.2"
 dependencies = [
@@ -1399,12 +1411,8 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
- "riri-common",
  "riri-nce",
- "riri-npm",
- "riri-pnpm",
  "riri-semver-range",
- "riri-yarn",
  "semver",
  "serde_json",
 ]
@@ -1416,10 +1424,7 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
- "riri-common",
  "riri-npd",
- "riri-npm",
- "riri-pnpm",
  "serde_json",
 ]
 
@@ -1432,6 +1437,7 @@ dependencies = [
  "console",
  "criterion",
  "riri-common",
+ "riri-lockfile",
  "riri-npm",
  "riri-pnpm",
  "riri-semver-range",
@@ -1461,6 +1467,7 @@ dependencies = [
  "dhat",
  "insta",
  "riri-common",
+ "riri-lockfile",
  "riri-node-lifecycle",
  "riri-npm",
  "riri-pnpm",
@@ -1500,6 +1507,7 @@ dependencies = [
  "criterion",
  "insta",
  "riri-common",
+ "riri-lockfile",
  "riri-npm",
  "riri-pnpm",
  "riri-task-runner",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2458,6 +2458,7 @@ dependencies = [
  "riri-node-lifecycle",
  "serde_json",
  "similar 3.1.1",
+ "tempfile",
  "tera",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = ["crates/*"]
 
 [workspace.package]
 edition = "2024"
+rust-version = "1.88.0"
 authors = ["Samuel MARLHENS <samuel.marlhens@proton.me>"]
 license = "BlueOak-1.0.0"
 repository = "https://github.com/smarlhens/riri-node-tools"

--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ riri-npd = { git = "https://github.com/smarlhens/riri-node-tools", rev = "000000
 
 `default-features = false` drops the CLI layer. `refresh`, the HTTP client behind `nce --refresh`, is off by default as well: released binaries enable it, a `cargo install --git` build needs `--features refresh`.
 
-Supported surface and publish plan: [docs/crate-api.md](docs/crate-api.md).
+What is supported is what each crate's rustdoc documents. `pub` alone is not a promise: the `cli` modules exist so the binaries and the NAPI shims can share code and move without notice, and undocumented `pub` items are incidental. Nothing reads the filesystem or opens a socket unless its name says so — `PackageJsonFile::read`, `YarnProject::scan`, the `refresh` feature.
+
+Every crate is `0.1.x`, where cargo treats a minor bump as breaking. A breaking change lands as a `feat!:` commit, which release-please turns into a minor bump; everything else becomes a patch.
 
 ## Benchmarks
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 ## Table of Contents
 
 - [Tools][tools]
+- [Using the crates][crates]
 - [Benchmarks][benchmarks]
 - [Development][development]
 - [License][license-section]
@@ -42,6 +43,20 @@ Prebuilt native binaries are published for:
 | Windows | x64                                    |
 
 ---
+
+## Using the crates
+
+The `riri-*` crates are libraries too. They are not on crates.io yet, so depend on them by git, and pin a `rev` rather than a tag: cargo rejects two dependencies on one git URL with different refs, so per-crate tags cannot be combined.
+
+```toml
+[dependencies]
+riri-nce = { git = "https://github.com/smarlhens/riri-node-tools", rev = "0000000", default-features = false }
+riri-npd = { git = "https://github.com/smarlhens/riri-node-tools", rev = "0000000", default-features = false }
+```
+
+`default-features = false` drops the CLI layer. `refresh`, the HTTP client behind `nce --refresh`, is off by default as well: released binaries enable it, a `cargo install --git` build needs `--features refresh`.
+
+Supported surface and publish plan: [docs/crate-api.md](docs/crate-api.md).
 
 ## Benchmarks
 
@@ -90,6 +105,7 @@ Microbenchmarks (point-in-time, machine-specific) live in [BENCHMARKS.md](BENCHM
 [BlueOak Model License 1.0.0](LICENSE.md).
 
 [tools]: #tools
+[crates]: #using-the-crates
 [benchmarks]: #benchmarks
 [development]: #development
 [license-section]: #license

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Microbenchmarks (point-in-time, machine-specific) live in [BENCHMARKS.md](BENCHM
 
 ### Prerequisites
 
-- [rustc](https://www.rust-lang.org/tools/install) **>=1.85.0 <2.0.0** (_tested with 1.97.1_)
+- [rustc](https://www.rust-lang.org/tools/install) **>=1.88.0 <2.0.0** (_tested with 1.97.1_)
 - [prek](https://prek.j178.dev/) **>=0.3.8** (_tested with 0.4.10_)
 - [node](https://nodejs.org/) **^22.22.2 || ^24.15.0 || >=26.0.0** (_tested with 22.22.2_)
 

--- a/crates/riri-bun/Cargo.toml
+++ b/crates/riri-bun/Cargo.toml
@@ -5,6 +5,8 @@ edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
+repository.workspace = true
+publish = false
 
 [lints]
 workspace = true

--- a/crates/riri-bun/Cargo.toml
+++ b/crates/riri-bun/Cargo.toml
@@ -2,6 +2,7 @@
 name = "riri-bun"
 version = "0.1.0"
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 

--- a/crates/riri-common/Cargo.toml
+++ b/crates/riri-common/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [features]
 sort = ["sort-package-json"]

--- a/crates/riri-common/Cargo.toml
+++ b/crates/riri-common/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "riri-common"
 version = "0.1.4"
+description = "Shared package.json, lockfile & detection primitives for the riri Node.js tools"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/riri-common/Cargo.toml
+++ b/crates/riri-common/Cargo.toml
@@ -3,6 +3,7 @@ name = "riri-common"
 version = "0.1.4"
 description = "Shared package.json, lockfile & detection primitives for the riri Node.js tools"
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 

--- a/crates/riri-common/src/detect.rs
+++ b/crates/riri-common/src/detect.rs
@@ -18,12 +18,6 @@ pub enum DetectError {
     PackageJsonParse(#[from] serde_json::Error),
 }
 
-const LOCKFILE_NAMES: &[(&str, PackageManager)] = &[
-    ("package-lock.json", PackageManager::Npm),
-    ("yarn.lock", PackageManager::Yarn),
-    ("pnpm-lock.yaml", PackageManager::Pnpm),
-];
-
 /// Detect which lockfile exists by walking up from `start`.
 ///
 /// When multiple lockfiles exist in the same directory, the most recently
@@ -33,7 +27,10 @@ const LOCKFILE_NAMES: &[(&str, PackageManager)] = &[
 ///
 /// Returns [`DetectError::NoLockfile`] if no supported lockfile is found.
 pub fn detect_lockfile(start: &Path) -> Result<LockFileResult, DetectError> {
-    let names: Vec<&str> = LOCKFILE_NAMES.iter().map(|(n, _)| *n).collect();
+    let names: Vec<&str> = PackageManager::ALL
+        .iter()
+        .map(|pm| pm.lockfile_name())
+        .collect();
     let matches = riri_find_up::find_up(start, &names);
 
     if matches.is_empty() {
@@ -47,10 +44,7 @@ pub fn detect_lockfile(start: &Path) -> Result<LockFileResult, DetectError> {
         .and_then(|s| s.to_str())
         .unwrap_or_default();
 
-    let package_manager = LOCKFILE_NAMES
-        .iter()
-        .find(|(n, _)| *n == file_name)
-        .map(|(_, pm)| pm.clone())
+    let package_manager = PackageManager::from_lockfile_name(file_name)
         .ok_or_else(|| DetectError::NoLockfile(start.into()))?;
 
     Ok(LockFileResult {

--- a/crates/riri-common/src/lib.rs
+++ b/crates/riri-common/src/lib.rs
@@ -120,6 +120,11 @@ pub struct PackageJson {
 /// Each package manager crate implements this for its own lockfile type.
 pub trait LockfileEngines {
     /// Iterate over `(package_name, engines)` pairs from the lockfile.
+    ///
+    /// `package_name` is the bare package name — `typescript`, `@scope/pkg` —
+    /// never the lockfile's own key. Implementations strip whatever decoration
+    /// their format uses: npm's `node_modules/` path prefixes, pnpm's
+    /// `@version` and peer suffixes. The npm root entry keeps its empty key.
     fn engines_iter(&self) -> Box<dyn Iterator<Item = (&str, &Engines)> + '_>;
 }
 
@@ -222,6 +227,22 @@ pub trait LockfileGraph {
     fn dep_graph(&self, package_json: &PackageJson) -> Result<LockGraph, GraphError>;
 }
 
+/// Bare package name from a `node_modules` path key.
+#[must_use]
+pub fn bare_package_name(key: &str) -> &str {
+    // Not `rfind("node_modules/")`: a multi-byte needle rebuilds a two-way
+    // searcher per call, and this runs once per lockfile entry.
+    let bytes = key.as_bytes();
+    let mut end = bytes.len();
+    while let Some(slash) = bytes[..end].iter().rposition(|&b| b == b'/') {
+        if bytes[..slash].ends_with(b"node_modules") {
+            return &key[slash + 1..];
+        }
+        end = slash;
+    }
+    key
+}
+
 /// Returns `true` if the specifier refers to a local path or workspace alias
 /// rather than a registry package.
 #[must_use]
@@ -247,6 +268,21 @@ mod graph_tests {
             RootDepKind::OptionalDependencies.as_str(),
             "optionalDependencies"
         );
+    }
+
+    #[test]
+    fn bare_package_name_strips_node_modules_segments() {
+        assert_eq!(bare_package_name("node_modules/typescript"), "typescript");
+        assert_eq!(bare_package_name("node_modules/@scope/pkg"), "@scope/pkg");
+        assert_eq!(bare_package_name("node_modules/a/node_modules/b"), "b");
+        assert_eq!(
+            bare_package_name("node_modules/a/node_modules/@scope/b"),
+            "@scope/b"
+        );
+        // Keys that are not node_modules paths pass through untouched.
+        assert_eq!(bare_package_name(""), "");
+        assert_eq!(bare_package_name("typescript"), "typescript");
+        assert_eq!(bare_package_name("packages/app"), "packages/app");
     }
 
     #[test]

--- a/crates/riri-common/src/lib.rs
+++ b/crates/riri-common/src/lib.rs
@@ -14,11 +14,40 @@ use std::fmt;
 use std::path::PathBuf;
 
 /// Package manager kind.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PackageManager {
     Npm,
     Yarn,
     Pnpm,
+}
+
+impl PackageManager {
+    pub const ALL: [Self; 3] = [Self::Npm, Self::Yarn, Self::Pnpm];
+
+    #[must_use]
+    pub const fn lockfile_name(self) -> &'static str {
+        match self {
+            Self::Npm => "package-lock.json",
+            Self::Yarn => "yarn.lock",
+            Self::Pnpm => "pnpm-lock.yaml",
+        }
+    }
+
+    #[must_use]
+    pub fn from_lockfile_name(name: &str) -> Option<Self> {
+        Self::ALL.into_iter().find(|pm| pm.lockfile_name() == name)
+    }
+
+    /// Parse from a lowercase name (`"npm"`, `"pnpm"`, `"yarn"`).
+    #[must_use]
+    pub fn from_str_lowercase(name: &str) -> Option<Self> {
+        match name {
+            "npm" => Some(Self::Npm),
+            "pnpm" => Some(Self::Pnpm),
+            "yarn" => Some(Self::Yarn),
+            _ => None,
+        }
+    }
 }
 
 /// Result of discovering a lockfile on disk.
@@ -283,6 +312,22 @@ mod graph_tests {
         assert_eq!(bare_package_name(""), "");
         assert_eq!(bare_package_name("typescript"), "typescript");
         assert_eq!(bare_package_name("packages/app"), "packages/app");
+    }
+
+    #[test]
+    fn package_manager_round_trips_names() {
+        for pm in PackageManager::ALL {
+            assert_eq!(
+                PackageManager::from_lockfile_name(pm.lockfile_name()),
+                Some(pm)
+            );
+        }
+        assert_eq!(
+            PackageManager::from_str_lowercase("pnpm"),
+            Some(PackageManager::Pnpm)
+        );
+        assert!(PackageManager::from_str_lowercase("bun").is_none());
+        assert!(PackageManager::from_lockfile_name("bun.lockb").is_none());
     }
 
     #[test]

--- a/crates/riri-find-up/Cargo.toml
+++ b/crates/riri-find-up/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "riri-find-up"
 version = "0.1.1"
+description = "Walk up the directory tree to find files"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/riri-find-up/Cargo.toml
+++ b/crates/riri-find-up/Cargo.toml
@@ -3,6 +3,7 @@ name = "riri-find-up"
 version = "0.1.1"
 description = "Walk up the directory tree to find files"
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 

--- a/crates/riri-find-up/Cargo.toml
+++ b/crates/riri-find-up/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/riri-lockfile/Cargo.toml
+++ b/crates/riri-lockfile/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "riri-lockfile"
+version = "0.1.0"
+description = "Parse any supported Node.js lockfile from a string, without touching the filesystem"
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[features]
+graph = [
+    "riri-common/graph",
+    "riri-npm/graph",
+    "riri-pnpm/graph",
+    "riri-yarn/graph",
+]
+
+[dependencies]
+riri-common = { path = "../riri-common", version = "0.1.4" }
+riri-npm = { path = "../riri-npm", version = "0.1.4" }
+riri-pnpm = { path = "../riri-pnpm", version = "0.1.4" }
+riri-yarn = { path = "../riri-yarn", version = "0.1.4" }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+rstest = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/riri-lockfile/src/lib.rs
+++ b/crates/riri-lockfile/src/lib.rs
@@ -1,0 +1,135 @@
+//! Parse any supported lockfile from a string, so consumers stop matching on
+//! package-manager kind and depending on all three parser crates to do it.
+
+#[cfg(feature = "graph")]
+use riri_common::LockfileGraph;
+use riri_common::{LockfileEngines, LockfileVersions, PackageManager};
+use riri_npm::{NpmPackageLock, NpmParseError};
+use riri_pnpm::{PnpmLockfile, PnpmParseError};
+use riri_yarn::{YarnLock, YarnParseError};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum LockfileParseError {
+    #[error(transparent)]
+    Npm(#[from] NpmParseError),
+    #[error(transparent)]
+    Pnpm(#[from] PnpmParseError),
+    #[error(transparent)]
+    Yarn(#[from] YarnParseError),
+}
+
+/// A parsed lockfile of any supported format.
+#[derive(Debug)]
+pub enum ParsedLockfile {
+    Npm(NpmPackageLock),
+    Pnpm(PnpmLockfile),
+    Yarn(YarnLock),
+}
+
+/// Parse `content` as the lockfile format `manager` writes.
+///
+/// # Errors
+///
+/// Returns [`LockfileParseError`] when the content is not a valid lockfile of
+/// that format, wrapping the format-specific parse error.
+pub fn parse_lockfile(
+    manager: PackageManager,
+    content: &str,
+) -> Result<ParsedLockfile, LockfileParseError> {
+    Ok(match manager {
+        PackageManager::Npm => ParsedLockfile::Npm(NpmPackageLock::parse(content)?),
+        PackageManager::Pnpm => ParsedLockfile::Pnpm(PnpmLockfile::parse(content)?),
+        PackageManager::Yarn => ParsedLockfile::Yarn(YarnLock::parse(content)?),
+    })
+}
+
+impl ParsedLockfile {
+    #[must_use]
+    pub fn versions(&self) -> &dyn LockfileVersions {
+        match self {
+            Self::Npm(lock) => lock,
+            Self::Pnpm(lock) => lock,
+            Self::Yarn(lock) => lock,
+        }
+    }
+
+    /// `None` for yarn: `yarn.lock` stores no `engines` at any version, so the
+    /// install tree is the only source — `riri_yarn::YarnProject` (feature
+    /// `scan`), which reads `node_modules` and so cannot live behind a pure
+    /// entry point.
+    /// The dependency graph, which every format can produce.
+    #[cfg(feature = "graph")]
+    #[must_use]
+    pub fn graph(&self) -> &dyn LockfileGraph {
+        match self {
+            Self::Npm(lock) => lock,
+            Self::Pnpm(lock) => lock,
+            Self::Yarn(lock) => lock,
+        }
+    }
+
+    #[must_use]
+    pub fn engines(&self) -> Option<&dyn LockfileEngines> {
+        match self {
+            Self::Npm(lock) => Some(lock),
+            Self::Pnpm(lock) => Some(lock),
+            Self::Yarn(_) => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_lockfile;
+    use riri_common::PackageManager;
+
+    const NPM_V3: &str = r#"{
+        "lockfileVersion": 3,
+        "packages": {
+            "": {"name": "app"},
+            "node_modules/typescript": {"version": "5.4.5", "engines": {"node": ">=14.17"}}
+        }
+    }"#;
+
+    const PNPM_V9: &str = "lockfileVersion: '9.0'\nimporters:\n  .:\n    dependencies:\n      typescript:\n        specifier: ^5.4.0\n        version: 5.4.5\npackages:\n  typescript@5.4.5:\n    engines: {node: '>=14.17'}\n";
+
+    const YARN_V1: &str = "# yarn lockfile v1\n\n\ntypescript@^5.4.0:\n  version \"5.4.5\"\n";
+
+    #[test]
+    fn parses_npm_versions_and_engines() {
+        let lock = parse_lockfile(PackageManager::Npm, NPM_V3).expect("parses");
+        assert_eq!(lock.versions().version_for("typescript"), Some("5.4.5"));
+        let engines = lock.engines().expect("npm lockfiles carry engines");
+        assert_eq!(
+            engines.engines_iter().count(),
+            1,
+            "one entry declares engines"
+        );
+    }
+
+    #[test]
+    fn parses_pnpm_versions_and_engines() {
+        let lock = parse_lockfile(PackageManager::Pnpm, PNPM_V9).expect("parses");
+        assert_eq!(lock.versions().version_for("typescript"), Some("5.4.5"));
+        assert!(lock.engines().is_some());
+    }
+
+    #[test]
+    fn parses_yarn_versions_but_reports_no_engines() {
+        let lock = parse_lockfile(PackageManager::Yarn, YARN_V1).expect("parses");
+        assert_eq!(
+            lock.versions().resolved_version("typescript", "^5.4.0"),
+            Some("5.4.5")
+        );
+        assert!(
+            lock.engines().is_none(),
+            "yarn.lock stores no engines at any version"
+        );
+    }
+
+    #[test]
+    fn wrong_format_for_the_content_is_an_error() {
+        assert!(parse_lockfile(PackageManager::Npm, YARN_V1).is_err());
+    }
+}

--- a/crates/riri-lockfile/tests/engines_names.rs
+++ b/crates/riri-lockfile/tests/engines_names.rs
@@ -1,0 +1,65 @@
+#![allow(clippy::tests_outside_test_module)]
+
+//! `LockfileEngines::engines_iter` promises bare package names. The three
+//! implementations live in downstream crates, so the invariant is checked here —
+//! the one crate that can see all of them — over the whole fixture corpus.
+
+use riri_common::PackageManager;
+use riri_lockfile::parse_lockfile;
+use std::path::{Path, PathBuf};
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("crate manifest under workspace")
+        .to_path_buf()
+}
+
+#[test]
+fn engines_iter_yields_bare_package_names() {
+    let fixtures = workspace_root().join("fixtures");
+    let mut names = 0_usize;
+
+    for entry in std::fs::read_dir(&fixtures).expect("read fixtures dir") {
+        let dir = entry.expect("fixture entry").path();
+        if !dir.is_dir() {
+            continue;
+        }
+        for manager in PackageManager::ALL {
+            let lockfile = dir.join(manager.lockfile_name());
+            if !lockfile.exists() {
+                continue;
+            }
+            let content = std::fs::read_to_string(&lockfile).expect("read lockfile");
+            let Ok(parsed) = parse_lockfile(manager, &content) else {
+                continue;
+            };
+            let Some(engines) = parsed.engines() else {
+                continue;
+            };
+
+            for (name, _) in engines.engines_iter() {
+                let at = || format!("{name} in {}", lockfile.display());
+                assert!(
+                    !name.contains("node_modules"),
+                    "path prefix left in: {}",
+                    at()
+                );
+                assert!(!name.starts_with('/'), "leading slash left in: {}", at());
+                assert!(!name.contains('('), "peer suffix left in: {}", at());
+                assert!(
+                    !name.get(1..).is_some_and(|rest| rest.contains('@')),
+                    "version suffix left in: {}",
+                    at()
+                );
+                names += 1;
+            }
+        }
+    }
+
+    assert!(
+        names > 50,
+        "fixture corpus should exercise this heavily, saw {names} names"
+    );
+}

--- a/crates/riri-napi-ncd/Cargo.toml
+++ b/crates/riri-napi-ncd/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "riri-napi-ncd"
 version = "0.1.2"
+description = "Find deprecated packages in the lockfile dependency tree"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/riri-napi-ncd/Cargo.toml
+++ b/crates/riri-napi-ncd/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [lib]
 crate-type = ["cdylib"]

--- a/crates/riri-napi-ncd/Cargo.toml
+++ b/crates/riri-napi-ncd/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 [dependencies]
 napi = { workspace = true }
 napi-derive = { workspace = true }
-riri-ncd = { path = "../riri-ncd", version = "0.1.2" }
+riri-ncd = { path = "../riri-ncd", version = "0.1.2", default-features = false, features = ["cli"] }
 
 [build-dependencies]
 napi-build = { workspace = true }

--- a/crates/riri-napi-ncd/Cargo.toml
+++ b/crates/riri-napi-ncd/Cargo.toml
@@ -3,6 +3,7 @@ name = "riri-napi-ncd"
 version = "0.1.2"
 description = "Find deprecated packages in the lockfile dependency tree"
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 

--- a/crates/riri-napi-ncd/README.md
+++ b/crates/riri-napi-ncd/README.md
@@ -129,7 +129,7 @@ if (tree) {
 ## Options
 
 ```text
-Core logic for npm-check-deprecations
+Find deprecated packages in the lockfile dependency tree & show the chains that pull them in
 
 Usage: ncd [OPTIONS]
 

--- a/crates/riri-napi-nce/Cargo.toml
+++ b/crates/riri-napi-nce/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [lib]
 crate-type = ["cdylib"]
@@ -13,13 +14,9 @@ crate-type = ["cdylib"]
 [dependencies]
 napi = { workspace = true }
 napi-derive = { workspace = true }
-riri-common = { path = "../riri-common", version = "0.1.4" }
 riri-nce = { path = "../riri-nce", version = "0.1.5", default-features = false, features = ["cli"] }
-riri-npm = { path = "../riri-npm", version = "0.1.4" }
-riri-pnpm = { path = "../riri-pnpm", version = "0.1.4" }
 riri-semver-range = { path = "../riri-semver-range", version = "0.1.2" }
 semver = { workspace = true }
-riri-yarn = { path = "../riri-yarn", version = "0.1.4" }
 serde_json = { workspace = true }
 
 [build-dependencies]

--- a/crates/riri-napi-nce/Cargo.toml
+++ b/crates/riri-napi-nce/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib"]
 napi = { workspace = true }
 napi-derive = { workspace = true }
 riri-common = { path = "../riri-common", version = "0.1.4" }
-riri-nce = { path = "../riri-nce", version = "0.1.5", default-features = false }
+riri-nce = { path = "../riri-nce", version = "0.1.5", default-features = false, features = ["cli"] }
 riri-npm = { path = "../riri-npm", version = "0.1.4" }
 riri-pnpm = { path = "../riri-pnpm", version = "0.1.4" }
 riri-semver-range = { path = "../riri-semver-range", version = "0.1.2" }

--- a/crates/riri-napi-nce/Cargo.toml
+++ b/crates/riri-napi-nce/Cargo.toml
@@ -3,6 +3,7 @@ name = "riri-napi-nce"
 version = "1.3.1"
 description = "Check and update Node.js engine constraints in package.json"
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 

--- a/crates/riri-napi-nce/README.md
+++ b/crates/riri-napi-nce/README.md
@@ -133,7 +133,7 @@ import {
 ## CLI Options
 
 ```text
-Check and update Node.js engine constraints in package.json based on the dependency tree from the lockfile
+Check & update Node.js engine constraints in package.json from the lockfile dependency tree
 
 Usage: nce [OPTIONS]
 

--- a/crates/riri-napi-nce/src/check_engines.rs
+++ b/crates/riri-napi-nce/src/check_engines.rs
@@ -1,7 +1,8 @@
 use napi_derive::napi;
-use riri_common::{EngineConstraintKey, Engines, LockfileEngines, PackageJson};
-use riri_nce::{CheckEnginesInput, check_engines as nce_check_engines};
-use riri_semver_range::VersionPrecision;
+use riri_nce::{
+    CheckEnginesInput, EngineConstraintKey, Engines, PackageJson, PackageManager, ParsedLockfile,
+    VersionPrecision, check_engines as nce_check_engines, parse_lockfile,
+};
 use std::collections::HashMap;
 
 #[napi(object)]
@@ -37,25 +38,18 @@ fn parse_precision(input: Option<&str>) -> VersionPrecision {
 fn parse_lockfile_engines(
     content: &str,
     lockfile_type: Option<&str>,
-) -> napi::Result<Box<dyn LockfileEngines>> {
-    match lockfile_type.unwrap_or("npm") {
-        "npm" => riri_npm::NpmPackageLock::parse(content)
-            .map(|lock| Box::new(lock) as Box<dyn LockfileEngines>)
-            .map_err(|error| {
-                napi::Error::from_reason(format!("failed to parse npm lockfile: {error}"))
-            }),
-        "pnpm" => riri_pnpm::PnpmLockfile::parse(content)
-            .map(|lock| Box::new(lock) as Box<dyn LockfileEngines>)
-            .map_err(|error| {
-                napi::Error::from_reason(format!("failed to parse pnpm lockfile: {error}"))
-            }),
-        "yarn" => Err(napi::Error::from_reason(
+) -> napi::Result<ParsedLockfile> {
+    let kind = lockfile_type.unwrap_or("npm");
+    let manager = PackageManager::from_str_lowercase(kind)
+        .ok_or_else(|| napi::Error::from_reason(format!("unknown lockfile type: {kind}")))?;
+    if manager == PackageManager::Yarn {
+        return Err(napi::Error::from_reason(
             "yarn lockfile parsing requires a directory path, not string content — use the CLI instead",
-        )),
-        other => Err(napi::Error::from_reason(format!(
-            "unknown lockfile type: {other}"
-        ))),
+        ));
     }
+    parse_lockfile(manager, content).map_err(|error| {
+        napi::Error::from_reason(format!("failed to parse {kind} lockfile: {error}"))
+    })
 }
 
 #[napi]
@@ -68,7 +62,10 @@ pub fn check_engines(options: CheckEnginesOptions) -> napi::Result<CheckEnginesR
     let lockfile =
         parse_lockfile_engines(&options.lockfile_content, options.lockfile_type.as_deref())?;
 
-    let entries: Vec<(&str, &Engines)> = lockfile.engines_iter().collect();
+    let engines = lockfile.engines().ok_or_else(|| {
+        napi::Error::from_reason("lockfile format records no engines".to_string())
+    })?;
+    let entries: Vec<(&str, &Engines)> = engines.engines_iter().collect();
 
     let filter_engines: Vec<EngineConstraintKey> = options
         .filter_engines

--- a/crates/riri-napi-npd/Cargo.toml
+++ b/crates/riri-napi-npd/Cargo.toml
@@ -3,6 +3,7 @@ name = "riri-napi-npd"
 version = "1.1.1"
 description = "Pin dependency ranges in package.json to the versions the lockfile resolved"
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 

--- a/crates/riri-napi-npd/Cargo.toml
+++ b/crates/riri-napi-npd/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "riri-napi-npd"
 version = "1.1.1"
+description = "Pin dependency ranges in package.json to the versions the lockfile resolved"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/riri-napi-npd/Cargo.toml
+++ b/crates/riri-napi-npd/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [lib]
 crate-type = ["cdylib"]
@@ -13,10 +14,7 @@ crate-type = ["cdylib"]
 [dependencies]
 napi = { workspace = true }
 napi-derive = { workspace = true }
-riri-common = { path = "../riri-common", version = "0.1.4" }
 riri-npd = { path = "../riri-npd", version = "0.1.4", default-features = false, features = ["cli"] }
-riri-npm = { path = "../riri-npm", version = "0.1.4" }
-riri-pnpm = { path = "../riri-pnpm", version = "0.1.4" }
 serde_json = { workspace = true }
 
 [build-dependencies]

--- a/crates/riri-napi-npd/Cargo.toml
+++ b/crates/riri-napi-npd/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib"]
 napi = { workspace = true }
 napi-derive = { workspace = true }
 riri-common = { path = "../riri-common", version = "0.1.4" }
-riri-npd = { path = "../riri-npd", version = "0.1.4" }
+riri-npd = { path = "../riri-npd", version = "0.1.4", default-features = false, features = ["cli"] }
 riri-npm = { path = "../riri-npm", version = "0.1.4" }
 riri-pnpm = { path = "../riri-pnpm", version = "0.1.4" }
 serde_json = { workspace = true }

--- a/crates/riri-napi-npd/README.md
+++ b/crates/riri-napi-npd/README.md
@@ -114,7 +114,7 @@ for (const { name, kind, from, to } of pins) {
 ## Options
 
 ```text
-Pin range-based dependency specifiers to the exact versions resolved by the lockfile
+Pin dependency ranges in package.json to the versions the lockfile resolved
 
 Usage: npd [OPTIONS]
 

--- a/crates/riri-napi-npd/src/lib.rs
+++ b/crates/riri-napi-npd/src/lib.rs
@@ -7,8 +7,10 @@
 #![allow(clippy::missing_errors_doc)]
 
 use napi_derive::napi;
-use riri_common::{LockfileVersions, PackageJson};
-use riri_npd::pin_dependencies as npd_pin_dependencies;
+use riri_npd::{
+    PackageJson, PackageManager, ParsedLockfile, parse_lockfile,
+    pin_dependencies as npd_pin_dependencies,
+};
 
 #[napi(object)]
 pub struct DependencyPin {
@@ -33,25 +35,18 @@ pub struct PinDependenciesOptions {
 fn parse_lockfile_versions(
     content: &str,
     lockfile_type: Option<&str>,
-) -> napi::Result<Box<dyn LockfileVersions>> {
-    match lockfile_type.unwrap_or("npm") {
-        "npm" => riri_npm::NpmPackageLock::parse(content)
-            .map(|lock| Box::new(lock) as Box<dyn LockfileVersions>)
-            .map_err(|error| {
-                napi::Error::from_reason(format!("failed to parse npm lockfile: {error}"))
-            }),
-        "pnpm" => riri_pnpm::PnpmLockfile::parse(content)
-            .map(|lock| Box::new(lock) as Box<dyn LockfileVersions>)
-            .map_err(|error| {
-                napi::Error::from_reason(format!("failed to parse pnpm lockfile: {error}"))
-            }),
-        "yarn" => Err(napi::Error::from_reason(
+) -> napi::Result<ParsedLockfile> {
+    let kind = lockfile_type.unwrap_or("npm");
+    let manager = PackageManager::from_str_lowercase(kind)
+        .ok_or_else(|| napi::Error::from_reason(format!("unknown lockfile type: {kind}")))?;
+    if manager == PackageManager::Yarn {
+        return Err(napi::Error::from_reason(
             "yarn lockfile parsing requires a directory path, not string content — use pinDependenciesFromPath instead",
-        )),
-        other => Err(napi::Error::from_reason(format!(
-            "unknown lockfile type: {other}"
-        ))),
+        ));
     }
+    parse_lockfile(manager, content).map_err(|error| {
+        napi::Error::from_reason(format!("failed to parse {kind} lockfile: {error}"))
+    })
 }
 
 /// Run the `npd` CLI in-process. `argv` must include the program name at
@@ -72,7 +67,7 @@ pub fn pin_dependencies(options: PinDependenciesOptions) -> napi::Result<PinDepe
     let lockfile =
         parse_lockfile_versions(&options.lockfile_content, options.lockfile_type.as_deref())?;
 
-    let pins = npd_pin_dependencies(&package_json, lockfile.as_ref())
+    let pins = npd_pin_dependencies(&package_json, lockfile.versions())
         .map_err(|error| napi::Error::from_reason(format!("pin_dependencies failed: {error}")))?
         .into_iter()
         .map(|pin| DependencyPin {

--- a/crates/riri-ncd/Cargo.toml
+++ b/crates/riri-ncd/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "Core logic for npm-check-deprecations"
+description = "Find deprecated packages in the lockfile dependency tree & show the chains that pull them in"
 
 [[bin]]
 name = "ncd"

--- a/crates/riri-ncd/Cargo.toml
+++ b/crates/riri-ncd/Cargo.toml
@@ -20,6 +20,7 @@ required-features = ["cli"]
 
 [dependencies]
 riri-common = { path = "../riri-common", version = "0.1.4", features = ["graph"] }
+riri-lockfile = { path = "../riri-lockfile", version = "0.1.0", features = ["graph"] }
 riri-npm = { path = "../riri-npm", version = "0.1.4", features = ["graph"] }
 riri-pnpm = { path = "../riri-pnpm", version = "0.1.4", features = ["graph"] }
 riri-semver-range = { path = "../riri-semver-range", version = "0.1.2" }

--- a/crates/riri-ncd/Cargo.toml
+++ b/crates/riri-ncd/Cargo.toml
@@ -11,29 +11,40 @@ description = "Find deprecated packages in the lockfile dependency tree & show t
 [[bin]]
 name = "ncd"
 path = "src/bin/ncd.rs"
+required-features = ["cli"]
 
 [[bin]]
 name = "npm-check-deprecations"
 path = "src/bin/npm-check-deprecations.rs"
+required-features = ["cli"]
 
 [dependencies]
 riri-common = { path = "../riri-common", version = "0.1.4", features = ["graph"] }
 riri-npm = { path = "../riri-npm", version = "0.1.4", features = ["graph"] }
 riri-pnpm = { path = "../riri-pnpm", version = "0.1.4", features = ["graph"] }
 riri-semver-range = { path = "../riri-semver-range", version = "0.1.2" }
-riri-task-runner = { path = "../riri-task-runner", version = "0.1.2" }
-riri-workspace = { path = "../riri-workspace", version = "0.1.4" }
+riri-task-runner = { path = "../riri-task-runner", version = "0.1.2", optional = true }
+riri-workspace = { path = "../riri-workspace", version = "0.1.4", optional = true }
 riri-yarn = { path = "../riri-yarn", version = "0.1.4", features = ["graph"] }
 anyhow = { workspace = true }
-clap = { workspace = true }
+clap = { workspace = true, optional = true }
 console = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
+tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"], optional = true }
 ureq = { workspace = true }
+
+[features]
+default = ["cli"]
+cli = [
+    "dep:clap",
+    "dep:riri-task-runner",
+    "dep:riri-workspace",
+    "dep:tracing-subscriber",
+]
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/crates/riri-ncd/Cargo.toml
+++ b/crates/riri-ncd/Cargo.toml
@@ -2,6 +2,7 @@
 name = "riri-ncd"
 version = "0.1.2"
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/riri-ncd/src/cli.rs
+++ b/crates/riri-ncd/src/cli.rs
@@ -5,14 +5,11 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use console::style;
 use riri_common::{
-    LockGraph, LockfileGraph, NpmrcRegistryConfig, PackageJson, PackageManager, detect_lockfile,
-    find_package_json,
+    LockGraph, NpmrcRegistryConfig, PackageJson, PackageManager, detect_lockfile, find_package_json,
 };
-use riri_npm::NpmPackageLock;
-use riri_pnpm::PnpmLockfile;
+use riri_lockfile::{ParsedLockfile, parse_lockfile};
 use riri_task_runner::{RendererMode, TaskRunner};
 use riri_workspace::{WorkspaceMember, WorkspaceProject};
-use riri_yarn::YarnLock;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
@@ -65,24 +62,17 @@ fn renderer_mode(args: &Args) -> RendererMode {
 
 /// Parse the detected lockfile and extract its full dependency graph.
 fn load_graph(
-    manager: &PackageManager,
+    manager: PackageManager,
     lockfile_path: &Path,
     package_json: &PackageJson,
 ) -> Result<LockGraph> {
     let content = std::fs::read_to_string(lockfile_path)
         .with_context(|| format!("failed to read {}", lockfile_path.display()))?;
-    let graph = match manager {
-        PackageManager::Npm => NpmPackageLock::parse(&content)
-            .context("failed to parse package-lock.json")?
-            .dep_graph(package_json),
-        PackageManager::Pnpm => PnpmLockfile::parse(&content)
-            .context("failed to parse pnpm-lock.yaml")?
-            .dep_graph(package_json),
-        PackageManager::Yarn => YarnLock::parse(&content)
-            .context("failed to parse yarn.lock")?
-            .dep_graph(package_json),
-    };
-    graph.map_err(|e| anyhow::anyhow!("failed to build dependency graph: {e}"))
+    parse_lockfile(manager, &content)
+        .with_context(|| format!("failed to parse {}", manager.lockfile_name()))?
+        .graph()
+        .dep_graph(package_json)
+        .map_err(|e| anyhow::anyhow!("failed to build dependency graph: {e}"))
 }
 
 fn project_name(package_json: &PackageJson, cwd: &Path) -> String {
@@ -147,7 +137,7 @@ pub fn run_with_source(args: &Args, cwd: &Path, source: &dyn DeprecationSource) 
 
     let task = runner.task("Building dependency graph...");
     let graph = match load_graph(
-        &lockfile_result.package_manager,
+        lockfile_result.package_manager,
         &lockfile_result.path,
         &package_json,
     ) {
@@ -227,23 +217,11 @@ impl DeprecationSource for MapSource {
 
 /// Parse the detected lockfile once into a graph-capable handle reused across
 /// every workspace member.
-fn parse_lockfile_graph(
-    manager: &PackageManager,
-    lockfile_path: &Path,
-) -> Result<Box<dyn LockfileGraph>> {
+fn parse_lockfile_graph(manager: PackageManager, lockfile_path: &Path) -> Result<ParsedLockfile> {
     let content = std::fs::read_to_string(lockfile_path)
         .with_context(|| format!("failed to read {}", lockfile_path.display()))?;
-    Ok(match manager {
-        PackageManager::Npm => {
-            Box::new(NpmPackageLock::parse(&content).context("failed to parse package-lock.json")?)
-        }
-        PackageManager::Pnpm => {
-            Box::new(PnpmLockfile::parse(&content).context("failed to parse pnpm-lock.yaml")?)
-        }
-        PackageManager::Yarn => {
-            Box::new(YarnLock::parse(&content).context("failed to parse yarn.lock")?)
-        }
-    })
+    parse_lockfile(manager, &content)
+        .with_context(|| format!("failed to parse {}", manager.lockfile_name()))
 }
 
 fn read_member_pkg(member: &WorkspaceMember) -> Result<PackageJson> {
@@ -288,7 +266,7 @@ fn analyze_workspace(
 
     let task = runner.task("Parsing lockfile...");
     let lockfile =
-        match parse_lockfile_graph(&lockfile_result.package_manager, &lockfile_result.path) {
+        match parse_lockfile_graph(lockfile_result.package_manager, &lockfile_result.path) {
             Ok(lock) => {
                 task.complete("Parsed lockfile");
                 lock
@@ -303,7 +281,7 @@ fn analyze_workspace(
     let mut member_graphs: Vec<(WorkspaceMember, LockGraph)> = Vec::new();
     for member in members {
         let pkg = read_member_pkg(&member).map_err(|e| anyhow::anyhow!("{}: {e}", member.name))?;
-        let graph = lockfile.dep_graph(&pkg).map_err(|e| {
+        let graph = lockfile.graph().dep_graph(&pkg).map_err(|e| {
             anyhow::anyhow!("{}: failed to build dependency graph: {e}", member.name)
         })?;
         member_graphs.push((member, graph));
@@ -560,7 +538,7 @@ mod tests {
         let path = fixture(dir);
         let result = detect_lockfile(&path).unwrap();
         let (pkg, _) = find_package_json(&path).unwrap();
-        let graph = load_graph(&result.package_manager, &result.path, &pkg).unwrap();
+        let graph = load_graph(result.package_manager, &result.path, &pkg).unwrap();
         analyze(&graph, "ncd-fixture", source).unwrap()
     }
 

--- a/crates/riri-ncd/src/lib.rs
+++ b/crates/riri-ncd/src/lib.rs
@@ -5,6 +5,9 @@ pub mod cli;
 pub mod registry;
 pub mod render;
 
+pub use analyze::Report;
+pub use riri_common::{LockGraph, NpmrcRegistryConfig};
+
 use semver::Version;
 use serde::Deserialize;
 use std::collections::HashMap;

--- a/crates/riri-ncd/src/lib.rs
+++ b/crates/riri-ncd/src/lib.rs
@@ -1,6 +1,7 @@
 //! Core logic for `npm-check-deprecations`.
 
 pub mod analyze;
+#[cfg(feature = "cli")]
 pub mod cli;
 pub mod registry;
 pub mod render;

--- a/crates/riri-ncd/src/lib.rs
+++ b/crates/riri-ncd/src/lib.rs
@@ -30,24 +30,18 @@ pub fn check_deprecations_from_content(
     registry: Option<String>,
 ) -> anyhow::Result<analyze::Report> {
     use anyhow::Context as _;
-    use riri_common::{LockfileGraph as _, NpmrcRegistryConfig, PackageJson};
+    use riri_common::{NpmrcRegistryConfig, PackageJson, PackageManager};
 
     let pkg: PackageJson =
         serde_json::from_str(package_json).context("failed to parse package.json")?;
 
-    let graph = match lockfile_type {
-        "npm" => riri_npm::NpmPackageLock::parse(lockfile_content)
-            .context("failed to parse package-lock.json")?
-            .dep_graph(&pkg),
-        "pnpm" => riri_pnpm::PnpmLockfile::parse(lockfile_content)
-            .context("failed to parse pnpm-lock.yaml")?
-            .dep_graph(&pkg),
-        "yarn" => riri_yarn::YarnLock::parse(lockfile_content)
-            .context("failed to parse yarn.lock")?
-            .dep_graph(&pkg),
-        other => anyhow::bail!("unknown lockfile type: {other}"),
-    }
-    .map_err(|e| anyhow::anyhow!("failed to build dependency graph: {e}"))?;
+    let manager = PackageManager::from_str_lowercase(lockfile_type)
+        .ok_or_else(|| anyhow::anyhow!("unknown lockfile type: {lockfile_type}"))?;
+    let graph = riri_lockfile::parse_lockfile(manager, lockfile_content)
+        .with_context(|| format!("failed to parse {}", manager.lockfile_name()))?
+        .graph()
+        .dep_graph(&pkg)
+        .map_err(|e| anyhow::anyhow!("failed to build dependency graph: {e}"))?;
 
     let project_name = pkg.name.clone().unwrap_or_else(|| "project".to_string());
     let client = registry::RegistryClient::new(NpmrcRegistryConfig::default(), registry);

--- a/crates/riri-nce/Cargo.toml
+++ b/crates/riri-nce/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "riri-nce"
 version = "0.1.5"
+description = "Check & update Node.js engine constraints in package.json from the lockfile dependency tree"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/riri-nce/Cargo.toml
+++ b/crates/riri-nce/Cargo.toml
@@ -38,7 +38,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"], optional = true }
 
 [features]
-default = ["cli", "refresh"]
+default = ["cli"]
 cli = [
     "dep:anyhow",
     "dep:clap",
@@ -49,6 +49,9 @@ cli = [
     "riri-common/sort",
 ]
 refresh = ["riri-node-lifecycle/refresh"]
+
+[package.metadata.dist]
+features = ["refresh"]
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/crates/riri-nce/Cargo.toml
+++ b/crates/riri-nce/Cargo.toml
@@ -3,6 +3,7 @@ name = "riri-nce"
 version = "0.1.5"
 description = "Check & update Node.js engine constraints in package.json from the lockfile dependency tree"
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/riri-nce/Cargo.toml
+++ b/crates/riri-nce/Cargo.toml
@@ -20,6 +20,7 @@ required-features = ["cli"]
 
 [dependencies]
 riri-common = { path = "../riri-common", version = "0.1.4" }
+riri-lockfile = { path = "../riri-lockfile", version = "0.1.0" }
 riri-node-lifecycle = { path = "../riri-node-lifecycle", version = "0.1.3" }
 riri-npm = { path = "../riri-npm", version = "0.1.4" }
 riri-pnpm = { path = "../riri-pnpm", version = "0.1.4" }

--- a/crates/riri-nce/Cargo.toml
+++ b/crates/riri-nce/Cargo.toml
@@ -11,32 +11,43 @@ repository.workspace = true
 [[bin]]
 name = "nce"
 path = "src/bin/nce.rs"
+required-features = ["cli"]
 
 [[bin]]
 name = "npm-check-engines"
 path = "src/bin/npm-check-engines.rs"
+required-features = ["cli"]
 
 [dependencies]
-riri-common = { path = "../riri-common", version = "0.1.4", features = ["sort"] }
+riri-common = { path = "../riri-common", version = "0.1.4" }
 riri-node-lifecycle = { path = "../riri-node-lifecycle", version = "0.1.3" }
 riri-npm = { path = "../riri-npm", version = "0.1.4" }
 riri-pnpm = { path = "../riri-pnpm", version = "0.1.4" }
 riri-semver-range = { path = "../riri-semver-range", version = "0.1.2" }
 riri-yarn = { path = "../riri-yarn", version = "0.1.4", features = ["scan"] }
-riri-task-runner = { path = "../riri-task-runner", version = "0.1.2" }
-anyhow = { workspace = true }
+riri-task-runner = { path = "../riri-task-runner", version = "0.1.2", optional = true }
+anyhow = { workspace = true, optional = true }
 chrono = { workspace = true }
-clap = { workspace = true }
-comfy-table = { workspace = true }
-console = { workspace = true }
+clap = { workspace = true, optional = true }
+comfy-table = { workspace = true, optional = true }
+console = { workspace = true, optional = true }
 semver = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
+tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"], optional = true }
 
 [features]
-default = ["refresh"]
+default = ["cli", "refresh"]
+cli = [
+    "dep:anyhow",
+    "dep:clap",
+    "dep:comfy-table",
+    "dep:console",
+    "dep:riri-task-runner",
+    "dep:tracing-subscriber",
+    "riri-common/sort",
+]
 refresh = ["riri-node-lifecycle/refresh"]
 
 [dev-dependencies]

--- a/crates/riri-nce/src/cli.rs
+++ b/crates/riri-nce/src/cli.rs
@@ -375,7 +375,7 @@ fn run(args: &Args) -> Result<i32> {
     // Update if requested
     if args.update {
         let task = runner.task("Updating package.json...");
-        apply_engines_update(&mut pkg_file, &output.engines_range_to_set);
+        apply_engines_update(&mut pkg_file.raw, &output.engines_range_to_set);
         if args.sort {
             pkg_file
                 .write_sorted()

--- a/crates/riri-nce/src/cli.rs
+++ b/crates/riri-nce/src/cli.rs
@@ -10,9 +10,8 @@ use riri_common::{
     EngineConstraintKey, LockfileEngines, PackageJsonFile, PackageManager, detect_lockfile,
     to_pretty_json_preserving_indent,
 };
+use riri_lockfile::parse_lockfile;
 use riri_node_lifecycle::{LifecycleData, Policy};
-use riri_npm::NpmPackageLock;
-use riri_pnpm::PnpmLockfile;
 use riri_semver_range::VersionPrecision;
 use riri_task_runner::{RendererMode, TaskRunner};
 use riri_yarn::YarnProject;
@@ -229,27 +228,9 @@ fn run(args: &Args) -> Result<i32> {
     let lockfile_content =
         std::fs::read_to_string(&lockfile_result.path).context("failed to read lockfile")?;
 
-    let parsed_lock: Box<dyn LockfileEngines> = match lockfile_result.package_manager {
-        PackageManager::Npm => match NpmPackageLock::parse(&lockfile_content) {
-            Err(e) => {
-                task.fail("Parsing lockfile");
-                return Err(anyhow::anyhow!(e));
-            }
-            Ok(lock) => {
-                task.complete("Parsed lockfile");
-                Box::new(lock)
-            }
-        },
-        PackageManager::Pnpm => match PnpmLockfile::parse(&lockfile_content) {
-            Err(e) => {
-                task.fail("Parsing lockfile");
-                return Err(anyhow::anyhow!(e));
-            }
-            Ok(lock) => {
-                task.complete("Parsed lockfile");
-                Box::new(lock)
-            }
-        },
+    let yarn_project;
+    let parsed_lock;
+    let lockfile_engines: &dyn LockfileEngines = match lockfile_result.package_manager {
         PackageManager::Yarn => {
             let project_dir = lockfile_result
                 .path
@@ -262,15 +243,29 @@ fn run(args: &Args) -> Result<i32> {
                 }
                 Ok(project) => {
                     task.complete("Scanned node_modules");
-                    Box::new(project)
+                    yarn_project = project;
+                    &yarn_project
                 }
             }
         }
+        manager => match parse_lockfile(manager, &lockfile_content) {
+            Err(e) => {
+                task.fail("Parsing lockfile");
+                return Err(anyhow::anyhow!(e));
+            }
+            Ok(lock) => {
+                task.complete("Parsed lockfile");
+                parsed_lock = lock;
+                parsed_lock
+                    .engines()
+                    .context("lockfile format records no engines")?
+            }
+        },
     };
 
     // Compute engine constraints
     let task = runner.task("Computing engine constraints...");
-    let entries: Vec<(&str, &riri_common::Engines)> = parsed_lock.engines_iter().collect();
+    let entries: Vec<(&str, &riri_common::Engines)> = lockfile_engines.engines_iter().collect();
     let filter_engines = parse_engine_filters(&args.engines);
 
     let input = CheckEnginesInput {

--- a/crates/riri-nce/src/cli.rs
+++ b/crates/riri-nce/src/cli.rs
@@ -587,7 +587,7 @@ fn refresh_user_cache(args: &Args) -> Result<()> {
 #[cfg(not(feature = "refresh"))]
 fn refresh_user_cache(_args: &Args) -> Result<()> {
     Err(anyhow::anyhow!(
-        "--refresh requires the `refresh` feature; use the standalone `nce` binary",
+        "--refresh requires the `refresh` feature; use a released `nce` binary or rebuild with `--features refresh`",
     ))
 }
 

--- a/crates/riri-nce/src/lib.rs
+++ b/crates/riri-nce/src/lib.rs
@@ -12,7 +12,8 @@ mod npm_bump;
 mod policy;
 
 pub use chrono::NaiveDate;
-pub use riri_common::{EngineConstraintKey, Engines, LockfileEngines, PackageJson};
+pub use riri_common::{EngineConstraintKey, Engines, LockfileEngines, PackageJson, PackageManager};
+pub use riri_lockfile::{LockfileParseError, ParsedLockfile, parse_lockfile};
 pub use riri_node_lifecycle::{LifecycleData, Policy};
 pub use riri_npm::{NpmPackageLock, NpmParseError};
 pub use riri_pnpm::{PnpmLockfile, PnpmParseError};

--- a/crates/riri-nce/src/lib.rs
+++ b/crates/riri-nce/src/lib.rs
@@ -10,6 +10,14 @@ mod mutate;
 mod npm_bump;
 mod policy;
 
+pub use chrono::NaiveDate;
+pub use riri_common::{EngineConstraintKey, Engines, LockfileEngines, PackageJson};
+pub use riri_node_lifecycle::{LifecycleData, Policy};
+pub use riri_npm::{NpmPackageLock, NpmParseError};
+pub use riri_pnpm::{PnpmLockfile, PnpmParseError};
+pub use riri_semver_range::VersionPrecision;
+pub use riri_yarn::{YarnProject, YarnScanError};
+
 pub use compute::{
     CheckEnginesInput, CheckEnginesOutput, EngineRangeToSet, check_engines,
     compute_engines_constraint, get_constraint_from_engines,

--- a/crates/riri-nce/src/lib.rs
+++ b/crates/riri-nce/src/lib.rs
@@ -3,6 +3,7 @@
 //! Computes the most restrictive engine constraints from a lockfile's
 //! dependency entries and compares them against the project's `package.json`.
 
+#[cfg(feature = "cli")]
 pub mod cli;
 mod compute;
 mod lifecycle;

--- a/crates/riri-nce/src/mutate.rs
+++ b/crates/riri-nce/src/mutate.rs
@@ -1,76 +1,111 @@
 //! Mutation helpers for applying engine constraint updates.
 
 use crate::EngineRangeToSet;
-use riri_common::PackageJsonFile;
 
-/// Apply computed engine updates to a `PackageJsonFile`'s raw JSON value.
-///
-/// For each engine change, sets `raw["engines"][key] = range_to_set`.
-/// Creates the `"engines"` object if it doesn't exist.
-pub fn apply_engines_update(pkg: &mut PackageJsonFile, changes: &[EngineRangeToSet]) {
+/// Set `pkg_raw["engines"][key] = range_to_set` for each change, creating the
+/// `"engines"` object when absent.
+pub fn apply_engines_update(pkg_raw: &mut serde_json::Value, changes: &[EngineRangeToSet]) {
     if changes.is_empty() {
         return;
     }
 
-    let engines = pkg.raw.as_object_mut().and_then(|obj| {
-        if !obj.contains_key("engines") {
-            obj.insert(
-                "engines".to_string(),
-                serde_json::Value::Object(serde_json::Map::new()),
-            );
-        }
-        obj.get_mut("engines")
-            .and_then(serde_json::Value::as_object_mut)
-    });
+    let Some(obj) = pkg_raw.as_object_mut() else {
+        return;
+    };
+    let Some(engines) = obj
+        .entry("engines")
+        .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()))
+        .as_object_mut()
+    else {
+        return;
+    };
 
-    if let Some(engines_obj) = engines {
-        for change in changes {
-            engines_obj.insert(
-                change.engine.to_string(),
-                serde_json::Value::String(change.range_to_set.clone()),
-            );
-        }
+    for change in changes {
+        engines.insert(
+            change.engine.to_string(),
+            serde_json::Value::String(change.range_to_set.clone()),
+        );
     }
 }
 
-/// Apply computed engine updates to the lockfile's root entry.
-///
-/// For npm v2/v3, updates `packages[""]["engines"][key] = range_to_set`.
+/// Same, on an npm v2/v3 lockfile's root entry (`packages[""]`).
 pub fn apply_engines_to_lockfile(
     lockfile_raw: &mut serde_json::Value,
     changes: &[EngineRangeToSet],
 ) {
-    if changes.is_empty() {
-        return;
-    }
-
     let root_entry = lockfile_raw
         .as_object_mut()
         .and_then(|obj| obj.get_mut("packages"))
         .and_then(serde_json::Value::as_object_mut)
         .and_then(|pkgs| pkgs.get_mut(""));
 
-    let Some(root) = root_entry else {
-        return;
-    };
+    if let Some(root) = root_entry {
+        apply_engines_update(root, changes);
+    }
+}
 
-    let engines = root.as_object_mut().and_then(|obj| {
-        if !obj.contains_key("engines") {
-            obj.insert(
-                "engines".to_string(),
-                serde_json::Value::Object(serde_json::Map::new()),
-            );
-        }
-        obj.get_mut("engines")
-            .and_then(serde_json::Value::as_object_mut)
-    });
+#[cfg(test)]
+mod tests {
+    use super::{apply_engines_to_lockfile, apply_engines_update};
+    use crate::{EngineConstraintKey, EngineRangeToSet};
 
-    if let Some(engines_obj) = engines {
-        for change in changes {
-            engines_obj.insert(
-                change.engine.to_string(),
-                serde_json::Value::String(change.range_to_set.clone()),
-            );
+    fn change(engine: EngineConstraintKey, range_to_set: &str) -> EngineRangeToSet {
+        EngineRangeToSet {
+            engine,
+            range: "*".to_string(),
+            range_to_set: range_to_set.to_string(),
         }
+    }
+
+    #[test]
+    fn creates_engines_object_when_absent() {
+        let mut pkg = serde_json::json!({"name": "app"});
+        apply_engines_update(&mut pkg, &[change(EngineConstraintKey::Node, ">=20.0.0")]);
+        assert_eq!(
+            pkg,
+            serde_json::json!({"name": "app", "engines": {"node": ">=20.0.0"}})
+        );
+    }
+
+    #[test]
+    fn overwrites_existing_engine_and_keeps_the_others() {
+        let mut pkg = serde_json::json!({"engines": {"node": ">=14.0.0", "npm": ">=6.0.0"}});
+        apply_engines_update(&mut pkg, &[change(EngineConstraintKey::Node, ">=20.0.0")]);
+        assert_eq!(
+            pkg,
+            serde_json::json!({"engines": {"node": ">=20.0.0", "npm": ">=6.0.0"}})
+        );
+    }
+
+    #[test]
+    fn leaves_the_value_untouched_when_there_is_nothing_to_change() {
+        let mut pkg = serde_json::json!({"name": "app"});
+        apply_engines_update(&mut pkg, &[]);
+        assert_eq!(pkg, serde_json::json!({"name": "app"}));
+    }
+
+    #[test]
+    fn lockfile_update_targets_the_root_entry() {
+        let mut lock = serde_json::json!({"packages": {"": {"name": "app"}, "node_modules/a": {}}});
+        apply_engines_to_lockfile(&mut lock, &[change(EngineConstraintKey::Node, ">=20.0.0")]);
+        assert_eq!(
+            lock,
+            serde_json::json!({
+                "packages": {
+                    "": {"name": "app", "engines": {"node": ">=20.0.0"}},
+                    "node_modules/a": {}
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn lockfile_update_is_a_no_op_without_a_root_entry() {
+        let mut lock = serde_json::json!({"packages": {"node_modules/a": {}}});
+        apply_engines_to_lockfile(&mut lock, &[change(EngineConstraintKey::Node, ">=20.0.0")]);
+        assert_eq!(
+            lock,
+            serde_json::json!({"packages": {"node_modules/a": {}}})
+        );
     }
 }

--- a/crates/riri-nce/tests/facade.rs
+++ b/crates/riri-nce/tests/facade.rs
@@ -1,0 +1,67 @@
+#![allow(clippy::tests_outside_test_module)]
+
+use riri_nce::{
+    CheckEnginesInput, EngineConstraintKey, LifecycleConfig, LifecycleData, NaiveDate, PackageJson,
+    PackageManager, Policy, VersionPrecision, check_engines, check_engines_with_lifecycle,
+    parse_lockfile,
+};
+
+const PKG: &str = r#"{"name": "app", "engines": {"node": ">=14.0.0"}}"#;
+
+const NPM_LOCK: &str = r#"{
+    "lockfileVersion": 3,
+    "packages": {
+        "": {"name": "app"},
+        "node_modules/typescript": {"version": "5.4.5", "engines": {"node": ">=14.17.0"}}
+    }
+}"#;
+
+#[test]
+fn checking_engines_needs_no_crate_beyond_riri_nce() {
+    let lockfile = parse_lockfile(PackageManager::Npm, NPM_LOCK).expect("lockfile parses");
+    let engines = lockfile.engines().expect("npm records engines");
+    let package_json: PackageJson = serde_json::from_str(PKG).expect("package.json parses");
+
+    let output = check_engines(&CheckEnginesInput {
+        lockfile_entries: engines.engines_iter().collect(),
+        package_engines: package_json.engines.as_ref(),
+        filter_engines: vec![EngineConstraintKey::Node],
+        precision: VersionPrecision::Full,
+    });
+
+    assert_eq!(
+        output.computed_engines[&EngineConstraintKey::Node],
+        ">=14.17.0"
+    );
+}
+
+#[test]
+fn the_lifecycle_rewrite_needs_no_crate_beyond_riri_nce() {
+    let lockfile = parse_lockfile(PackageManager::Npm, NPM_LOCK).expect("lockfile parses");
+    let engines = lockfile.engines().expect("npm records engines");
+    let package_json: PackageJson = serde_json::from_str(PKG).expect("package.json parses");
+
+    let input = CheckEnginesInput {
+        lockfile_entries: engines.engines_iter().collect(),
+        package_engines: package_json.engines.as_ref(),
+        filter_engines: vec![EngineConstraintKey::Node],
+        precision: VersionPrecision::Full,
+    };
+    let config = LifecycleConfig {
+        data: LifecycleData::bundled(),
+        policy: Policy::Supported,
+        today: NaiveDate::from_ymd_opt(2026, 8, 18).expect("valid date"),
+        allow_eol: true,
+        bump_npm: false,
+        npm_precision: VersionPrecision::Full,
+    };
+
+    let (output, _lifecycle) =
+        check_engines_with_lifecycle(&input, &config).expect("lifecycle rewrite");
+
+    assert!(
+        output
+            .computed_engines
+            .contains_key(&EngineConstraintKey::Node)
+    );
+}

--- a/crates/riri-node-lifecycle/Cargo.toml
+++ b/crates/riri-node-lifecycle/Cargo.toml
@@ -3,6 +3,7 @@ name = "riri-node-lifecycle"
 version = "0.1.3"
 description = "Node.js release lifecycle data, EOL status & bundled npm versions"
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 

--- a/crates/riri-node-lifecycle/Cargo.toml
+++ b/crates/riri-node-lifecycle/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "riri-node-lifecycle"
 version = "0.1.3"
+description = "Node.js release lifecycle data, EOL status & bundled npm versions"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/riri-node-lifecycle/Cargo.toml
+++ b/crates/riri-node-lifecycle/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [dependencies]
 anyhow = { workspace = true, optional = true }

--- a/crates/riri-npd/Cargo.toml
+++ b/crates/riri-npd/Cargo.toml
@@ -3,6 +3,7 @@ name = "riri-npd"
 version = "0.1.4"
 description = "Pin dependency ranges in package.json to the versions the lockfile resolved"
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/riri-npd/Cargo.toml
+++ b/crates/riri-npd/Cargo.toml
@@ -20,6 +20,7 @@ required-features = ["cli"]
 
 [dependencies]
 riri-common = { path = "../riri-common", version = "0.1.4" }
+riri-lockfile = { path = "../riri-lockfile", version = "0.1.0" }
 riri-npm = { path = "../riri-npm", version = "0.1.4" }
 riri-pnpm = { path = "../riri-pnpm", version = "0.1.4", features = ["catalog"] }
 riri-task-runner = { path = "../riri-task-runner", version = "0.1.2", optional = true }

--- a/crates/riri-npd/Cargo.toml
+++ b/crates/riri-npd/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "riri-npd"
 version = "0.1.4"
+description = "Pin dependency ranges in package.json to the versions the lockfile resolved"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/riri-npd/Cargo.toml
+++ b/crates/riri-npd/Cargo.toml
@@ -11,30 +11,47 @@ repository.workspace = true
 [[bin]]
 name = "npd"
 path = "src/bin/npd.rs"
+required-features = ["cli"]
 
 [[bin]]
 name = "npm-pin-dependencies"
 path = "src/bin/npm-pin-dependencies.rs"
+required-features = ["cli"]
 
 [dependencies]
-riri-common = { path = "../riri-common", version = "0.1.4", features = ["sort"] }
+riri-common = { path = "../riri-common", version = "0.1.4" }
 riri-npm = { path = "../riri-npm", version = "0.1.4" }
 riri-pnpm = { path = "../riri-pnpm", version = "0.1.4", features = ["catalog"] }
-riri-task-runner = { path = "../riri-task-runner", version = "0.1.2" }
-riri-workspace = { path = "../riri-workspace", version = "0.1.4" }
+riri-task-runner = { path = "../riri-task-runner", version = "0.1.2", optional = true }
+riri-workspace = { path = "../riri-workspace", version = "0.1.4", optional = true }
 riri-yarn = { path = "../riri-yarn", version = "0.1.4" }
-anyhow = { workspace = true }
-clap = { workspace = true }
-comfy-table = { workspace = true }
-console = { workspace = true }
+anyhow = { workspace = true, optional = true }
+clap = { workspace = true, optional = true }
+comfy-table = { workspace = true, optional = true }
+console = { workspace = true, optional = true }
 semver = { workspace = true }
-serde_json = { workspace = true }
+serde_json = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
+tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"], optional = true }
+
+[features]
+default = ["cli"]
+cli = [
+    "dep:anyhow",
+    "dep:clap",
+    "dep:comfy-table",
+    "dep:console",
+    "dep:riri-task-runner",
+    "dep:riri-workspace",
+    "dep:serde_json",
+    "dep:tracing-subscriber",
+    "riri-common/sort",
+]
 
 [dev-dependencies]
 criterion = { workspace = true }
+serde_json = { workspace = true }
 insta = { workspace = true }
 rstest = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/riri-npd/src/cli.rs
+++ b/crates/riri-npd/src/cli.rs
@@ -6,10 +6,8 @@ use clap::Parser;
 use comfy_table::{Table, presets};
 use console::style;
 use riri_common::{LockfileVersions, PackageJsonFile, PackageManager, detect_lockfile};
-use riri_npm::NpmPackageLock;
-use riri_pnpm::PnpmLockfile;
+use riri_lockfile::{ParsedLockfile, parse_lockfile};
 use riri_task_runner::{RendererMode, TaskRunner};
-use riri_yarn::YarnLock;
 use std::path::{Path, PathBuf};
 
 use crate::{CatalogPin, DependencyKind, VersionToPin, pin_dependencies};
@@ -83,31 +81,11 @@ fn renderer_mode(args: &Args) -> RendererMode {
     }
 }
 
-fn load_lockfile(
-    manager: &PackageManager,
-    lockfile_path: &Path,
-) -> Result<Box<dyn LockfileVersions>> {
-    match manager {
-        PackageManager::Npm => {
-            let content = std::fs::read_to_string(lockfile_path)
-                .with_context(|| format!("failed to read {}", lockfile_path.display()))?;
-            let lock =
-                NpmPackageLock::parse(&content).context("failed to parse package-lock.json")?;
-            Ok(Box::new(lock))
-        }
-        PackageManager::Pnpm => {
-            let content = std::fs::read_to_string(lockfile_path)
-                .with_context(|| format!("failed to read {}", lockfile_path.display()))?;
-            let lock = PnpmLockfile::parse(&content).context("failed to parse pnpm-lock.yaml")?;
-            Ok(Box::new(lock))
-        }
-        PackageManager::Yarn => {
-            let content = std::fs::read_to_string(lockfile_path)
-                .with_context(|| format!("failed to read {}", lockfile_path.display()))?;
-            let lock = YarnLock::parse(&content).context("failed to parse yarn.lock")?;
-            Ok(Box::new(lock))
-        }
-    }
+fn load_lockfile(manager: PackageManager, lockfile_path: &Path) -> Result<ParsedLockfile> {
+    let content = std::fs::read_to_string(lockfile_path)
+        .with_context(|| format!("failed to read {}", lockfile_path.display()))?;
+    parse_lockfile(manager, &content)
+        .with_context(|| format!("failed to parse {}", manager.lockfile_name()))
 }
 
 #[allow(clippy::too_many_lines)]
@@ -158,7 +136,7 @@ fn run(args: &Args) -> Result<i32> {
     };
 
     let task = runner.task("Parsing lockfile...");
-    let lockfile = match load_lockfile(&lockfile_result.package_manager, &lockfile_result.path) {
+    let lockfile = match load_lockfile(lockfile_result.package_manager, &lockfile_result.path) {
         Ok(lock) => {
             task.complete("Parsed lockfile");
             lock
@@ -170,7 +148,7 @@ fn run(args: &Args) -> Result<i32> {
     };
 
     let task = runner.task("Computing dependency pins...");
-    let pins = pin_dependencies(&pkg_file.parsed, lockfile.as_ref())
+    let pins = pin_dependencies(&pkg_file.parsed, lockfile.versions())
         .map_err(|e| anyhow::anyhow!("pin_dependencies failed: {e}"))?;
     task.complete("Computed dependency pins");
 
@@ -178,7 +156,7 @@ fn run(args: &Args) -> Result<i32> {
         pins: catalog_pins,
         source: catalog_source,
     } = if args.pin_catalog {
-        resolve_catalog_pins(args, &runner, &lockfile_result, &cwd, lockfile.as_ref())?
+        resolve_catalog_pins(args, &runner, &lockfile_result, &cwd, lockfile.versions())?
     } else {
         CatalogPlan {
             pins: Vec::new(),
@@ -495,7 +473,7 @@ fn run_workspace(
     };
 
     let task = runner.task("Parsing lockfile...");
-    let lockfile = match load_lockfile(&lockfile_result.package_manager, &lockfile_result.path) {
+    let lockfile = match load_lockfile(lockfile_result.package_manager, &lockfile_result.path) {
         Ok(lock) => {
             task.complete("Parsed lockfile");
             lock
@@ -516,7 +494,7 @@ fn run_workspace(
     for member in members {
         let mut pkg_file = PackageJsonFile::read(&member.manifest_path)
             .map_err(|e| anyhow::anyhow!("{}: {e}", member.name))?;
-        let pins = pin_dependencies(&pkg_file.parsed, lockfile.as_ref())
+        let pins = pin_dependencies(&pkg_file.parsed, lockfile.versions())
             .map_err(|e| anyhow::anyhow!("{}: pin_dependencies failed: {e}", member.name))?;
         if !pins.is_empty() {
             worst = EXIT_PINS_PENDING;
@@ -543,7 +521,7 @@ fn run_workspace(
             runner,
             &lockfile_result,
             project.root(),
-            lockfile.as_ref(),
+            lockfile.versions(),
         )?;
         if !plan.pins.is_empty() {
             worst = EXIT_PINS_PENDING;

--- a/crates/riri-npd/src/lib.rs
+++ b/crates/riri-npd/src/lib.rs
@@ -6,7 +6,13 @@
 
 pub mod cli;
 
-use riri_common::{LockfileVersions, PackageJson, is_local_specifier};
+pub use riri_common::{LockfileVersions, PackageJson};
+pub use riri_npm::{NpmPackageLock, NpmParseError};
+pub use riri_pnpm::catalog::{CatalogError, PnpmCatalog};
+pub use riri_pnpm::{PnpmLockfile, PnpmParseError};
+pub use riri_yarn::{YarnLock, YarnParseError};
+
+use riri_common::is_local_specifier;
 use semver::Version;
 use thiserror::Error;
 use tracing::debug;
@@ -169,7 +175,7 @@ fn is_already_pinned(spec: &str, locked: &str) -> bool {
 ///   - Entries with no matching lockfile entry.
 #[must_use]
 pub fn pin_catalog_entries(
-    catalog: &riri_pnpm::catalog::PnpmCatalog,
+    catalog: &PnpmCatalog,
     lockfile: &dyn LockfileVersions,
 ) -> Vec<CatalogPin> {
     let mut result = Vec::new();

--- a/crates/riri-npd/src/lib.rs
+++ b/crates/riri-npd/src/lib.rs
@@ -7,7 +7,8 @@
 #[cfg(feature = "cli")]
 pub mod cli;
 
-pub use riri_common::{LockfileVersions, PackageJson};
+pub use riri_common::{LockfileVersions, PackageJson, PackageManager};
+pub use riri_lockfile::{LockfileParseError, ParsedLockfile, parse_lockfile};
 pub use riri_npm::{NpmPackageLock, NpmParseError};
 pub use riri_pnpm::catalog::{CatalogError, PnpmCatalog};
 pub use riri_pnpm::{PnpmLockfile, PnpmParseError};

--- a/crates/riri-npd/src/lib.rs
+++ b/crates/riri-npd/src/lib.rs
@@ -4,6 +4,7 @@
 //! `optionalDependencies` against the lockfile and reports any range
 //! specifier (e.g. `^1.2.3`) that should be pinned to the resolved version.
 
+#[cfg(feature = "cli")]
 pub mod cli;
 
 pub use riri_common::{LockfileVersions, PackageJson};

--- a/crates/riri-npd/tests/facade.rs
+++ b/crates/riri-npd/tests/facade.rs
@@ -1,0 +1,25 @@
+#![allow(clippy::tests_outside_test_module)]
+
+use riri_npd::{PackageJson, PackageManager, parse_lockfile, pin_dependencies};
+
+const PKG: &str = r#"{"name": "app", "dependencies": {"typescript": "^5.4.0"}}"#;
+
+const NPM_LOCK: &str = r#"{
+    "lockfileVersion": 3,
+    "packages": {
+        "": {"name": "app"},
+        "node_modules/typescript": {"version": "5.4.5"}
+    }
+}"#;
+
+#[test]
+fn pinning_needs_no_crate_beyond_riri_npd() {
+    let lockfile = parse_lockfile(PackageManager::Npm, NPM_LOCK).expect("lockfile parses");
+    let package_json: PackageJson = serde_json::from_str(PKG).expect("package.json parses");
+
+    let pins = pin_dependencies(&package_json, lockfile.versions()).expect("pins");
+
+    assert_eq!(pins.len(), 1);
+    assert_eq!(pins[0].name, "typescript");
+    assert_eq!(pins[0].pinned_version, "5.4.5");
+}

--- a/crates/riri-npm/Cargo.toml
+++ b/crates/riri-npm/Cargo.toml
@@ -3,6 +3,7 @@ name = "riri-npm"
 version = "0.1.4"
 description = "npm package-lock.json parser (v1, v2, v3)"
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 

--- a/crates/riri-npm/Cargo.toml
+++ b/crates/riri-npm/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "riri-npm"
 version = "0.1.4"
+description = "npm package-lock.json parser (v1, v2, v3)"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/riri-npm/Cargo.toml
+++ b/crates/riri-npm/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [features]
 graph = ["riri-common/graph"]

--- a/crates/riri-npm/src/graph.rs
+++ b/crates/riri-npm/src/graph.rs
@@ -21,17 +21,6 @@ impl LockfileGraph for NpmPackageLock {
     }
 }
 
-const NODE_MODULES: &str = "node_modules/";
-
-/// Package name from a v2/v3 `packages` key — portion after the last
-/// `node_modules/`, or the whole key for workspace entries (no segment).
-fn node_name_from_key(key: &str) -> &str {
-    match key.rfind(NODE_MODULES) {
-        Some(i) => &key[i + NODE_MODULES.len()..],
-        None => key,
-    }
-}
-
 /// Resolve dep `name` required from the package at `from_key` by walking
 /// ancestor `node_modules` scopes, innermost first; follows `link:` entries.
 fn resolve_key(
@@ -94,7 +83,7 @@ fn graph_from_packages(
         };
         let idx = graph.nodes.len();
         graph.nodes.push(LockGraphNode {
-            name: node_name_from_key(key).to_string(),
+            name: riri_common::bare_package_name(key).to_string(),
             version: version.clone(),
             deps: Vec::new(),
         });

--- a/crates/riri-npm/src/lib.rs
+++ b/crates/riri-npm/src/lib.rs
@@ -134,11 +134,12 @@ impl NpmPackageLock {
 
 impl LockfileEngines for NpmPackageLock {
     fn engines_iter(&self) -> Box<dyn Iterator<Item = (&str, &Engines)> + '_> {
-        Box::new(
-            self.entries()
-                .iter()
-                .filter_map(|(name, entry)| entry.engines.as_ref().map(|e| (name.as_str(), e))),
-        )
+        Box::new(self.entries().iter().filter_map(|(key, entry)| {
+            entry
+                .engines
+                .as_ref()
+                .map(|e| (riri_common::bare_package_name(key), e))
+        }))
     }
 }
 

--- a/crates/riri-npm/tests/snapshots/parse_fixtures__parse_npm_fixture@npm-v2-deps-and-packages-fields.snap
+++ b/crates/riri-npm/tests/snapshots/parse_fixtures__parse_npm_fixture@npm-v2-deps-and-packages-fields.snap
@@ -2,4 +2,4 @@
 source: crates/riri-npm/tests/parse_fixtures.rs
 expression: snapshot
 ---
-node_modules/fake-package-01: {node: >=6.9.0}
+fake-package-01: {node: >=6.9.0}

--- a/crates/riri-npm/tests/snapshots/parse_fixtures__parse_npm_fixture@npm-v2-packages-field-only.snap
+++ b/crates/riri-npm/tests/snapshots/parse_fixtures__parse_npm_fixture@npm-v2-packages-field-only.snap
@@ -2,4 +2,4 @@
 source: crates/riri-npm/tests/parse_fixtures.rs
 expression: snapshot
 ---
-node_modules/fake-package-01: {node: >=6.9.0}
+fake-package-01: {node: >=6.9.0}

--- a/crates/riri-npm/tests/snapshots/parse_fixtures__parse_npm_fixture@npm-v3-500-deps.snap
+++ b/crates/riri-npm/tests/snapshots/parse_fixtures__parse_npm_fixture@npm-v3-500-deps.snap
@@ -2,503 +2,503 @@
 source: crates/riri-npm/tests/parse_fixtures.rs
 expression: snapshot
 ---
-node_modules/fake-dep-0: {node: >=6.9.0}
-node_modules/fake-dep-1: {node: >=12.22.0}
-node_modules/fake-dep-10: {node: *}
-node_modules/fake-dep-100: {node: *}
-node_modules/fake-dep-101: {node: >=0.10.0}
-node_modules/fake-dep-102: {node: >=8.0.0}
-node_modules/fake-dep-103: {node: >=10.13.0}
-node_modules/fake-dep-104: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-105: {node: >=6.9.0}
-node_modules/fake-dep-106: {node: >=12.22.0}
-node_modules/fake-dep-107: {node: >=14.0.0}
-node_modules/fake-dep-108: {node: >=16.0.0}
-node_modules/fake-dep-109: {node: >=18.0.0}
-node_modules/fake-dep-11: {node: >=0.10.0}
-node_modules/fake-dep-110: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-111: {node: >=16.0.0||^14.17.0}
-node_modules/fake-dep-112: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-113: {node: >=14.0.0}
-node_modules/fake-dep-114: {node: ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-115: {node: *}
-node_modules/fake-dep-116: {node: >=0.10.0}
-node_modules/fake-dep-117: {node: >=8.0.0}
-node_modules/fake-dep-118: {node: >=10.13.0}
-node_modules/fake-dep-119: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-12: {node: >=8.0.0}
-node_modules/fake-dep-120: {node: >=6.9.0}
-node_modules/fake-dep-121: {node: >=12.22.0}
-node_modules/fake-dep-122: {node: >=14.0.0}
-node_modules/fake-dep-123: {node: >=16.0.0}
-node_modules/fake-dep-124: {node: >=18.0.0}
-node_modules/fake-dep-125: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-126: {node: >=16.0.0||^14.17.0}
-node_modules/fake-dep-127: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-128: {node: >=14.0.0}
-node_modules/fake-dep-129: {node: ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-13: {node: >=10.13.0}
-node_modules/fake-dep-130: {node: *}
-node_modules/fake-dep-131: {node: >=0.10.0}
-node_modules/fake-dep-132: {node: >=8.0.0}
-node_modules/fake-dep-133: {node: >=10.13.0}
-node_modules/fake-dep-134: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-135: {node: >=6.9.0}
-node_modules/fake-dep-136: {node: >=12.22.0}
-node_modules/fake-dep-137: {node: >=14.0.0}
-node_modules/fake-dep-138: {node: >=16.0.0}
-node_modules/fake-dep-139: {node: >=18.0.0}
-node_modules/fake-dep-14: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-140: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-141: {node: >=16.0.0||^14.17.0}
-node_modules/fake-dep-142: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-143: {node: >=14.0.0}
-node_modules/fake-dep-144: {node: ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-145: {node: *}
-node_modules/fake-dep-146: {node: >=0.10.0}
-node_modules/fake-dep-147: {node: >=8.0.0}
-node_modules/fake-dep-148: {node: >=10.13.0}
-node_modules/fake-dep-149: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-15: {node: >=6.9.0}
-node_modules/fake-dep-150: {node: >=6.9.0}
-node_modules/fake-dep-151: {node: >=12.22.0}
-node_modules/fake-dep-152: {node: >=14.0.0}
-node_modules/fake-dep-153: {node: >=16.0.0}
-node_modules/fake-dep-154: {node: >=18.0.0}
-node_modules/fake-dep-155: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-156: {node: >=16.0.0||^14.17.0}
-node_modules/fake-dep-157: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-158: {node: >=14.0.0}
-node_modules/fake-dep-159: {node: ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-16: {node: >=12.22.0}
-node_modules/fake-dep-160: {node: *}
-node_modules/fake-dep-161: {node: >=0.10.0}
-node_modules/fake-dep-162: {node: >=8.0.0}
-node_modules/fake-dep-163: {node: >=10.13.0}
-node_modules/fake-dep-164: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-165: {node: >=6.9.0}
-node_modules/fake-dep-166: {node: >=12.22.0}
-node_modules/fake-dep-167: {node: >=14.0.0}
-node_modules/fake-dep-168: {node: >=16.0.0}
-node_modules/fake-dep-169: {node: >=18.0.0}
-node_modules/fake-dep-17: {node: >=14.0.0}
-node_modules/fake-dep-170: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-171: {node: >=16.0.0||^14.17.0}
-node_modules/fake-dep-172: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-173: {node: >=14.0.0}
-node_modules/fake-dep-174: {node: ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-175: {node: *}
-node_modules/fake-dep-176: {node: >=0.10.0}
-node_modules/fake-dep-177: {node: >=8.0.0}
-node_modules/fake-dep-178: {node: >=10.13.0}
-node_modules/fake-dep-179: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-18: {node: >=16.0.0}
-node_modules/fake-dep-180: {node: >=6.9.0}
-node_modules/fake-dep-181: {node: >=12.22.0}
-node_modules/fake-dep-182: {node: >=14.0.0}
-node_modules/fake-dep-183: {node: >=16.0.0}
-node_modules/fake-dep-184: {node: >=18.0.0}
-node_modules/fake-dep-185: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-186: {node: >=16.0.0||^14.17.0}
-node_modules/fake-dep-187: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-188: {node: >=14.0.0}
-node_modules/fake-dep-189: {node: ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-19: {node: >=18.0.0}
-node_modules/fake-dep-190: {node: *}
-node_modules/fake-dep-191: {node: >=0.10.0}
-node_modules/fake-dep-192: {node: >=8.0.0}
-node_modules/fake-dep-193: {node: >=10.13.0}
-node_modules/fake-dep-194: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-195: {node: >=6.9.0}
-node_modules/fake-dep-196: {node: >=12.22.0}
-node_modules/fake-dep-197: {node: >=14.0.0}
-node_modules/fake-dep-198: {node: >=16.0.0}
-node_modules/fake-dep-199: {node: >=18.0.0}
-node_modules/fake-dep-2: {node: >=14.0.0}
-node_modules/fake-dep-20: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-200: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-201: {node: >=16.0.0||^14.17.0}
-node_modules/fake-dep-202: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-203: {node: >=14.0.0}
-node_modules/fake-dep-204: {node: ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-205: {node: *}
-node_modules/fake-dep-206: {node: >=0.10.0}
-node_modules/fake-dep-207: {node: >=8.0.0}
-node_modules/fake-dep-208: {node: >=10.13.0}
-node_modules/fake-dep-209: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-21: {node: >=16.0.0||^14.17.0}
-node_modules/fake-dep-210: {node: >=6.9.0}
-node_modules/fake-dep-211: {node: >=12.22.0}
-node_modules/fake-dep-212: {node: >=14.0.0}
-node_modules/fake-dep-213: {node: >=16.0.0}
-node_modules/fake-dep-214: {node: >=18.0.0}
-node_modules/fake-dep-215: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-216: {node: >=16.0.0||^14.17.0}
-node_modules/fake-dep-217: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-218: {node: >=14.0.0}
-node_modules/fake-dep-219: {node: ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-22: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-220: {node: *}
-node_modules/fake-dep-221: {node: >=0.10.0}
-node_modules/fake-dep-222: {node: >=8.0.0}
-node_modules/fake-dep-223: {node: >=10.13.0}
-node_modules/fake-dep-224: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-225: {node: >=6.9.0}
-node_modules/fake-dep-226: {node: >=12.22.0}
-node_modules/fake-dep-227: {node: >=14.0.0}
-node_modules/fake-dep-228: {node: >=16.0.0}
-node_modules/fake-dep-229: {node: >=18.0.0}
-node_modules/fake-dep-23: {node: >=14.0.0}
-node_modules/fake-dep-230: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-231: {node: >=16.0.0||^14.17.0}
-node_modules/fake-dep-232: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-233: {node: >=14.0.0}
-node_modules/fake-dep-234: {node: ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-235: {node: *}
-node_modules/fake-dep-236: {node: >=0.10.0}
-node_modules/fake-dep-237: {node: >=8.0.0}
-node_modules/fake-dep-238: {node: >=10.13.0}
-node_modules/fake-dep-239: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-24: {node: ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-240: {node: >=6.9.0}
-node_modules/fake-dep-241: {node: >=12.22.0}
-node_modules/fake-dep-242: {node: >=14.0.0}
-node_modules/fake-dep-243: {node: >=16.0.0}
-node_modules/fake-dep-244: {node: >=18.0.0}
-node_modules/fake-dep-245: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-246: {node: >=16.0.0||^14.17.0}
-node_modules/fake-dep-247: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-248: {node: >=14.0.0}
-node_modules/fake-dep-249: {node: ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-25: {node: *}
-node_modules/fake-dep-250: {node: *}
-node_modules/fake-dep-251: {node: >=0.10.0}
-node_modules/fake-dep-252: {node: >=8.0.0}
-node_modules/fake-dep-253: {node: >=10.13.0}
-node_modules/fake-dep-254: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-255: {node: >=6.9.0}
-node_modules/fake-dep-256: {node: >=12.22.0}
-node_modules/fake-dep-257: {node: >=14.0.0}
-node_modules/fake-dep-258: {node: >=16.0.0}
-node_modules/fake-dep-259: {node: >=18.0.0}
-node_modules/fake-dep-26: {node: >=0.10.0}
-node_modules/fake-dep-260: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-261: {node: >=16.0.0||^14.17.0}
-node_modules/fake-dep-262: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-263: {node: >=14.0.0}
-node_modules/fake-dep-264: {node: ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-265: {node: *}
-node_modules/fake-dep-266: {node: >=0.10.0}
-node_modules/fake-dep-267: {node: >=8.0.0}
-node_modules/fake-dep-268: {node: >=10.13.0}
-node_modules/fake-dep-269: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-27: {node: >=8.0.0}
-node_modules/fake-dep-270: {node: >=6.9.0}
-node_modules/fake-dep-271: {node: >=12.22.0}
-node_modules/fake-dep-272: {node: >=14.0.0}
-node_modules/fake-dep-273: {node: >=16.0.0}
-node_modules/fake-dep-274: {node: >=18.0.0}
-node_modules/fake-dep-275: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-276: {node: >=16.0.0||^14.17.0}
-node_modules/fake-dep-277: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-278: {node: >=14.0.0}
-node_modules/fake-dep-279: {node: ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-28: {node: >=10.13.0}
-node_modules/fake-dep-280: {node: *}
-node_modules/fake-dep-281: {node: >=0.10.0}
-node_modules/fake-dep-282: {node: >=8.0.0}
-node_modules/fake-dep-283: {node: >=10.13.0}
-node_modules/fake-dep-284: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-285: {node: >=6.9.0}
-node_modules/fake-dep-286: {node: >=12.22.0}
-node_modules/fake-dep-287: {node: >=14.0.0}
-node_modules/fake-dep-288: {node: >=16.0.0}
-node_modules/fake-dep-289: {node: >=18.0.0}
-node_modules/fake-dep-29: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-290: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-291: {node: >=16.0.0||^14.17.0}
-node_modules/fake-dep-292: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-293: {node: >=14.0.0}
-node_modules/fake-dep-294: {node: ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-295: {node: *}
-node_modules/fake-dep-296: {node: >=0.10.0}
-node_modules/fake-dep-297: {node: >=8.0.0}
-node_modules/fake-dep-298: {node: >=10.13.0}
-node_modules/fake-dep-299: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-3: {node: >=16.0.0}
-node_modules/fake-dep-30: {node: >=6.9.0}
-node_modules/fake-dep-300: {node: >=6.9.0}
-node_modules/fake-dep-301: {node: >=12.22.0}
-node_modules/fake-dep-302: {node: >=14.0.0}
-node_modules/fake-dep-303: {node: >=16.0.0}
-node_modules/fake-dep-304: {node: >=18.0.0}
-node_modules/fake-dep-305: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-306: {node: >=16.0.0||^14.17.0}
-node_modules/fake-dep-307: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-308: {node: >=14.0.0}
-node_modules/fake-dep-309: {node: ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-31: {node: >=12.22.0}
-node_modules/fake-dep-310: {node: *}
-node_modules/fake-dep-311: {node: >=0.10.0}
-node_modules/fake-dep-312: {node: >=8.0.0}
-node_modules/fake-dep-313: {node: >=10.13.0}
-node_modules/fake-dep-314: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-315: {node: >=6.9.0}
-node_modules/fake-dep-316: {node: >=12.22.0}
-node_modules/fake-dep-317: {node: >=14.0.0}
-node_modules/fake-dep-318: {node: >=16.0.0}
-node_modules/fake-dep-319: {node: >=18.0.0}
-node_modules/fake-dep-32: {node: >=14.0.0}
-node_modules/fake-dep-320: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-321: {node: >=16.0.0||^14.17.0}
-node_modules/fake-dep-322: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-323: {node: >=14.0.0}
-node_modules/fake-dep-324: {node: ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-325: {node: *}
-node_modules/fake-dep-326: {node: >=0.10.0}
-node_modules/fake-dep-327: {node: >=8.0.0}
-node_modules/fake-dep-328: {node: >=10.13.0}
-node_modules/fake-dep-329: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-33: {node: >=16.0.0}
-node_modules/fake-dep-330: {node: >=6.9.0}
-node_modules/fake-dep-331: {node: >=12.22.0}
-node_modules/fake-dep-332: {node: >=14.0.0}
-node_modules/fake-dep-333: {node: >=16.0.0}
-node_modules/fake-dep-334: {node: >=18.0.0}
-node_modules/fake-dep-335: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-336: {node: >=16.0.0||^14.17.0}
-node_modules/fake-dep-337: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-338: {node: >=14.0.0}
-node_modules/fake-dep-339: {node: ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-34: {node: >=18.0.0}
-node_modules/fake-dep-340: {node: *}
-node_modules/fake-dep-341: {node: >=0.10.0}
-node_modules/fake-dep-342: {node: >=8.0.0}
-node_modules/fake-dep-343: {node: >=10.13.0}
-node_modules/fake-dep-344: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-345: {node: >=6.9.0}
-node_modules/fake-dep-346: {node: >=12.22.0}
-node_modules/fake-dep-347: {node: >=14.0.0}
-node_modules/fake-dep-348: {node: >=16.0.0}
-node_modules/fake-dep-349: {node: >=18.0.0}
-node_modules/fake-dep-35: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-350: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-351: {node: >=16.0.0||^14.17.0}
-node_modules/fake-dep-352: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-353: {node: >=14.0.0}
-node_modules/fake-dep-354: {node: ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-355: {node: *}
-node_modules/fake-dep-356: {node: >=0.10.0}
-node_modules/fake-dep-357: {node: >=8.0.0}
-node_modules/fake-dep-358: {node: >=10.13.0}
-node_modules/fake-dep-359: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-36: {node: >=16.0.0||^14.17.0}
-node_modules/fake-dep-360: {node: >=6.9.0}
-node_modules/fake-dep-361: {node: >=12.22.0}
-node_modules/fake-dep-362: {node: >=14.0.0}
-node_modules/fake-dep-363: {node: >=16.0.0}
-node_modules/fake-dep-364: {node: >=18.0.0}
-node_modules/fake-dep-365: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-366: {node: >=16.0.0||^14.17.0}
-node_modules/fake-dep-367: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-368: {node: >=14.0.0}
-node_modules/fake-dep-369: {node: ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-37: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-370: {node: *}
-node_modules/fake-dep-371: {node: >=0.10.0}
-node_modules/fake-dep-372: {node: >=8.0.0}
-node_modules/fake-dep-373: {node: >=10.13.0}
-node_modules/fake-dep-374: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-375: {node: >=6.9.0}
-node_modules/fake-dep-376: {node: >=12.22.0}
-node_modules/fake-dep-377: {node: >=14.0.0}
-node_modules/fake-dep-378: {node: >=16.0.0}
-node_modules/fake-dep-379: {node: >=18.0.0}
-node_modules/fake-dep-38: {node: >=14.0.0}
-node_modules/fake-dep-380: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-381: {node: >=16.0.0||^14.17.0}
-node_modules/fake-dep-382: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-383: {node: >=14.0.0}
-node_modules/fake-dep-384: {node: ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-385: {node: *}
-node_modules/fake-dep-386: {node: >=0.10.0}
-node_modules/fake-dep-387: {node: >=8.0.0}
-node_modules/fake-dep-388: {node: >=10.13.0}
-node_modules/fake-dep-389: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-39: {node: ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-390: {node: >=6.9.0}
-node_modules/fake-dep-391: {node: >=12.22.0}
-node_modules/fake-dep-392: {node: >=14.0.0}
-node_modules/fake-dep-393: {node: >=16.0.0}
-node_modules/fake-dep-394: {node: >=18.0.0}
-node_modules/fake-dep-395: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-396: {node: >=16.0.0||^14.17.0}
-node_modules/fake-dep-397: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-398: {node: >=14.0.0}
-node_modules/fake-dep-399: {node: ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-4: {node: >=18.0.0}
-node_modules/fake-dep-40: {node: *}
-node_modules/fake-dep-400: {node: *}
-node_modules/fake-dep-401: {node: >=0.10.0}
-node_modules/fake-dep-402: {node: >=8.0.0}
-node_modules/fake-dep-403: {node: >=10.13.0}
-node_modules/fake-dep-404: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-405: {node: >=6.9.0}
-node_modules/fake-dep-406: {node: >=12.22.0}
-node_modules/fake-dep-407: {node: >=14.0.0}
-node_modules/fake-dep-408: {node: >=16.0.0}
-node_modules/fake-dep-409: {node: >=18.0.0}
-node_modules/fake-dep-41: {node: >=0.10.0}
-node_modules/fake-dep-410: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-411: {node: >=16.0.0||^14.17.0}
-node_modules/fake-dep-412: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-413: {node: >=14.0.0}
-node_modules/fake-dep-414: {node: ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-415: {node: *}
-node_modules/fake-dep-416: {node: >=0.10.0}
-node_modules/fake-dep-417: {node: >=8.0.0}
-node_modules/fake-dep-418: {node: >=10.13.0}
-node_modules/fake-dep-419: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-42: {node: >=8.0.0}
-node_modules/fake-dep-420: {node: >=6.9.0}
-node_modules/fake-dep-421: {node: >=12.22.0}
-node_modules/fake-dep-422: {node: >=14.0.0}
-node_modules/fake-dep-423: {node: >=16.0.0}
-node_modules/fake-dep-424: {node: >=18.0.0}
-node_modules/fake-dep-425: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-426: {node: >=16.0.0||^14.17.0}
-node_modules/fake-dep-427: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-428: {node: >=14.0.0}
-node_modules/fake-dep-429: {node: ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-43: {node: >=10.13.0}
-node_modules/fake-dep-430: {node: *}
-node_modules/fake-dep-431: {node: >=0.10.0}
-node_modules/fake-dep-432: {node: >=8.0.0}
-node_modules/fake-dep-433: {node: >=10.13.0}
-node_modules/fake-dep-434: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-435: {node: >=6.9.0}
-node_modules/fake-dep-436: {node: >=12.22.0}
-node_modules/fake-dep-437: {node: >=14.0.0}
-node_modules/fake-dep-438: {node: >=16.0.0}
-node_modules/fake-dep-439: {node: >=18.0.0}
-node_modules/fake-dep-44: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-440: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-441: {node: >=16.0.0||^14.17.0}
-node_modules/fake-dep-442: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-443: {node: >=14.0.0}
-node_modules/fake-dep-444: {node: ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-445: {node: *}
-node_modules/fake-dep-446: {node: >=0.10.0}
-node_modules/fake-dep-447: {node: >=8.0.0}
-node_modules/fake-dep-448: {node: >=10.13.0}
-node_modules/fake-dep-449: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-45: {node: >=6.9.0}
-node_modules/fake-dep-450: {node: >=6.9.0}
-node_modules/fake-dep-451: {node: >=12.22.0}
-node_modules/fake-dep-452: {node: >=14.0.0}
-node_modules/fake-dep-453: {node: >=16.0.0}
-node_modules/fake-dep-454: {node: >=18.0.0}
-node_modules/fake-dep-455: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-456: {node: >=16.0.0||^14.17.0}
-node_modules/fake-dep-457: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-458: {node: >=14.0.0}
-node_modules/fake-dep-459: {node: ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-46: {node: >=12.22.0}
-node_modules/fake-dep-460: {node: *}
-node_modules/fake-dep-461: {node: >=0.10.0}
-node_modules/fake-dep-462: {node: >=8.0.0}
-node_modules/fake-dep-463: {node: >=10.13.0}
-node_modules/fake-dep-464: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-465: {node: >=6.9.0}
-node_modules/fake-dep-466: {node: >=12.22.0}
-node_modules/fake-dep-467: {node: >=14.0.0}
-node_modules/fake-dep-468: {node: >=16.0.0}
-node_modules/fake-dep-469: {node: >=18.0.0}
-node_modules/fake-dep-47: {node: >=14.0.0}
-node_modules/fake-dep-470: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-471: {node: >=16.0.0||^14.17.0}
-node_modules/fake-dep-472: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-473: {node: >=14.0.0}
-node_modules/fake-dep-474: {node: ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-475: {node: *}
-node_modules/fake-dep-476: {node: >=0.10.0}
-node_modules/fake-dep-477: {node: >=8.0.0}
-node_modules/fake-dep-478: {node: >=10.13.0}
-node_modules/fake-dep-479: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-48: {node: >=16.0.0}
-node_modules/fake-dep-480: {node: >=6.9.0}
-node_modules/fake-dep-481: {node: >=12.22.0}
-node_modules/fake-dep-482: {node: >=14.0.0}
-node_modules/fake-dep-483: {node: >=16.0.0}
-node_modules/fake-dep-484: {node: >=18.0.0}
-node_modules/fake-dep-485: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-486: {node: >=16.0.0||^14.17.0}
-node_modules/fake-dep-487: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-488: {node: >=14.0.0}
-node_modules/fake-dep-489: {node: ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-49: {node: >=18.0.0}
-node_modules/fake-dep-490: {node: *}
-node_modules/fake-dep-491: {node: >=0.10.0}
-node_modules/fake-dep-492: {node: >=8.0.0}
-node_modules/fake-dep-493: {node: >=10.13.0}
-node_modules/fake-dep-494: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-495: {node: >=6.9.0}
-node_modules/fake-dep-496: {node: >=12.22.0}
-node_modules/fake-dep-497: {node: >=14.0.0}
-node_modules/fake-dep-498: {node: >=16.0.0}
-node_modules/fake-dep-499: {node: >=18.0.0}
-node_modules/fake-dep-5: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-50: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-51: {node: >=16.0.0||^14.17.0}
-node_modules/fake-dep-52: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-53: {node: >=14.0.0}
-node_modules/fake-dep-54: {node: ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-55: {node: *}
-node_modules/fake-dep-56: {node: >=0.10.0}
-node_modules/fake-dep-57: {node: >=8.0.0}
-node_modules/fake-dep-58: {node: >=10.13.0}
-node_modules/fake-dep-59: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-6: {node: >=16.0.0||^14.17.0}
-node_modules/fake-dep-60: {node: >=6.9.0}
-node_modules/fake-dep-61: {node: >=12.22.0}
-node_modules/fake-dep-62: {node: >=14.0.0}
-node_modules/fake-dep-63: {node: >=16.0.0}
-node_modules/fake-dep-64: {node: >=18.0.0}
-node_modules/fake-dep-65: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-66: {node: >=16.0.0||^14.17.0}
-node_modules/fake-dep-67: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-68: {node: >=14.0.0}
-node_modules/fake-dep-69: {node: ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-7: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-70: {node: *}
-node_modules/fake-dep-71: {node: >=0.10.0}
-node_modules/fake-dep-72: {node: >=8.0.0}
-node_modules/fake-dep-73: {node: >=10.13.0}
-node_modules/fake-dep-74: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-75: {node: >=6.9.0}
-node_modules/fake-dep-76: {node: >=12.22.0}
-node_modules/fake-dep-77: {node: >=14.0.0}
-node_modules/fake-dep-78: {node: >=16.0.0}
-node_modules/fake-dep-79: {node: >=18.0.0}
-node_modules/fake-dep-8: {node: >=14.0.0}
-node_modules/fake-dep-80: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-81: {node: >=16.0.0||^14.17.0}
-node_modules/fake-dep-82: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-83: {node: >=14.0.0}
-node_modules/fake-dep-84: {node: ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-85: {node: *}
-node_modules/fake-dep-86: {node: >=0.10.0}
-node_modules/fake-dep-87: {node: >=8.0.0}
-node_modules/fake-dep-88: {node: >=10.13.0}
-node_modules/fake-dep-89: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-9: {node: ^18.0.0 || ^20.0.0}
-node_modules/fake-dep-90: {node: >=6.9.0}
-node_modules/fake-dep-91: {node: >=12.22.0}
-node_modules/fake-dep-92: {node: >=14.0.0}
-node_modules/fake-dep-93: {node: >=16.0.0}
-node_modules/fake-dep-94: {node: >=18.0.0}
-node_modules/fake-dep-95: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-96: {node: >=16.0.0||^14.17.0}
-node_modules/fake-dep-97: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
-node_modules/fake-dep-98: {node: >=14.0.0}
-node_modules/fake-dep-99: {node: ^18.0.0 || ^20.0.0}
+fake-dep-0: {node: >=6.9.0}
+fake-dep-1: {node: >=12.22.0}
+fake-dep-10: {node: *}
+fake-dep-100: {node: *}
+fake-dep-101: {node: >=0.10.0}
+fake-dep-102: {node: >=8.0.0}
+fake-dep-103: {node: >=10.13.0}
+fake-dep-104: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
+fake-dep-105: {node: >=6.9.0}
+fake-dep-106: {node: >=12.22.0}
+fake-dep-107: {node: >=14.0.0}
+fake-dep-108: {node: >=16.0.0}
+fake-dep-109: {node: >=18.0.0}
+fake-dep-11: {node: >=0.10.0}
+fake-dep-110: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+fake-dep-111: {node: >=16.0.0||^14.17.0}
+fake-dep-112: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
+fake-dep-113: {node: >=14.0.0}
+fake-dep-114: {node: ^18.0.0 || ^20.0.0}
+fake-dep-115: {node: *}
+fake-dep-116: {node: >=0.10.0}
+fake-dep-117: {node: >=8.0.0}
+fake-dep-118: {node: >=10.13.0}
+fake-dep-119: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
+fake-dep-12: {node: >=8.0.0}
+fake-dep-120: {node: >=6.9.0}
+fake-dep-121: {node: >=12.22.0}
+fake-dep-122: {node: >=14.0.0}
+fake-dep-123: {node: >=16.0.0}
+fake-dep-124: {node: >=18.0.0}
+fake-dep-125: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+fake-dep-126: {node: >=16.0.0||^14.17.0}
+fake-dep-127: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
+fake-dep-128: {node: >=14.0.0}
+fake-dep-129: {node: ^18.0.0 || ^20.0.0}
+fake-dep-13: {node: >=10.13.0}
+fake-dep-130: {node: *}
+fake-dep-131: {node: >=0.10.0}
+fake-dep-132: {node: >=8.0.0}
+fake-dep-133: {node: >=10.13.0}
+fake-dep-134: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
+fake-dep-135: {node: >=6.9.0}
+fake-dep-136: {node: >=12.22.0}
+fake-dep-137: {node: >=14.0.0}
+fake-dep-138: {node: >=16.0.0}
+fake-dep-139: {node: >=18.0.0}
+fake-dep-14: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
+fake-dep-140: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+fake-dep-141: {node: >=16.0.0||^14.17.0}
+fake-dep-142: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
+fake-dep-143: {node: >=14.0.0}
+fake-dep-144: {node: ^18.0.0 || ^20.0.0}
+fake-dep-145: {node: *}
+fake-dep-146: {node: >=0.10.0}
+fake-dep-147: {node: >=8.0.0}
+fake-dep-148: {node: >=10.13.0}
+fake-dep-149: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
+fake-dep-15: {node: >=6.9.0}
+fake-dep-150: {node: >=6.9.0}
+fake-dep-151: {node: >=12.22.0}
+fake-dep-152: {node: >=14.0.0}
+fake-dep-153: {node: >=16.0.0}
+fake-dep-154: {node: >=18.0.0}
+fake-dep-155: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+fake-dep-156: {node: >=16.0.0||^14.17.0}
+fake-dep-157: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
+fake-dep-158: {node: >=14.0.0}
+fake-dep-159: {node: ^18.0.0 || ^20.0.0}
+fake-dep-16: {node: >=12.22.0}
+fake-dep-160: {node: *}
+fake-dep-161: {node: >=0.10.0}
+fake-dep-162: {node: >=8.0.0}
+fake-dep-163: {node: >=10.13.0}
+fake-dep-164: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
+fake-dep-165: {node: >=6.9.0}
+fake-dep-166: {node: >=12.22.0}
+fake-dep-167: {node: >=14.0.0}
+fake-dep-168: {node: >=16.0.0}
+fake-dep-169: {node: >=18.0.0}
+fake-dep-17: {node: >=14.0.0}
+fake-dep-170: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+fake-dep-171: {node: >=16.0.0||^14.17.0}
+fake-dep-172: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
+fake-dep-173: {node: >=14.0.0}
+fake-dep-174: {node: ^18.0.0 || ^20.0.0}
+fake-dep-175: {node: *}
+fake-dep-176: {node: >=0.10.0}
+fake-dep-177: {node: >=8.0.0}
+fake-dep-178: {node: >=10.13.0}
+fake-dep-179: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
+fake-dep-18: {node: >=16.0.0}
+fake-dep-180: {node: >=6.9.0}
+fake-dep-181: {node: >=12.22.0}
+fake-dep-182: {node: >=14.0.0}
+fake-dep-183: {node: >=16.0.0}
+fake-dep-184: {node: >=18.0.0}
+fake-dep-185: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+fake-dep-186: {node: >=16.0.0||^14.17.0}
+fake-dep-187: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
+fake-dep-188: {node: >=14.0.0}
+fake-dep-189: {node: ^18.0.0 || ^20.0.0}
+fake-dep-19: {node: >=18.0.0}
+fake-dep-190: {node: *}
+fake-dep-191: {node: >=0.10.0}
+fake-dep-192: {node: >=8.0.0}
+fake-dep-193: {node: >=10.13.0}
+fake-dep-194: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
+fake-dep-195: {node: >=6.9.0}
+fake-dep-196: {node: >=12.22.0}
+fake-dep-197: {node: >=14.0.0}
+fake-dep-198: {node: >=16.0.0}
+fake-dep-199: {node: >=18.0.0}
+fake-dep-2: {node: >=14.0.0}
+fake-dep-20: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+fake-dep-200: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+fake-dep-201: {node: >=16.0.0||^14.17.0}
+fake-dep-202: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
+fake-dep-203: {node: >=14.0.0}
+fake-dep-204: {node: ^18.0.0 || ^20.0.0}
+fake-dep-205: {node: *}
+fake-dep-206: {node: >=0.10.0}
+fake-dep-207: {node: >=8.0.0}
+fake-dep-208: {node: >=10.13.0}
+fake-dep-209: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
+fake-dep-21: {node: >=16.0.0||^14.17.0}
+fake-dep-210: {node: >=6.9.0}
+fake-dep-211: {node: >=12.22.0}
+fake-dep-212: {node: >=14.0.0}
+fake-dep-213: {node: >=16.0.0}
+fake-dep-214: {node: >=18.0.0}
+fake-dep-215: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+fake-dep-216: {node: >=16.0.0||^14.17.0}
+fake-dep-217: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
+fake-dep-218: {node: >=14.0.0}
+fake-dep-219: {node: ^18.0.0 || ^20.0.0}
+fake-dep-22: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
+fake-dep-220: {node: *}
+fake-dep-221: {node: >=0.10.0}
+fake-dep-222: {node: >=8.0.0}
+fake-dep-223: {node: >=10.13.0}
+fake-dep-224: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
+fake-dep-225: {node: >=6.9.0}
+fake-dep-226: {node: >=12.22.0}
+fake-dep-227: {node: >=14.0.0}
+fake-dep-228: {node: >=16.0.0}
+fake-dep-229: {node: >=18.0.0}
+fake-dep-23: {node: >=14.0.0}
+fake-dep-230: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+fake-dep-231: {node: >=16.0.0||^14.17.0}
+fake-dep-232: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
+fake-dep-233: {node: >=14.0.0}
+fake-dep-234: {node: ^18.0.0 || ^20.0.0}
+fake-dep-235: {node: *}
+fake-dep-236: {node: >=0.10.0}
+fake-dep-237: {node: >=8.0.0}
+fake-dep-238: {node: >=10.13.0}
+fake-dep-239: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
+fake-dep-24: {node: ^18.0.0 || ^20.0.0}
+fake-dep-240: {node: >=6.9.0}
+fake-dep-241: {node: >=12.22.0}
+fake-dep-242: {node: >=14.0.0}
+fake-dep-243: {node: >=16.0.0}
+fake-dep-244: {node: >=18.0.0}
+fake-dep-245: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+fake-dep-246: {node: >=16.0.0||^14.17.0}
+fake-dep-247: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
+fake-dep-248: {node: >=14.0.0}
+fake-dep-249: {node: ^18.0.0 || ^20.0.0}
+fake-dep-25: {node: *}
+fake-dep-250: {node: *}
+fake-dep-251: {node: >=0.10.0}
+fake-dep-252: {node: >=8.0.0}
+fake-dep-253: {node: >=10.13.0}
+fake-dep-254: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
+fake-dep-255: {node: >=6.9.0}
+fake-dep-256: {node: >=12.22.0}
+fake-dep-257: {node: >=14.0.0}
+fake-dep-258: {node: >=16.0.0}
+fake-dep-259: {node: >=18.0.0}
+fake-dep-26: {node: >=0.10.0}
+fake-dep-260: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+fake-dep-261: {node: >=16.0.0||^14.17.0}
+fake-dep-262: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
+fake-dep-263: {node: >=14.0.0}
+fake-dep-264: {node: ^18.0.0 || ^20.0.0}
+fake-dep-265: {node: *}
+fake-dep-266: {node: >=0.10.0}
+fake-dep-267: {node: >=8.0.0}
+fake-dep-268: {node: >=10.13.0}
+fake-dep-269: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
+fake-dep-27: {node: >=8.0.0}
+fake-dep-270: {node: >=6.9.0}
+fake-dep-271: {node: >=12.22.0}
+fake-dep-272: {node: >=14.0.0}
+fake-dep-273: {node: >=16.0.0}
+fake-dep-274: {node: >=18.0.0}
+fake-dep-275: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+fake-dep-276: {node: >=16.0.0||^14.17.0}
+fake-dep-277: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
+fake-dep-278: {node: >=14.0.0}
+fake-dep-279: {node: ^18.0.0 || ^20.0.0}
+fake-dep-28: {node: >=10.13.0}
+fake-dep-280: {node: *}
+fake-dep-281: {node: >=0.10.0}
+fake-dep-282: {node: >=8.0.0}
+fake-dep-283: {node: >=10.13.0}
+fake-dep-284: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
+fake-dep-285: {node: >=6.9.0}
+fake-dep-286: {node: >=12.22.0}
+fake-dep-287: {node: >=14.0.0}
+fake-dep-288: {node: >=16.0.0}
+fake-dep-289: {node: >=18.0.0}
+fake-dep-29: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
+fake-dep-290: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+fake-dep-291: {node: >=16.0.0||^14.17.0}
+fake-dep-292: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
+fake-dep-293: {node: >=14.0.0}
+fake-dep-294: {node: ^18.0.0 || ^20.0.0}
+fake-dep-295: {node: *}
+fake-dep-296: {node: >=0.10.0}
+fake-dep-297: {node: >=8.0.0}
+fake-dep-298: {node: >=10.13.0}
+fake-dep-299: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
+fake-dep-3: {node: >=16.0.0}
+fake-dep-30: {node: >=6.9.0}
+fake-dep-300: {node: >=6.9.0}
+fake-dep-301: {node: >=12.22.0}
+fake-dep-302: {node: >=14.0.0}
+fake-dep-303: {node: >=16.0.0}
+fake-dep-304: {node: >=18.0.0}
+fake-dep-305: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+fake-dep-306: {node: >=16.0.0||^14.17.0}
+fake-dep-307: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
+fake-dep-308: {node: >=14.0.0}
+fake-dep-309: {node: ^18.0.0 || ^20.0.0}
+fake-dep-31: {node: >=12.22.0}
+fake-dep-310: {node: *}
+fake-dep-311: {node: >=0.10.0}
+fake-dep-312: {node: >=8.0.0}
+fake-dep-313: {node: >=10.13.0}
+fake-dep-314: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
+fake-dep-315: {node: >=6.9.0}
+fake-dep-316: {node: >=12.22.0}
+fake-dep-317: {node: >=14.0.0}
+fake-dep-318: {node: >=16.0.0}
+fake-dep-319: {node: >=18.0.0}
+fake-dep-32: {node: >=14.0.0}
+fake-dep-320: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+fake-dep-321: {node: >=16.0.0||^14.17.0}
+fake-dep-322: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
+fake-dep-323: {node: >=14.0.0}
+fake-dep-324: {node: ^18.0.0 || ^20.0.0}
+fake-dep-325: {node: *}
+fake-dep-326: {node: >=0.10.0}
+fake-dep-327: {node: >=8.0.0}
+fake-dep-328: {node: >=10.13.0}
+fake-dep-329: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
+fake-dep-33: {node: >=16.0.0}
+fake-dep-330: {node: >=6.9.0}
+fake-dep-331: {node: >=12.22.0}
+fake-dep-332: {node: >=14.0.0}
+fake-dep-333: {node: >=16.0.0}
+fake-dep-334: {node: >=18.0.0}
+fake-dep-335: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+fake-dep-336: {node: >=16.0.0||^14.17.0}
+fake-dep-337: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
+fake-dep-338: {node: >=14.0.0}
+fake-dep-339: {node: ^18.0.0 || ^20.0.0}
+fake-dep-34: {node: >=18.0.0}
+fake-dep-340: {node: *}
+fake-dep-341: {node: >=0.10.0}
+fake-dep-342: {node: >=8.0.0}
+fake-dep-343: {node: >=10.13.0}
+fake-dep-344: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
+fake-dep-345: {node: >=6.9.0}
+fake-dep-346: {node: >=12.22.0}
+fake-dep-347: {node: >=14.0.0}
+fake-dep-348: {node: >=16.0.0}
+fake-dep-349: {node: >=18.0.0}
+fake-dep-35: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+fake-dep-350: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+fake-dep-351: {node: >=16.0.0||^14.17.0}
+fake-dep-352: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
+fake-dep-353: {node: >=14.0.0}
+fake-dep-354: {node: ^18.0.0 || ^20.0.0}
+fake-dep-355: {node: *}
+fake-dep-356: {node: >=0.10.0}
+fake-dep-357: {node: >=8.0.0}
+fake-dep-358: {node: >=10.13.0}
+fake-dep-359: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
+fake-dep-36: {node: >=16.0.0||^14.17.0}
+fake-dep-360: {node: >=6.9.0}
+fake-dep-361: {node: >=12.22.0}
+fake-dep-362: {node: >=14.0.0}
+fake-dep-363: {node: >=16.0.0}
+fake-dep-364: {node: >=18.0.0}
+fake-dep-365: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+fake-dep-366: {node: >=16.0.0||^14.17.0}
+fake-dep-367: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
+fake-dep-368: {node: >=14.0.0}
+fake-dep-369: {node: ^18.0.0 || ^20.0.0}
+fake-dep-37: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
+fake-dep-370: {node: *}
+fake-dep-371: {node: >=0.10.0}
+fake-dep-372: {node: >=8.0.0}
+fake-dep-373: {node: >=10.13.0}
+fake-dep-374: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
+fake-dep-375: {node: >=6.9.0}
+fake-dep-376: {node: >=12.22.0}
+fake-dep-377: {node: >=14.0.0}
+fake-dep-378: {node: >=16.0.0}
+fake-dep-379: {node: >=18.0.0}
+fake-dep-38: {node: >=14.0.0}
+fake-dep-380: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+fake-dep-381: {node: >=16.0.0||^14.17.0}
+fake-dep-382: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
+fake-dep-383: {node: >=14.0.0}
+fake-dep-384: {node: ^18.0.0 || ^20.0.0}
+fake-dep-385: {node: *}
+fake-dep-386: {node: >=0.10.0}
+fake-dep-387: {node: >=8.0.0}
+fake-dep-388: {node: >=10.13.0}
+fake-dep-389: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
+fake-dep-39: {node: ^18.0.0 || ^20.0.0}
+fake-dep-390: {node: >=6.9.0}
+fake-dep-391: {node: >=12.22.0}
+fake-dep-392: {node: >=14.0.0}
+fake-dep-393: {node: >=16.0.0}
+fake-dep-394: {node: >=18.0.0}
+fake-dep-395: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+fake-dep-396: {node: >=16.0.0||^14.17.0}
+fake-dep-397: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
+fake-dep-398: {node: >=14.0.0}
+fake-dep-399: {node: ^18.0.0 || ^20.0.0}
+fake-dep-4: {node: >=18.0.0}
+fake-dep-40: {node: *}
+fake-dep-400: {node: *}
+fake-dep-401: {node: >=0.10.0}
+fake-dep-402: {node: >=8.0.0}
+fake-dep-403: {node: >=10.13.0}
+fake-dep-404: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
+fake-dep-405: {node: >=6.9.0}
+fake-dep-406: {node: >=12.22.0}
+fake-dep-407: {node: >=14.0.0}
+fake-dep-408: {node: >=16.0.0}
+fake-dep-409: {node: >=18.0.0}
+fake-dep-41: {node: >=0.10.0}
+fake-dep-410: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+fake-dep-411: {node: >=16.0.0||^14.17.0}
+fake-dep-412: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
+fake-dep-413: {node: >=14.0.0}
+fake-dep-414: {node: ^18.0.0 || ^20.0.0}
+fake-dep-415: {node: *}
+fake-dep-416: {node: >=0.10.0}
+fake-dep-417: {node: >=8.0.0}
+fake-dep-418: {node: >=10.13.0}
+fake-dep-419: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
+fake-dep-42: {node: >=8.0.0}
+fake-dep-420: {node: >=6.9.0}
+fake-dep-421: {node: >=12.22.0}
+fake-dep-422: {node: >=14.0.0}
+fake-dep-423: {node: >=16.0.0}
+fake-dep-424: {node: >=18.0.0}
+fake-dep-425: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+fake-dep-426: {node: >=16.0.0||^14.17.0}
+fake-dep-427: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
+fake-dep-428: {node: >=14.0.0}
+fake-dep-429: {node: ^18.0.0 || ^20.0.0}
+fake-dep-43: {node: >=10.13.0}
+fake-dep-430: {node: *}
+fake-dep-431: {node: >=0.10.0}
+fake-dep-432: {node: >=8.0.0}
+fake-dep-433: {node: >=10.13.0}
+fake-dep-434: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
+fake-dep-435: {node: >=6.9.0}
+fake-dep-436: {node: >=12.22.0}
+fake-dep-437: {node: >=14.0.0}
+fake-dep-438: {node: >=16.0.0}
+fake-dep-439: {node: >=18.0.0}
+fake-dep-44: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
+fake-dep-440: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+fake-dep-441: {node: >=16.0.0||^14.17.0}
+fake-dep-442: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
+fake-dep-443: {node: >=14.0.0}
+fake-dep-444: {node: ^18.0.0 || ^20.0.0}
+fake-dep-445: {node: *}
+fake-dep-446: {node: >=0.10.0}
+fake-dep-447: {node: >=8.0.0}
+fake-dep-448: {node: >=10.13.0}
+fake-dep-449: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
+fake-dep-45: {node: >=6.9.0}
+fake-dep-450: {node: >=6.9.0}
+fake-dep-451: {node: >=12.22.0}
+fake-dep-452: {node: >=14.0.0}
+fake-dep-453: {node: >=16.0.0}
+fake-dep-454: {node: >=18.0.0}
+fake-dep-455: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+fake-dep-456: {node: >=16.0.0||^14.17.0}
+fake-dep-457: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
+fake-dep-458: {node: >=14.0.0}
+fake-dep-459: {node: ^18.0.0 || ^20.0.0}
+fake-dep-46: {node: >=12.22.0}
+fake-dep-460: {node: *}
+fake-dep-461: {node: >=0.10.0}
+fake-dep-462: {node: >=8.0.0}
+fake-dep-463: {node: >=10.13.0}
+fake-dep-464: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
+fake-dep-465: {node: >=6.9.0}
+fake-dep-466: {node: >=12.22.0}
+fake-dep-467: {node: >=14.0.0}
+fake-dep-468: {node: >=16.0.0}
+fake-dep-469: {node: >=18.0.0}
+fake-dep-47: {node: >=14.0.0}
+fake-dep-470: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+fake-dep-471: {node: >=16.0.0||^14.17.0}
+fake-dep-472: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
+fake-dep-473: {node: >=14.0.0}
+fake-dep-474: {node: ^18.0.0 || ^20.0.0}
+fake-dep-475: {node: *}
+fake-dep-476: {node: >=0.10.0}
+fake-dep-477: {node: >=8.0.0}
+fake-dep-478: {node: >=10.13.0}
+fake-dep-479: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
+fake-dep-48: {node: >=16.0.0}
+fake-dep-480: {node: >=6.9.0}
+fake-dep-481: {node: >=12.22.0}
+fake-dep-482: {node: >=14.0.0}
+fake-dep-483: {node: >=16.0.0}
+fake-dep-484: {node: >=18.0.0}
+fake-dep-485: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+fake-dep-486: {node: >=16.0.0||^14.17.0}
+fake-dep-487: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
+fake-dep-488: {node: >=14.0.0}
+fake-dep-489: {node: ^18.0.0 || ^20.0.0}
+fake-dep-49: {node: >=18.0.0}
+fake-dep-490: {node: *}
+fake-dep-491: {node: >=0.10.0}
+fake-dep-492: {node: >=8.0.0}
+fake-dep-493: {node: >=10.13.0}
+fake-dep-494: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
+fake-dep-495: {node: >=6.9.0}
+fake-dep-496: {node: >=12.22.0}
+fake-dep-497: {node: >=14.0.0}
+fake-dep-498: {node: >=16.0.0}
+fake-dep-499: {node: >=18.0.0}
+fake-dep-5: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+fake-dep-50: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+fake-dep-51: {node: >=16.0.0||^14.17.0}
+fake-dep-52: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
+fake-dep-53: {node: >=14.0.0}
+fake-dep-54: {node: ^18.0.0 || ^20.0.0}
+fake-dep-55: {node: *}
+fake-dep-56: {node: >=0.10.0}
+fake-dep-57: {node: >=8.0.0}
+fake-dep-58: {node: >=10.13.0}
+fake-dep-59: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
+fake-dep-6: {node: >=16.0.0||^14.17.0}
+fake-dep-60: {node: >=6.9.0}
+fake-dep-61: {node: >=12.22.0}
+fake-dep-62: {node: >=14.0.0}
+fake-dep-63: {node: >=16.0.0}
+fake-dep-64: {node: >=18.0.0}
+fake-dep-65: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+fake-dep-66: {node: >=16.0.0||^14.17.0}
+fake-dep-67: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
+fake-dep-68: {node: >=14.0.0}
+fake-dep-69: {node: ^18.0.0 || ^20.0.0}
+fake-dep-7: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
+fake-dep-70: {node: *}
+fake-dep-71: {node: >=0.10.0}
+fake-dep-72: {node: >=8.0.0}
+fake-dep-73: {node: >=10.13.0}
+fake-dep-74: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
+fake-dep-75: {node: >=6.9.0}
+fake-dep-76: {node: >=12.22.0}
+fake-dep-77: {node: >=14.0.0}
+fake-dep-78: {node: >=16.0.0}
+fake-dep-79: {node: >=18.0.0}
+fake-dep-8: {node: >=14.0.0}
+fake-dep-80: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+fake-dep-81: {node: >=16.0.0||^14.17.0}
+fake-dep-82: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
+fake-dep-83: {node: >=14.0.0}
+fake-dep-84: {node: ^18.0.0 || ^20.0.0}
+fake-dep-85: {node: *}
+fake-dep-86: {node: >=0.10.0}
+fake-dep-87: {node: >=8.0.0}
+fake-dep-88: {node: >=10.13.0}
+fake-dep-89: {node: ^16.0.0 || ^18.0.0 || ^20.0.0}
+fake-dep-9: {node: ^18.0.0 || ^20.0.0}
+fake-dep-90: {node: >=6.9.0}
+fake-dep-91: {node: >=12.22.0}
+fake-dep-92: {node: >=14.0.0}
+fake-dep-93: {node: >=16.0.0}
+fake-dep-94: {node: >=18.0.0}
+fake-dep-95: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+fake-dep-96: {node: >=16.0.0||^14.17.0}
+fake-dep-97: {node: ^14.17.0 || ^16.10.0 || >=17.0.0}
+fake-dep-98: {node: >=14.0.0}
+fake-dep-99: {node: ^18.0.0 || ^20.0.0}

--- a/crates/riri-npm/tests/snapshots/parse_fixtures__parse_npm_fixture@npm-v3-engines-as-array.snap
+++ b/crates/riri-npm/tests/snapshots/parse_fixtures__parse_npm_fixture@npm-v3-engines-as-array.snap
@@ -2,4 +2,4 @@
 source: crates/riri-npm/tests/parse_fixtures.rs
 expression: snapshot
 ---
-node_modules/arr-engines: ["node >= 7"]
+arr-engines: ["node >= 7"]

--- a/crates/riri-npm/tests/snapshots/parse_fixtures__parse_npm_fixture@npm-v3-no-intersection.snap
+++ b/crates/riri-npm/tests/snapshots/parse_fixtures__parse_npm_fixture@npm-v3-no-intersection.snap
@@ -3,4 +3,4 @@ source: crates/riri-npm/tests/parse_fixtures.rs
 expression: snapshot
 ---
 : {node: 18.14}
-node_modules/foo: {node: 18.13}
+foo: {node: 18.13}

--- a/crates/riri-npm/tests/snapshots/parse_fixtures__parse_npm_fixture@npm-v3-no-npmrc.snap
+++ b/crates/riri-npm/tests/snapshots/parse_fixtures__parse_npm_fixture@npm-v3-no-npmrc.snap
@@ -2,9 +2,9 @@
 source: crates/riri-npm/tests/parse_fixtures.rs
 expression: snapshot
 ---
-node_modules/all: {node: *}
-node_modules/arr: ["node >= 7"]
-node_modules/bar: {node: >=12.22.0, npm: >=6.0.0, yarn: ^1.22.4}
-node_modules/complex1: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-node_modules/complex2: {node: >=16.0.0||^14.17.0}
-node_modules/foo: {node: >=6.9.0}
+all: {node: *}
+arr: ["node >= 7"]
+bar: {node: >=12.22.0, npm: >=6.0.0, yarn: ^1.22.4}
+complex1: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+complex2: {node: >=16.0.0||^14.17.0}
+foo: {node: >=6.9.0}

--- a/crates/riri-npm/tests/snapshots/parse_fixtures__parse_npm_fixture@npm-v3-npmrc-empty.snap
+++ b/crates/riri-npm/tests/snapshots/parse_fixtures__parse_npm_fixture@npm-v3-npmrc-empty.snap
@@ -2,9 +2,9 @@
 source: crates/riri-npm/tests/parse_fixtures.rs
 expression: snapshot
 ---
-node_modules/all: {node: *}
-node_modules/arr: ["node >= 7"]
-node_modules/bar: {node: >=12.22.0, npm: >=6.0.0, yarn: ^1.22.4}
-node_modules/complex1: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-node_modules/complex2: {node: >=16.0.0||^14.17.0}
-node_modules/foo: {node: >=6.9.0}
+all: {node: *}
+arr: ["node >= 7"]
+bar: {node: >=12.22.0, npm: >=6.0.0, yarn: ^1.22.4}
+complex1: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+complex2: {node: >=16.0.0||^14.17.0}
+foo: {node: >=6.9.0}

--- a/crates/riri-npm/tests/snapshots/parse_fixtures__parse_npm_fixture@npm-v3-npmrc-engine-strict.snap
+++ b/crates/riri-npm/tests/snapshots/parse_fixtures__parse_npm_fixture@npm-v3-npmrc-engine-strict.snap
@@ -2,9 +2,9 @@
 source: crates/riri-npm/tests/parse_fixtures.rs
 expression: snapshot
 ---
-node_modules/all: {node: *}
-node_modules/arr: ["node >= 7"]
-node_modules/bar: {node: >=12.22.0, npm: >=6.0.0, yarn: ^1.22.4}
-node_modules/complex1: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-node_modules/complex2: {node: >=16.0.0||^14.17.0}
-node_modules/foo: {node: >=6.9.0}
+all: {node: *}
+arr: ["node >= 7"]
+bar: {node: >=12.22.0, npm: >=6.0.0, yarn: ^1.22.4}
+complex1: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+complex2: {node: >=16.0.0||^14.17.0}
+foo: {node: >=6.9.0}

--- a/crates/riri-npm/tests/snapshots/parse_fixtures__parse_npm_fixture@npm-v3-or-ranges-node-npm-yarn.snap
+++ b/crates/riri-npm/tests/snapshots/parse_fixtures__parse_npm_fixture@npm-v3-or-ranges-node-npm-yarn.snap
@@ -2,9 +2,9 @@
 source: crates/riri-npm/tests/parse_fixtures.rs
 expression: snapshot
 ---
-node_modules/all: {node: *}
-node_modules/arr: ["node >= 7"]
-node_modules/bar: {node: >=12.22.0, npm: >=6.0.0, yarn: ^1.22.4}
-node_modules/complex1: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-node_modules/complex2: {node: >=16.0.0||^14.17.0}
-node_modules/foo: {node: >=6.9.0}
+all: {node: *}
+arr: ["node >= 7"]
+bar: {node: >=12.22.0, npm: >=6.0.0, yarn: ^1.22.4}
+complex1: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+complex2: {node: >=16.0.0||^14.17.0}
+foo: {node: >=6.9.0}

--- a/crates/riri-npm/tests/snapshots/parse_fixtures__parse_npm_fixture@npm-v3-or-ranges-node-only.snap
+++ b/crates/riri-npm/tests/snapshots/parse_fixtures__parse_npm_fixture@npm-v3-or-ranges-node-only.snap
@@ -2,9 +2,9 @@
 source: crates/riri-npm/tests/parse_fixtures.rs
 expression: snapshot
 ---
-node_modules/all: {node: *}
-node_modules/arr: ["node >= 7"]
-node_modules/bar: {node: >=12.22.0}
-node_modules/complex1: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-node_modules/complex2: {node: >=16.0.0||^14.17.0}
-node_modules/foo: {node: >=6.9.0}
+all: {node: *}
+arr: ["node >= 7"]
+bar: {node: >=12.22.0}
+complex1: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+complex2: {node: >=16.0.0||^14.17.0}
+foo: {node: >=6.9.0}

--- a/crates/riri-npm/tests/snapshots/parse_fixtures__parse_npm_fixture@npm-v3-packages-field.snap
+++ b/crates/riri-npm/tests/snapshots/parse_fixtures__parse_npm_fixture@npm-v3-packages-field.snap
@@ -2,4 +2,4 @@
 source: crates/riri-npm/tests/parse_fixtures.rs
 expression: snapshot
 ---
-node_modules/fake-package-01: {node: >=6.9.0}
+fake-package-01: {node: >=6.9.0}

--- a/crates/riri-npm/tests/snapshots/parse_fixtures__parse_npm_fixture@npm-v3-wildcard-and-missing.snap
+++ b/crates/riri-npm/tests/snapshots/parse_fixtures__parse_npm_fixture@npm-v3-wildcard-and-missing.snap
@@ -2,5 +2,5 @@
 source: crates/riri-npm/tests/parse_fixtures.rs
 expression: snapshot
 ---
-node_modules/with-constraint: {node: >=16.0.0}
-node_modules/with-wildcard: {node: *}
+with-constraint: {node: >=16.0.0}
+with-wildcard: {node: *}

--- a/crates/riri-pnpm/Cargo.toml
+++ b/crates/riri-pnpm/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "riri-pnpm"
 version = "0.1.4"
+description = "pnpm-lock.yaml parser (v5 to v11) with workspace catalog support"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/riri-pnpm/Cargo.toml
+++ b/crates/riri-pnpm/Cargo.toml
@@ -3,6 +3,7 @@ name = "riri-pnpm"
 version = "0.1.4"
 description = "pnpm-lock.yaml parser (v5 to v11) with workspace catalog support"
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 

--- a/crates/riri-pnpm/Cargo.toml
+++ b/crates/riri-pnpm/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [features]
 graph = ["riri-common/graph"]

--- a/crates/riri-pnpm/src/lib.rs
+++ b/crates/riri-pnpm/src/lib.rs
@@ -226,7 +226,7 @@ impl LockfileEngines for PnpmLockfile {
         Box::new(
             self.entries()
                 .iter()
-                .filter_map(|(name, entry)| entry.engines.as_ref().map(|e| (name.as_str(), e))),
+                .filter_map(|(key, entry)| entry.engines.as_ref().map(|e| (pkg_key_name(key), e))),
         )
     }
 }
@@ -261,25 +261,37 @@ impl LockfileVersions for PnpmLockfile {
     }
 }
 
-/// Split a `packages`/`snapshots` key into `(name, version-with-peer-suffix)`.
+/// Split a `packages`/`snapshots` key into `(name, version-with-peer-suffix)`,
+/// both slices of `key`. `None` when the key carries no version.
 ///
 /// - v5: `/name/1.2.3`, `/@scope/name/1.2.3`
 /// - v6: `/name@1.2.3(peer)`, `/@scope/name@1.2.3`
 /// - v9: `name@1.2.3(peer)`, `@scope/name@1.2.3`
-#[cfg(feature = "graph")]
-fn parse_pkg_key(key: &str) -> Option<(String, String)> {
+fn split_pkg_key(key: &str) -> Option<(&str, &str)> {
     let k = key.strip_prefix('/').unwrap_or(key);
     if let Some(idx) = find_name_version_at(k) {
-        return Some((k[..idx].to_string(), k[idx + 1..].to_string()));
+        return Some((&k[..idx], &k[idx + 1..]));
     }
     // v5 slash form: version is the segment after the last `/`.
-    let (name, version) = k.rsplit_once('/')?;
-    Some((name.to_string(), version.to_string()))
+    k.rsplit_once('/')
+}
+
+#[cfg(feature = "graph")]
+fn parse_pkg_key(key: &str) -> Option<(String, String)> {
+    split_pkg_key(key).map(|(name, version)| (name.to_string(), version.to_string()))
+}
+
+/// Package name from a `packages`/`snapshots` key, as a slice of the key.
+///
+/// `/typescript@5.4.5` -> `typescript`, `/@scope/pkg/1.2.3` -> `@scope/pkg`,
+/// `foo@1.0.0(react@18.2.0)` -> `foo`.
+fn pkg_key_name(key: &str) -> &str {
+    let k = key.strip_prefix('/').unwrap_or(key);
+    split_pkg_key(key).map_or(k, |(name, _)| name)
 }
 
 /// Index of the `@` separating name from version: ignores a leading scope `@`
 /// and only looks before any `(` peer suffix.
-#[cfg(feature = "graph")]
 fn find_name_version_at(k: &str) -> Option<usize> {
     let stop = k.find('(').unwrap_or(k.len());
     k[..stop].rfind('@').filter(|&i| i > 0)
@@ -701,5 +713,21 @@ packages:
             parse_pkg_key("@scope/name@1.2.0"),
             Some(("@scope/name".into(), "1.2.0".into()))
         );
+    }
+}
+
+#[cfg(test)]
+mod key_tests {
+    use super::pkg_key_name;
+
+    #[test]
+    fn pkg_key_name_handles_all_forms() {
+        assert_eq!(pkg_key_name("/a/1.2.0"), "a");
+        assert_eq!(pkg_key_name("/@scope/name/1.2.0"), "@scope/name");
+        assert_eq!(pkg_key_name("/a@1.2.0"), "a");
+        assert_eq!(pkg_key_name("/a@1.2.0(peer@1.0.0)"), "a");
+        assert_eq!(pkg_key_name("a@1.2.0(peer@1.0.0)"), "a");
+        assert_eq!(pkg_key_name("@scope/name@1.2.0"), "@scope/name");
+        assert_eq!(pkg_key_name("a"), "a");
     }
 }

--- a/crates/riri-pnpm/tests/parse_fixtures.rs
+++ b/crates/riri-pnpm/tests/parse_fixtures.rs
@@ -38,13 +38,18 @@ fn parse_pnpm_fixture(#[files("../../fixtures/pnpm-*/pnpm-lock.yaml")] lockfile_
     let lock = PnpmLockfile::parse(&content)
         .unwrap_or_else(|e| panic!("failed to parse {fixture_name}: {e}"));
 
-    // Collect engine entries sorted by name for deterministic snapshots
-    let mut engines: Vec<(&str, &Engines)> = lock.engines_iter().collect();
-    engines.sort_by_key(|(name, _)| *name);
+    // Snapshot the lockfile's own keys, sorted: they are unique, so the order is
+    // total, and they keep the version that `engines_iter` normalizes away.
+    let mut engines: Vec<(&str, &Engines)> = lock
+        .entries()
+        .iter()
+        .filter_map(|(key, entry)| entry.engines.as_ref().map(|e| (key.as_str(), e)))
+        .collect();
+    engines.sort_by_key(|(key, _)| *key);
 
     let snapshot = engines
         .iter()
-        .map(|(name, eng)| format!("{name}: {}", fmt_engines(eng)))
+        .map(|(key, eng)| format!("{key}: {}", fmt_engines(eng)))
         .collect::<Vec<_>>()
         .join("\n");
 

--- a/crates/riri-semver-range/Cargo.toml
+++ b/crates/riri-semver-range/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "riri-semver-range"
 version = "0.1.2"
+description = "npm-style semver range parsing, narrowing & humanizing"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/riri-semver-range/Cargo.toml
+++ b/crates/riri-semver-range/Cargo.toml
@@ -3,6 +3,7 @@ name = "riri-semver-range"
 version = "0.1.2"
 description = "npm-style semver range parsing, narrowing & humanizing"
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 

--- a/crates/riri-semver-range/Cargo.toml
+++ b/crates/riri-semver-range/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [dependencies]
 semver = { workspace = true }

--- a/crates/riri-task-runner/Cargo.toml
+++ b/crates/riri-task-runner/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [dependencies]
 console = { workspace = true }

--- a/crates/riri-task-runner/Cargo.toml
+++ b/crates/riri-task-runner/Cargo.toml
@@ -3,6 +3,7 @@ name = "riri-task-runner"
 version = "0.1.2"
 description = "Task runner with spinner, verbose & silent renderers"
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 

--- a/crates/riri-task-runner/Cargo.toml
+++ b/crates/riri-task-runner/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "riri-task-runner"
 version = "0.1.2"
+description = "Task runner with spinner, verbose & silent renderers"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/riri-workspace/Cargo.toml
+++ b/crates/riri-workspace/Cargo.toml
@@ -3,6 +3,7 @@ name = "riri-workspace"
 version = "0.1.4"
 description = "Workspace detection & member iteration for npm, pnpm & yarn monorepos"
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 

--- a/crates/riri-workspace/Cargo.toml
+++ b/crates/riri-workspace/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "riri-workspace"
 version = "0.1.4"
+description = "Workspace detection & member iteration for npm, pnpm & yarn monorepos"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/riri-workspace/Cargo.toml
+++ b/crates/riri-workspace/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [dependencies]
 riri-common = { path = "../riri-common", version = "0.1.4" }

--- a/crates/riri-yarn/Cargo.toml
+++ b/crates/riri-yarn/Cargo.toml
@@ -3,6 +3,7 @@ name = "riri-yarn"
 version = "0.1.4"
 description = "yarn.lock parser (classic v1 & berry v2+) with node_modules engine scanning"
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 

--- a/crates/riri-yarn/Cargo.toml
+++ b/crates/riri-yarn/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "riri-yarn"
 version = "0.1.4"
+description = "yarn.lock parser (classic v1 & berry v2+) with node_modules engine scanning"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/riri-yarn/Cargo.toml
+++ b/crates/riri-yarn/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [features]
 graph = ["riri-common/graph"]

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
+repository.workspace = true
 publish = false
 
 [dependencies]

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -2,6 +2,7 @@
 name = "xtask"
 version = "0.1.3"
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 publish = false
@@ -14,6 +15,9 @@ riri-node-lifecycle = { path = "../riri-node-lifecycle", version = "0.1.3", feat
 serde_json = { workspace = true }
 similar = "3.1.1"
 tera = { version = "2.0.0", default-features = false }
+
+[dev-dependencies]
+tempfile = { workspace = true }
 
 [lib]
 path = "src/lib.rs"

--- a/crates/xtask/src/regen_readme.rs
+++ b/crates/xtask/src/regen_readme.rs
@@ -276,6 +276,22 @@ fn rust_tested_with(workspace_root: &Path) -> String {
         .unwrap_or_else(|| tool_version("rustc", &["--version"]))
 }
 
+/// The rustc constraint advertised in the root README, read from
+/// `[workspace.package] rust-version` so the two cannot drift.
+fn rust_constraint(workspace_root: &Path) -> anyhow::Result<String> {
+    let manifest = std::fs::read_to_string(workspace_root.join("Cargo.toml"))
+        .context("read workspace Cargo.toml")?;
+    let msrv = manifest
+        .lines()
+        .map(str::trim)
+        .find_map(|line| line.strip_prefix("rust-version"))
+        .and_then(|rest| rest.trim_start().strip_prefix('='))
+        .map(|value| value.trim().trim_matches('"').to_string())
+        .filter(|version| !version.is_empty())
+        .context("no rust-version in [workspace.package]")?;
+    Ok(format!(">={msrv} <2.0.0"))
+}
+
 /// Extract the `channel` value from a `rust-toolchain.toml`'s `[toolchain]` table.
 fn parse_toolchain_channel(toml: &str) -> Option<String> {
     toml.lines()
@@ -284,6 +300,21 @@ fn parse_toolchain_channel(toml: &str) -> Option<String> {
         .and_then(|rest| rest.trim_start().strip_prefix('='))
         .map(|value| value.trim().trim_matches('"').to_string())
         .filter(|channel| !channel.is_empty())
+}
+
+/// The prek version advertised as "tested with", read from the version pinned in
+/// the composite action — the single source of truth across workflows — so the
+/// README does not depend on whichever prek sits on the regenerating machine.
+fn prek_tested_with(workspace_root: &Path) -> anyhow::Result<String> {
+    let action = workspace_root.join(".github/actions/setup-prek/action.yml");
+    let yaml =
+        std::fs::read_to_string(&action).with_context(|| format!("read {}", action.display()))?;
+    yaml.lines()
+        .map(str::trim)
+        .find_map(|line| line.strip_prefix("prek-version:"))
+        .map(|value| value.trim().trim_matches('"').to_string())
+        .filter(|version| !version.is_empty())
+        .context("no prek-version pin in .github/actions/setup-prek/action.yml")
 }
 
 /// Run `cmd args` and parse a version from combined stdout/stderr; `"n/a"` on failure.
@@ -572,8 +603,8 @@ fn render_root(
 fn regenerate_root(workspace_root: &Path, tera: &Tera) -> anyhow::Result<String> {
     let node_constraint = node_constraint(workspace_root)?;
     let prereqs = serde_json::json!([
-        {"name":"rustc","url":RUSTC_URL,"constraint":">=1.85.0 <2.0.0","tested_with":rust_tested_with(workspace_root)},
-        {"name":"prek","url":PREK_URL,"constraint":">=0.3.8","tested_with":tool_version("prek",&["--version"])},
+        {"name":"rustc","url":RUSTC_URL,"constraint":rust_constraint(workspace_root)?,"tested_with":rust_tested_with(workspace_root)},
+        {"name":"prek","url":PREK_URL,"constraint":">=0.3.8","tested_with":prek_tested_with(workspace_root)?},
         {"name":"node","url":NODE_URL,"constraint":node_constraint,"tested_with":tool_version("node",&["--version"])},
     ]);
     let tools = CRATES
@@ -618,7 +649,7 @@ fn parse_version(raw: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{build_tera, parse_version, render_root};
+    use super::{build_tera, parse_version, prek_tested_with, render_root, rust_constraint};
 
     #[test]
     fn parses_rustc() {
@@ -655,6 +686,33 @@ mod tests {
     #[test]
     fn toolchain_channel_absent() {
         assert_eq!(super::parse_toolchain_channel("[toolchain]\n"), None);
+    }
+
+    #[test]
+    fn prek_tested_with_reads_the_action_pin() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let action = dir.path().join(".github/actions/setup-prek");
+        std::fs::create_dir_all(&action).expect("create dirs");
+        std::fs::write(
+            action.join("action.yml"),
+            "runs:\n  steps:\n    - with:\n        prek-version: \"0.4.10\"\n",
+        )
+        .expect("write action");
+        assert_eq!(prek_tested_with(dir.path()).expect("prek"), "0.4.10");
+    }
+
+    #[test]
+    fn rust_constraint_tracks_workspace_rust_version() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            dir.path().join("Cargo.toml"),
+            "[workspace.package]\nrust-version = \"1.97.1\"\n",
+        )
+        .expect("write manifest");
+        assert_eq!(
+            rust_constraint(dir.path()).expect("constraint"),
+            ">=1.97.1 <2.0.0"
+        );
     }
 
     #[test]

--- a/crates/xtask/templates/readme-root.tera
+++ b/crates/xtask/templates/readme-root.tera
@@ -11,6 +11,7 @@
 ## Table of Contents
 
 - [Tools][tools]
+- [Using the crates][crates]
 - [Benchmarks][benchmarks]
 - [Development][development]
 - [License][license-section]
@@ -32,6 +33,20 @@ Prebuilt native binaries are published for:
 {{ platforms_table }}
 
 ---
+
+## Using the crates
+
+The `riri-*` crates are libraries too. They are not on crates.io yet, so depend on them by git, and pin a `rev` rather than a tag: cargo rejects two dependencies on one git URL with different refs, so per-crate tags cannot be combined.
+
+```toml
+[dependencies]
+riri-nce = { git = "https://github.com/smarlhens/riri-node-tools", rev = "0000000", default-features = false }
+riri-npd = { git = "https://github.com/smarlhens/riri-node-tools", rev = "0000000", default-features = false }
+```
+
+`default-features = false` drops the CLI layer. `refresh`, the HTTP client behind `nce --refresh`, is off by default as well: released binaries enable it, a `cargo install --git` build needs `--features refresh`.
+
+Supported surface and publish plan: [docs/crate-api.md](docs/crate-api.md).
 
 ## Benchmarks
 
@@ -78,6 +93,7 @@ Microbenchmarks (point-in-time, machine-specific) live in [BENCHMARKS.md](BENCHM
 [BlueOak Model License 1.0.0](LICENSE.md).
 
 [tools]: #tools
+[crates]: #using-the-crates
 [benchmarks]: #benchmarks
 [development]: #development
 [license-section]: #license

--- a/crates/xtask/templates/readme-root.tera
+++ b/crates/xtask/templates/readme-root.tera
@@ -46,7 +46,9 @@ riri-npd = { git = "https://github.com/smarlhens/riri-node-tools", rev = "000000
 
 `default-features = false` drops the CLI layer. `refresh`, the HTTP client behind `nce --refresh`, is off by default as well: released binaries enable it, a `cargo install --git` build needs `--features refresh`.
 
-Supported surface and publish plan: [docs/crate-api.md](docs/crate-api.md).
+What is supported is what each crate's rustdoc documents. `pub` alone is not a promise: the `cli` modules exist so the binaries and the NAPI shims can share code and move without notice, and undocumented `pub` items are incidental. Nothing reads the filesystem or opens a socket unless its name says so — `PackageJsonFile::read`, `YarnProject::scan`, the `refresh` feature.
+
+Every crate is `0.1.x`, where cargo treats a minor bump as breaking. A breaking change lands as a `feat!:` commit, which release-please turns into a minor bump; everything else becomes a patch.
 
 ## Benchmarks
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -51,6 +51,11 @@
         { "type": "toml", "path": "/Cargo.lock", "jsonpath": "$.package[?(@.name.value=='riri-common')].version" }
       ]
     },
+    "crates/riri-lockfile": {
+      "extra-files": [
+        { "type": "toml", "path": "/Cargo.lock", "jsonpath": "$.package[?(@.name.value=='riri-lockfile')].version" }
+      ]
+    },
     "crates/riri-find-up": {
       "extra-files": [
         { "type": "toml", "path": "/Cargo.lock", "jsonpath": "$.package[?(@.name.value=='riri-find-up')].version" }


### PR DESCRIPTION
Makes the `riri-*` crates usable as libraries: publishable metadata, no CLI layer forced into a library build, no HTTP stack by default, and engine application that works on a `serde_json::Value` instead of a file on disk.

| # | Item | Commit |
| --- | --- | --- |
| 1 | `description` on every publishable crate | `561f264` |
| 2 | `rust-version = 1.88.0` — measured floor, 1.87 fails on let-chains | `2d1ef5a` |
| 3 | README: pin a `rev`, not a per-crate tag | `df3ddf0` |
| 4 | Re-export consumer-facing types (nce, npd, ncd) | `70aba95` |
| 5 | Feature-gate `pub mod cli` (nce, npd, ncd) | `1f7d696` |
| 6 | `refresh` out of default features | `d449121` |
| 7 | `engines_iter()` yields bare package names | `7039173` |
| 8 | Pure engine application | `57aac6a` |
| 9 | `parse_lockfile(PackageManager, &str)` in a new `riri-lockfile` crate | `199dcfb` |
| 10 | API policy in the README + publish metadata | `fa37e59` |

## Breaking

- `apply_engines_update` takes `&mut serde_json::Value`, not `&mut PackageJsonFile`.
- `engines_iter()` yields `typescript`, not `node_modules/typescript`.
- `riri-nce`'s `refresh` is no longer default. Released binaries keep it via `[package.metadata.dist] features`; `cargo install --git` needs `--features refresh`.

## Verified

- Zero hand-rolled package-manager matches left in `src/` — was 5 (`riri-ncd` ×3, both napi shims).
- Napi shims import only from the facade: −4 direct deps in `riri-napi-nce`, −3 in `riri-napi-npd`.
- Lean builds drop clap, `clap_*`, comfy-table, console, anyhow, tracing-subscriber, task-runner, `sort-package-json`, ureq/rustls/webpki-roots; `riri-ncd --no-default-features` also drops indicatif.
- `riri-lockfile/tests/engines_names.rs` enforces the bare-name contract over the fixture corpus; reverting one impl to raw keys fails it.
- `tests/facade.rs` in nce and npd imports only its own crate root, incl. `check_engines_with_lifecycle`.
- 1.88.0 compiles `--lib --bins`, `--no-default-features`, `--all-features`, `--all-targets`.
- `check_engines: 500 deps` unchanged vs `main` (64.3 µs). pnpm snapshots byte-identical to `main`.
- CI builds both new configs (`--no-default-features`, `--features refresh`).

## Not done

- `riri-ncd`'s `ureq` stays unconditional: `check_deprecations_from_content` builds the registry client itself, so making it optional means pushing that out to `DeprecationSource`.
- `ParsedLockfile::engines()` returns `Option` because the entry point is pure; a `scan`-gated `open_engines` would remove the last yarn special case.
- Pre-existing, unrelated: `riri-semver-range` gives `false` for `<0.0.0-beta` vs `0.0.0-alpha` where nodejs-semver gives `true` (proptest seed `cc 6b24f37aae62dce4d5f6c097dbee74902b8a8a151a3a5c974b46b57b875fa8d1`); `nce/cli.rs` reads `package.json` twice; `riri_npm::version_for` allocates per lookup.
- No CI gate on the MSRV floor.
