### PR TITLE
feat(ncd)!: make the http stack opt-in & gate the msrv floor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,9 @@ jobs:
           skip-github-release: ${{ env.skip_github_release }}
           token: ${{ secrets.PAT }}
 
+  msrv:
+    uses: ./.github/workflows/msrv.yml
+
   bench-baseline:
     needs: changes
     if: needs.changes.outputs.bench == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Lint
         run: cargo clippy --workspace --all-targets
       - name: Check the library-only configuration
-        run: cargo check -p riri-nce -p riri-npd --no-default-features
+        run: cargo check -p riri-nce -p riri-ncd -p riri-npd --no-default-features
       - name: Lint the refresh path
         run: cargo clippy -p riri-nce --features refresh --all-targets
       - name: Test

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -1,0 +1,32 @@
+name: msrv
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_MSRV: "1.88.0"
+
+jobs:
+  msrv:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Install the MSRV toolchain
+        run: rustup toolchain install "$RUST_MSRV" --profile minimal
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: msrv
+      - name: Check the floor
+        run: cargo "+$RUST_MSRV" check --locked --workspace --lib --bins
+      - name: Check the floor for the library-only configuration
+        run: cargo "+$RUST_MSRV" check --locked -p riri-nce -p riri-ncd -p riri-npd --no-default-features --lib
+      - name: Check the floor for the refresh path
+        run: cargo "+$RUST_MSRV" check --locked -p riri-nce --features refresh --lib

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Test
         run: cargo test --workspace --verbose
 
+  msrv:
+    uses: ./.github/workflows/msrv.yml
+
   readme-drift:
     name: readme-drift - ${{ matrix.crate.name }}
     runs-on: ubuntu-24.04

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Lint
         run: cargo clippy --workspace --all-targets
       - name: Check the library-only configuration
-        run: cargo check -p riri-nce -p riri-npd --no-default-features
+        run: cargo check -p riri-nce -p riri-ncd -p riri-npd --no-default-features
       - name: Lint the refresh path
         run: cargo clippy -p riri-nce --features refresh --all-targets
       - name: Test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1391,6 +1391,7 @@ dependencies = [
  "riri-pnpm",
  "riri-yarn",
  "rstest",
+ "tempfile",
  "thiserror",
 ]
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ riri-ncd = { git = "https://github.com/smarlhens/riri-node-tools", rev = "000000
 riri-npd = { git = "https://github.com/smarlhens/riri-node-tools", rev = "0000000", default-features = false }
 ```
 
-`default-features = false` drops the CLI layer, and with it every HTTP client. The two that exist are opt-in: `riri-nce`'s `refresh` (behind `nce --refresh`) and `riri-ncd`'s `http` (the registry-backed `DeprecationSource`). Released binaries enable them; a `cargo install --git` build needs `--features refresh`. Without `http`, `riri-ncd` still analyzes a lockfile through `check_deprecations` against a `DeprecationSource` you supply.
+`default-features = false` drops the CLI layer, and with it every HTTP client. Both are opt-in: `riri-nce`'s `refresh` (behind `nce --refresh`) and `riri-ncd`'s `http`, the registry-backed `DeprecationSource`; released binaries enable them, and a `cargo install --git` build needs `--features refresh`. Without `http`, `riri-ncd` still analyzes a lockfile: `check_deprecations` takes any `DeprecationSource`. Bring your own, or use the bundled `registry::FileRegistry`, which reads packuments from a directory.
 
 What is supported is what each crate's rustdoc documents. `pub` alone is not a promise: the `cli` modules exist so the binaries and the NAPI shims can share code and move without notice, and undocumented `pub` items are incidental. Nothing reads the filesystem or opens a socket unless its name says so — `PackageJsonFile::read`, `YarnProject::scan`, the `refresh` and `http` features.
 

--- a/README.md
+++ b/README.md
@@ -51,12 +51,13 @@ The `riri-*` crates are libraries too. They are not on crates.io yet, so depend 
 ```toml
 [dependencies]
 riri-nce = { git = "https://github.com/smarlhens/riri-node-tools", rev = "0000000", default-features = false }
+riri-ncd = { git = "https://github.com/smarlhens/riri-node-tools", rev = "0000000", default-features = false }
 riri-npd = { git = "https://github.com/smarlhens/riri-node-tools", rev = "0000000", default-features = false }
 ```
 
-`default-features = false` drops the CLI layer. `refresh`, the HTTP client behind `nce --refresh`, is off by default as well: released binaries enable it, a `cargo install --git` build needs `--features refresh`.
+`default-features = false` drops the CLI layer, and with it every HTTP client. The two that exist are opt-in: `riri-nce`'s `refresh` (behind `nce --refresh`) and `riri-ncd`'s `http` (the registry-backed `DeprecationSource`). Released binaries enable them; a `cargo install --git` build needs `--features refresh`. Without `http`, `riri-ncd` still analyzes a lockfile through `check_deprecations` against a `DeprecationSource` you supply.
 
-What is supported is what each crate's rustdoc documents. `pub` alone is not a promise: the `cli` modules exist so the binaries and the NAPI shims can share code and move without notice, and undocumented `pub` items are incidental. Nothing reads the filesystem or opens a socket unless its name says so — `PackageJsonFile::read`, `YarnProject::scan`, the `refresh` feature.
+What is supported is what each crate's rustdoc documents. `pub` alone is not a promise: the `cli` modules exist so the binaries and the NAPI shims can share code and move without notice, and undocumented `pub` items are incidental. Nothing reads the filesystem or opens a socket unless its name says so — `PackageJsonFile::read`, `YarnProject::scan`, the `refresh` and `http` features.
 
 Every crate is `0.1.x`, where cargo treats a minor bump as breaking. A breaking change lands as a `feat!:` commit, which release-please turns into a minor bump; everything else becomes a patch.
 

--- a/crates/riri-lockfile/Cargo.toml
+++ b/crates/riri-lockfile/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 repository.workspace = true
 
 [features]
+scan = ["riri-yarn/scan"]
 graph = [
     "riri-common/graph",
     "riri-npm/graph",
@@ -25,6 +26,7 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 rstest = { workspace = true }
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/riri-lockfile/src/lib.rs
+++ b/crates/riri-lockfile/src/lib.rs
@@ -7,6 +7,10 @@ use riri_common::{LockfileEngines, LockfileVersions, PackageManager};
 use riri_npm::{NpmPackageLock, NpmParseError};
 use riri_pnpm::{PnpmLockfile, PnpmParseError};
 use riri_yarn::{YarnLock, YarnParseError};
+#[cfg(feature = "scan")]
+use riri_yarn::{YarnProject, YarnScanError};
+#[cfg(feature = "scan")]
+use std::path::Path;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -54,10 +58,6 @@ impl ParsedLockfile {
         }
     }
 
-    /// `None` for yarn: `yarn.lock` stores no `engines` at any version, so the
-    /// install tree is the only source — `riri_yarn::YarnProject` (feature
-    /// `scan`), which reads `node_modules` and so cannot live behind a pure
-    /// entry point.
     /// The dependency graph, which every format can produce.
     #[cfg(feature = "graph")]
     #[must_use]
@@ -69,6 +69,8 @@ impl ParsedLockfile {
         }
     }
 
+    /// Engine constraints recorded in the lockfile itself. `None` for yarn,
+    /// which records none — see [`open_engines`] (feature `scan`).
     #[must_use]
     pub fn engines(&self) -> Option<&dyn LockfileEngines> {
         match self {
@@ -77,6 +79,68 @@ impl ParsedLockfile {
             Self::Yarn(_) => None,
         }
     }
+}
+
+/// Errors from [`open_engines`].
+#[cfg(feature = "scan")]
+#[derive(Debug, Error)]
+pub enum OpenEnginesError {
+    #[error(transparent)]
+    Parse(#[from] LockfileParseError),
+    #[error(transparent)]
+    Scan(#[from] YarnScanError),
+}
+
+/// An engine source, owning whatever it was read from.
+#[cfg(feature = "scan")]
+#[derive(Debug)]
+pub enum OpenedEngines {
+    Npm(NpmPackageLock),
+    Pnpm(PnpmLockfile),
+    /// Scanned from `node_modules`, which is where yarn keeps them.
+    InstallTree(YarnProject),
+}
+
+#[cfg(feature = "scan")]
+impl OpenedEngines {
+    #[must_use]
+    pub fn engines(&self) -> &dyn LockfileEngines {
+        match self {
+            Self::Npm(lock) => lock,
+            Self::Pnpm(lock) => lock,
+            Self::InstallTree(project) => project,
+        }
+    }
+}
+
+/// Engine constraints for any package manager.
+///
+/// npm and pnpm are parsed from `content`. yarn records none, so it is scanned
+/// from `{lockfile_path parent}/node_modules` — the only I/O here, and the
+/// reason for the `scan` feature.
+///
+/// # Errors
+///
+/// [`OpenEnginesError::Parse`] when `content` is not that format,
+/// [`OpenEnginesError::Scan`] when yarn's `node_modules` is missing.
+#[cfg(feature = "scan")]
+pub fn open_engines(
+    manager: PackageManager,
+    lockfile_path: &Path,
+    content: &str,
+) -> Result<OpenedEngines, OpenEnginesError> {
+    Ok(match manager {
+        PackageManager::Npm => {
+            OpenedEngines::Npm(NpmPackageLock::parse(content).map_err(LockfileParseError::Npm)?)
+        }
+        PackageManager::Pnpm => {
+            OpenedEngines::Pnpm(PnpmLockfile::parse(content).map_err(LockfileParseError::Pnpm)?)
+        }
+        PackageManager::Yarn => {
+            let project_dir = lockfile_path.parent().unwrap_or_else(|| Path::new("."));
+            OpenedEngines::InstallTree(YarnProject::scan(project_dir)?)
+        }
+    })
 }
 
 #[cfg(test)]
@@ -131,5 +195,72 @@ mod tests {
     #[test]
     fn wrong_format_for_the_content_is_an_error() {
         assert!(parse_lockfile(PackageManager::Npm, YARN_V1).is_err());
+    }
+
+    #[cfg(feature = "scan")]
+    mod open_engines {
+        use super::{NPM_V3, PNPM_V9, YARN_V1};
+        use crate::{OpenEnginesError, open_engines};
+        use riri_common::PackageManager;
+        use std::path::Path;
+
+        #[test]
+        fn npm_and_pnpm_read_engines_out_of_the_content() {
+            for (manager, content) in [
+                (PackageManager::Npm, NPM_V3),
+                (PackageManager::Pnpm, PNPM_V9),
+            ] {
+                // The path is unused for these two: nothing on disk to find.
+                let opened = open_engines(manager, Path::new("/nonexistent/lock"), content)
+                    .expect("parses from content alone");
+                assert_eq!(
+                    opened.engines().engines_iter().count(),
+                    1,
+                    "{manager:?} records engines in the lockfile"
+                );
+            }
+        }
+
+        #[test]
+        fn yarn_reads_engines_out_of_node_modules() {
+            let project = tempfile::TempDir::new().expect("tempdir");
+            let pkg_dir = project.path().join("node_modules/typescript");
+            std::fs::create_dir_all(&pkg_dir).expect("create node_modules");
+            std::fs::write(
+                pkg_dir.join("package.json"),
+                r#"{"version": "5.4.5", "engines": {"node": ">=14.17"}}"#,
+            )
+            .expect("write package.json");
+
+            let opened = open_engines(
+                PackageManager::Yarn,
+                &project.path().join("yarn.lock"),
+                YARN_V1,
+            )
+            .expect("scans the install tree");
+
+            let entries: Vec<_> = opened.engines().engines_iter().collect();
+            assert_eq!(entries.len(), 1, "one installed package declares engines");
+            assert_eq!(entries[0].0, "typescript");
+        }
+
+        #[test]
+        fn yarn_without_node_modules_is_a_scan_error() {
+            let project = tempfile::TempDir::new().expect("tempdir");
+            let error = open_engines(
+                PackageManager::Yarn,
+                &project.path().join("yarn.lock"),
+                YARN_V1,
+            )
+            .expect_err("no install tree to scan");
+            assert!(matches!(error, OpenEnginesError::Scan(_)));
+        }
+
+        #[test]
+        fn wrong_format_for_the_content_is_a_parse_error() {
+            let error = open_engines(PackageManager::Npm, Path::new("lock"), YARN_V1)
+                .expect_err("yarn.lock is not package-lock.json");
+            assert!(matches!(error, OpenEnginesError::Parse(_)));
+        }
     }
 }

--- a/crates/riri-ncd/Cargo.toml
+++ b/crates/riri-ncd/Cargo.toml
@@ -36,7 +36,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"], optional = true }
-ureq = { workspace = true }
+ureq = { workspace = true, optional = true }
 
 [features]
 default = ["cli"]
@@ -45,7 +45,9 @@ cli = [
     "dep:riri-task-runner",
     "dep:riri-workspace",
     "dep:tracing-subscriber",
+    "http",
 ]
+http = ["dep:ureq"]
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/crates/riri-ncd/src/lib.rs
+++ b/crates/riri-ncd/src/lib.rs
@@ -13,24 +13,21 @@ use semver::Version;
 use serde::Deserialize;
 use std::collections::HashMap;
 
-/// Analyze a project's lockfile (supplied as in-memory content) against the
-/// live npm registry and return the deprecation [`Report`](analyze::Report).
+/// Deprecation [`Report`](analyze::Report) for an in-memory lockfile, against a
+/// caller-supplied [`DeprecationSource`].
 ///
-/// `lockfile_type` is `"npm"`, `"pnpm"`, or `"yarn"`. `registry` overrides the
-/// registry URL (defaults to <https://registry.npmjs.org>). Performs blocking
-/// network requests; `.npmrc` is not consulted (pass `registry` explicitly for
-/// private registries).
+/// `lockfile_type` is `"npm"`, `"pnpm"`, or `"yarn"`.
 ///
 /// # Errors
-/// Parse failures, an unknown `lockfile_type`, or registry/auth failures.
-pub fn check_deprecations_from_content(
+/// Parse failures, an unknown `lockfile_type`, or a `source` failure.
+pub fn check_deprecations(
     package_json: &str,
     lockfile_content: &str,
     lockfile_type: &str,
-    registry: Option<String>,
+    source: &dyn DeprecationSource,
 ) -> anyhow::Result<analyze::Report> {
     use anyhow::Context as _;
-    use riri_common::{NpmrcRegistryConfig, PackageJson, PackageManager};
+    use riri_common::{PackageJson, PackageManager};
 
     let pkg: PackageJson =
         serde_json::from_str(package_json).context("failed to parse package.json")?;
@@ -44,8 +41,25 @@ pub fn check_deprecations_from_content(
         .map_err(|e| anyhow::anyhow!("failed to build dependency graph: {e}"))?;
 
     let project_name = pkg.name.clone().unwrap_or_else(|| "project".to_string());
+    analyze::analyze(&graph, &project_name, source).map_err(|error| anyhow::anyhow!(error))
+}
+
+/// [`check_deprecations`] against the live npm registry.
+///
+/// `registry` defaults to <https://registry.npmjs.org>; `.npmrc` is not
+/// consulted, so private registries need it passed explicitly.
+///
+/// # Errors
+/// Parse failures, an unknown `lockfile_type`, or registry/auth failures.
+#[cfg(feature = "http")]
+pub fn check_deprecations_from_content(
+    package_json: &str,
+    lockfile_content: &str,
+    lockfile_type: &str,
+    registry: Option<String>,
+) -> anyhow::Result<analyze::Report> {
     let client = registry::RegistryClient::new(NpmrcRegistryConfig::default(), registry);
-    analyze::analyze(&graph, &project_name, &client).map_err(|error| anyhow::anyhow!(error))
+    check_deprecations(package_json, lockfile_content, lockfile_type, &client)
 }
 
 /// `deprecated` is a string message in the wild, but some packuments carry a

--- a/crates/riri-ncd/src/registry.rs
+++ b/crates/riri-ncd/src/registry.rs
@@ -15,7 +15,7 @@ pub fn packument_url(registry: &str, name: &str) -> String {
     format!("{}/{}", registry.trim_end_matches('/'), encoded)
 }
 
-/// Live registry-backed [`DeprecationSource`]. Requires the `http` feature.
+/// Live registry-backed [`DeprecationSource`].
 #[cfg(feature = "http")]
 pub struct RegistryClient {
     agent: ureq::Agent,
@@ -46,24 +46,35 @@ impl RegistryClient {
     }
 }
 
-/// Read a packument from a `file://` registry directory (`{dir}/{name}.json`).
-/// Offline source used by fixtures and README generation. `Ok(None)` when the
-/// file is absent, mirroring a registry 404.
-#[cfg(feature = "http")]
-fn read_packument_file(dir: &str, name: &str) -> Result<Option<Packument>, SourceError> {
-    let path = std::path::Path::new(dir).join(format!("{name}.json"));
-    match std::fs::read_to_string(&path) {
-        Ok(body) => serde_json::from_str(&body)
-            .map(Some)
-            .map_err(|e| SourceError::Request {
+/// Offline [`DeprecationSource`] reading `{dir}/{name}.json`, behind a
+/// `file://` registry URL.
+pub struct FileRegistry {
+    dir: std::path::PathBuf,
+}
+
+impl FileRegistry {
+    #[must_use]
+    pub fn new(dir: impl Into<std::path::PathBuf>) -> Self {
+        Self { dir: dir.into() }
+    }
+}
+
+impl DeprecationSource for FileRegistry {
+    fn packument(&self, name: &str) -> Result<Option<Packument>, SourceError> {
+        let path = self.dir.join(format!("{name}.json"));
+        match std::fs::read_to_string(&path) {
+            Ok(body) => serde_json::from_str(&body)
+                .map(Some)
+                .map_err(|e| SourceError::Request {
+                    name: name.to_string(),
+                    detail: format!("invalid packument: {e}"),
+                }),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(SourceError::Request {
                 name: name.to_string(),
-                detail: format!("invalid packument: {e}"),
+                detail: e.to_string(),
             }),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
-        Err(e) => Err(SourceError::Request {
-            name: name.to_string(),
-            detail: e.to_string(),
-        }),
+        }
     }
 }
 
@@ -72,7 +83,7 @@ impl DeprecationSource for RegistryClient {
     fn packument(&self, name: &str) -> Result<Option<Packument>, SourceError> {
         let registry = self.registry_for(name);
         if let Some(dir) = registry.strip_prefix("file://") {
-            return read_packument_file(dir, name);
+            return FileRegistry::new(dir).packument(name);
         }
         let url = packument_url(registry, name);
         let mut req = self.agent.get(&url).header("accept", ACCEPT_ABBREVIATED);
@@ -165,22 +176,58 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "http")]
-    #[test]
-    fn file_registry_reads_local_packuments() {
+    /// Writes `{dir}/foo.json` and `{dir}/@scope/pkg.json`.
+    fn fixture_registry() -> tempfile::TempDir {
         let dir = tempfile::TempDir::new().unwrap();
         std::fs::write(
             dir.path().join("foo.json"),
             r#"{"dist-tags": {"latest": "1.0.0"}, "versions": {"1.0.0": {}}}"#,
         )
         .unwrap();
+        std::fs::create_dir_all(dir.path().join("@scope")).unwrap();
+        std::fs::write(
+            dir.path().join("@scope/pkg.json"),
+            r#"{"dist-tags": {"latest": "2.0.0"}, "versions": {"2.0.0": {}}}"#,
+        )
+        .unwrap();
+        dir
+    }
+
+    #[test]
+    fn file_registry_reads_local_packuments() {
+        let dir = fixture_registry();
+        let source = FileRegistry::new(dir.path());
+        assert_eq!(
+            source.packument("foo").unwrap().unwrap().latest(),
+            Some("1.0.0")
+        );
+        // A scoped name nests instead of percent-encoding.
+        assert_eq!(
+            source.packument("@scope/pkg").unwrap().unwrap().latest(),
+            Some("2.0.0")
+        );
+        // Absent file behaves like a registry 404.
+        assert!(source.packument("missing").unwrap().is_none());
+    }
+
+    #[test]
+    fn file_registry_rejects_invalid_packuments() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(dir.path().join("bad.json"), "not json").unwrap();
+        let error = FileRegistry::new(dir.path()).packument("bad").unwrap_err();
+        assert!(error.to_string().contains("invalid packument"));
+    }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn file_url_registry_routes_to_the_file_source() {
+        let dir = fixture_registry();
         let client = RegistryClient::new(
             riri_common::NpmrcRegistryConfig::default(),
             Some(format!("file://{}", dir.path().display())),
         );
         let packument = client.packument("foo").unwrap().unwrap();
         assert_eq!(packument.latest(), Some("1.0.0"));
-        // Absent file behaves like a registry 404.
         assert!(client.packument("missing").unwrap().is_none());
     }
 

--- a/crates/riri-ncd/src/registry.rs
+++ b/crates/riri-ncd/src/registry.rs
@@ -1,10 +1,10 @@
 //! Registry packument client and parallel fetch.
 
 use crate::{DeprecationSource, Packument, SourceError};
-use riri_common::NpmrcRegistryConfig;
 use std::collections::HashMap;
 use std::sync::Mutex;
 
+#[cfg(feature = "http")]
 const ACCEPT_ABBREVIATED: &str = "application/vnd.npm.install-v1+json";
 const CONCURRENCY: usize = 16;
 
@@ -15,17 +15,22 @@ pub fn packument_url(registry: &str, name: &str) -> String {
     format!("{}/{}", registry.trim_end_matches('/'), encoded)
 }
 
-/// Live registry-backed [`DeprecationSource`].
+/// Live registry-backed [`DeprecationSource`]. Requires the `http` feature.
+#[cfg(feature = "http")]
 pub struct RegistryClient {
     agent: ureq::Agent,
-    config: NpmrcRegistryConfig,
+    config: riri_common::NpmrcRegistryConfig,
     /// Overrides every scope when set (`--registry` flag).
     registry_override: Option<String>,
 }
 
+#[cfg(feature = "http")]
 impl RegistryClient {
     #[must_use]
-    pub fn new(config: NpmrcRegistryConfig, registry_override: Option<String>) -> Self {
+    pub fn new(
+        config: riri_common::NpmrcRegistryConfig,
+        registry_override: Option<String>,
+    ) -> Self {
         Self {
             agent: ureq::Agent::new_with_defaults(),
             config,
@@ -44,6 +49,7 @@ impl RegistryClient {
 /// Read a packument from a `file://` registry directory (`{dir}/{name}.json`).
 /// Offline source used by fixtures and README generation. `Ok(None)` when the
 /// file is absent, mirroring a registry 404.
+#[cfg(feature = "http")]
 fn read_packument_file(dir: &str, name: &str) -> Result<Option<Packument>, SourceError> {
     let path = std::path::Path::new(dir).join(format!("{name}.json"));
     match std::fs::read_to_string(&path) {
@@ -61,6 +67,7 @@ fn read_packument_file(dir: &str, name: &str) -> Result<Option<Packument>, Sourc
     }
 }
 
+#[cfg(feature = "http")]
 impl DeprecationSource for RegistryClient {
     fn packument(&self, name: &str) -> Result<Option<Packument>, SourceError> {
         let registry = self.registry_for(name);
@@ -158,6 +165,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "http")]
     #[test]
     fn file_registry_reads_local_packuments() {
         let dir = tempfile::TempDir::new().unwrap();

--- a/crates/riri-ncd/tests/facade.rs
+++ b/crates/riri-ncd/tests/facade.rs
@@ -1,0 +1,50 @@
+#![allow(clippy::tests_outside_test_module)]
+
+use riri_ncd::{
+    DeprecatedField, DeprecationSource, Packument, PackumentVersion, SourceError,
+    check_deprecations,
+};
+use std::collections::HashMap;
+
+const PKG: &str = r#"{"name": "app", "dependencies": {"typescript": "^5.4.0"}}"#;
+
+const NPM_LOCK: &str = r#"{
+    "lockfileVersion": 3,
+    "packages": {
+        "": {"name": "app", "dependencies": {"typescript": "^5.4.0"}},
+        "node_modules/typescript": {"version": "5.4.5"}
+    }
+}"#;
+
+/// Offline source: `typescript@5.4.5` is deprecated, `5.5.0` is not.
+struct StubSource;
+
+impl DeprecationSource for StubSource {
+    fn packument(&self, name: &str) -> Result<Option<Packument>, SourceError> {
+        if name != "typescript" {
+            return Ok(None);
+        }
+        let mut versions = HashMap::new();
+        versions.insert(
+            "5.4.5".to_string(),
+            PackumentVersion {
+                deprecated: Some(DeprecatedField::Message("use 5.5.0".into())),
+                ..PackumentVersion::default()
+            },
+        );
+        versions.insert("5.5.0".to_string(), PackumentVersion::default());
+        Ok(Some(Packument {
+            dist_tags: HashMap::from([("latest".to_string(), "5.5.0".to_string())]),
+            versions,
+        }))
+    }
+}
+
+#[test]
+fn checking_deprecations_needs_no_crate_beyond_riri_ncd() {
+    let report = check_deprecations(PKG, NPM_LOCK, "npm", &StubSource).expect("report");
+
+    assert_eq!(report.deprecated.len(), 1);
+    assert_eq!(report.deprecated[0].name, "typescript");
+    assert_eq!(report.deprecated[0].version, "5.4.5");
+}

--- a/crates/riri-nce/Cargo.toml
+++ b/crates/riri-nce/Cargo.toml
@@ -20,7 +20,7 @@ required-features = ["cli"]
 
 [dependencies]
 riri-common = { path = "../riri-common", version = "0.1.4" }
-riri-lockfile = { path = "../riri-lockfile", version = "0.1.0" }
+riri-lockfile = { path = "../riri-lockfile", version = "0.1.0", features = ["scan"] }
 riri-node-lifecycle = { path = "../riri-node-lifecycle", version = "0.1.3" }
 riri-npm = { path = "../riri-npm", version = "0.1.4" }
 riri-pnpm = { path = "../riri-pnpm", version = "0.1.4" }

--- a/crates/riri-nce/src/cli.rs
+++ b/crates/riri-nce/src/cli.rs
@@ -10,11 +10,10 @@ use riri_common::{
     EngineConstraintKey, LockfileEngines, PackageJsonFile, PackageManager, detect_lockfile,
     to_pretty_json_preserving_indent,
 };
-use riri_lockfile::parse_lockfile;
+use riri_lockfile::open_engines;
 use riri_node_lifecycle::{LifecycleData, Policy};
 use riri_semver_range::VersionPrecision;
 use riri_task_runner::{RendererMode, TaskRunner};
-use riri_yarn::YarnProject;
 use std::path::PathBuf;
 
 use crate::{
@@ -228,40 +227,26 @@ fn run(args: &Args) -> Result<i32> {
     let lockfile_content =
         std::fs::read_to_string(&lockfile_result.path).context("failed to read lockfile")?;
 
-    let yarn_project;
-    let parsed_lock;
-    let lockfile_engines: &dyn LockfileEngines = match lockfile_result.package_manager {
-        PackageManager::Yarn => {
-            let project_dir = lockfile_result
-                .path
-                .parent()
-                .unwrap_or_else(|| std::path::Path::new("."));
-            match YarnProject::scan(project_dir) {
-                Err(e) => {
-                    task.fail("Scanning node_modules");
-                    return Err(anyhow::anyhow!(e));
-                }
-                Ok(project) => {
-                    task.complete("Scanned node_modules");
-                    yarn_project = project;
-                    &yarn_project
-                }
-            }
-        }
-        manager => match parse_lockfile(manager, &lockfile_content) {
-            Err(e) => {
-                task.fail("Parsing lockfile");
-                return Err(anyhow::anyhow!(e));
-            }
-            Ok(lock) => {
-                task.complete("Parsed lockfile");
-                parsed_lock = lock;
-                parsed_lock
-                    .engines()
-                    .context("lockfile format records no engines")?
-            }
-        },
+    let (done, failed) = if lockfile_result.package_manager == PackageManager::Yarn {
+        ("Scanned node_modules", "Scanning node_modules")
+    } else {
+        ("Parsed lockfile", "Parsing lockfile")
     };
+    let engine_source = match open_engines(
+        lockfile_result.package_manager,
+        &lockfile_result.path,
+        &lockfile_content,
+    ) {
+        Err(e) => {
+            task.fail(failed);
+            return Err(anyhow::anyhow!(e));
+        }
+        Ok(source) => {
+            task.complete(done);
+            source
+        }
+    };
+    let lockfile_engines: &dyn LockfileEngines = engine_source.engines();
 
     // Compute engine constraints
     let task = runner.task("Computing engine constraints...");

--- a/crates/riri-nce/src/lib.rs
+++ b/crates/riri-nce/src/lib.rs
@@ -13,7 +13,10 @@ mod policy;
 
 pub use chrono::NaiveDate;
 pub use riri_common::{EngineConstraintKey, Engines, LockfileEngines, PackageJson, PackageManager};
-pub use riri_lockfile::{LockfileParseError, ParsedLockfile, parse_lockfile};
+pub use riri_lockfile::{
+    LockfileParseError, OpenEnginesError, OpenedEngines, ParsedLockfile, open_engines,
+    parse_lockfile,
+};
 pub use riri_node_lifecycle::{LifecycleData, Policy};
 pub use riri_npm::{NpmPackageLock, NpmParseError};
 pub use riri_pnpm::{PnpmLockfile, PnpmParseError};

--- a/crates/xtask/templates/readme-root.tera
+++ b/crates/xtask/templates/readme-root.tera
@@ -45,7 +45,7 @@ riri-ncd = { git = "https://github.com/smarlhens/riri-node-tools", rev = "000000
 riri-npd = { git = "https://github.com/smarlhens/riri-node-tools", rev = "0000000", default-features = false }
 ```
 
-`default-features = false` drops the CLI layer, and with it every HTTP client. The two that exist are opt-in: `riri-nce`'s `refresh` (behind `nce --refresh`) and `riri-ncd`'s `http` (the registry-backed `DeprecationSource`). Released binaries enable them; a `cargo install --git` build needs `--features refresh`.
+`default-features = false` drops the CLI layer, and with it every HTTP client. Both are opt-in: `riri-nce`'s `refresh` (behind `nce --refresh`) and `riri-ncd`'s `http`, the registry-backed `DeprecationSource`; released binaries enable them, and a `cargo install --git` build needs `--features refresh`. Without `http`, `riri-ncd` still analyzes a lockfile: `check_deprecations` takes any `DeprecationSource`. Bring your own, or use the bundled `registry::FileRegistry`, which reads packuments from a directory.
 
 What is supported is what each crate's rustdoc documents. `pub` alone is not a promise: the `cli` modules exist so the binaries and the NAPI shims can share code and move without notice, and undocumented `pub` items are incidental. Nothing reads the filesystem or opens a socket unless its name says so — `PackageJsonFile::read`, `YarnProject::scan`, the `refresh` and `http` features.
 

--- a/crates/xtask/templates/readme-root.tera
+++ b/crates/xtask/templates/readme-root.tera
@@ -41,12 +41,13 @@ The `riri-*` crates are libraries too. They are not on crates.io yet, so depend 
 ```toml
 [dependencies]
 riri-nce = { git = "https://github.com/smarlhens/riri-node-tools", rev = "0000000", default-features = false }
+riri-ncd = { git = "https://github.com/smarlhens/riri-node-tools", rev = "0000000", default-features = false }
 riri-npd = { git = "https://github.com/smarlhens/riri-node-tools", rev = "0000000", default-features = false }
 ```
 
-`default-features = false` drops the CLI layer. `refresh`, the HTTP client behind `nce --refresh`, is off by default as well: released binaries enable it, a `cargo install --git` build needs `--features refresh`.
+`default-features = false` drops the CLI layer, and with it every HTTP client. The two that exist are opt-in: `riri-nce`'s `refresh` (behind `nce --refresh`) and `riri-ncd`'s `http` (the registry-backed `DeprecationSource`). Released binaries enable them; a `cargo install --git` build needs `--features refresh`.
 
-What is supported is what each crate's rustdoc documents. `pub` alone is not a promise: the `cli` modules exist so the binaries and the NAPI shims can share code and move without notice, and undocumented `pub` items are incidental. Nothing reads the filesystem or opens a socket unless its name says so — `PackageJsonFile::read`, `YarnProject::scan`, the `refresh` feature.
+What is supported is what each crate's rustdoc documents. `pub` alone is not a promise: the `cli` modules exist so the binaries and the NAPI shims can share code and move without notice, and undocumented `pub` items are incidental. Nothing reads the filesystem or opens a socket unless its name says so — `PackageJsonFile::read`, `YarnProject::scan`, the `refresh` and `http` features.
 
 Every crate is `0.1.x`, where cargo treats a minor bump as breaking. A breaking change lands as a `feat!:` commit, which release-please turns into a minor bump; everything else becomes a patch.
 

--- a/crates/xtask/tests/msrv_pin.rs
+++ b/crates/xtask/tests/msrv_pin.rs
@@ -1,0 +1,33 @@
+//! `msrv.yml` pins `RUST_MSRV` by hand; a pin above
+//! `workspace.package.rust-version` would silently gate a newer floor.
+
+#![allow(clippy::tests_outside_test_module)]
+
+const WORKFLOW: &str = "../../.github/workflows/msrv.yml";
+
+fn declared_msrv(yaml: &str) -> Option<&str> {
+    yaml.lines()
+        .find_map(|line| line.trim().strip_prefix("RUST_MSRV:"))
+        .map(|value| value.trim().trim_matches('"'))
+}
+
+#[test]
+fn the_workflow_pins_the_manifest_msrv() {
+    let manifest = env!("CARGO_PKG_RUST_VERSION");
+    let yaml = std::fs::read_to_string(WORKFLOW)
+        .unwrap_or_else(|e| panic!("failed to read {WORKFLOW}: {e}"));
+    let pinned = declared_msrv(&yaml).unwrap_or_else(|| panic!("{WORKFLOW} declares no RUST_MSRV"));
+    assert_eq!(
+        pinned, manifest,
+        "{WORKFLOW} pins RUST_MSRV {pinned}, workspace.package.rust-version is {manifest}"
+    );
+}
+
+#[test]
+fn a_commented_out_pin_does_not_count() {
+    assert_eq!(
+        declared_msrv("env:\n  # RUST_MSRV: \"1.0.0\"\n  RUST_MSRV: \"1.88.0\"\n"),
+        Some("1.88.0")
+    );
+    assert_eq!(declared_msrv("env:\n  CARGO_TERM_COLOR: always\n"), None);
+}


### PR DESCRIPTION
Picks up the three `Not done` items from #274 that were left on the table.

| # | Item | Commit |
| --- | --- | --- |
| 1 | `ureq` optional in `riri-ncd`, behind a new `http` feature | `47b65a3` |
| 2 | Offline `DeprecationSource` (`registry::FileRegistry`), no HTTP client | `73f230b` |
| 3 | `open_engines()` for any package manager, `scan`-gated | `efbba71` |
| 4 | MSRV floor gated in CI at 1.88.0 | `2baa586` |

## Breaking

- `riri-ncd`'s `check_deprecations_from_content` needs `--features http`. `cli` implies it, so binaries and the napi shim are unchanged; only `--no-default-features` consumers lose it.

## Notes

- `check_deprecations(pkg, lock, type, &dyn DeprecationSource)` is the new pure entry point — the reason the HTTP client could move out.
- `open_engines(manager, lockfile_path, content)` takes both path and content so npm/pnpm parse in memory and only yarn touches disk. `ParsedLockfile::engines()` stays, additive.
- `OpenedEngines` uses concrete `Npm`/`Pnpm`/`InstallTree` variants so `engines()` is total — no `unreachable!` for the yarn arm `open_engines` can never build.
- MSRV job is rustls-shaped, and lives in a reusable `msrv.yml` that `ci` and `pr` both call, following `bench-run.yml`. `--locked --lib --bins` so dev-deps cannot raise the floor. `cargo "+$RUST_MSRV"` is required because `rust-toolchain.toml` pins 1.97.1 and overrides an installed default.
- `xtask/tests/msrv_pin.rs` asserts `msrv.yml`'s `RUST_MSRV` equals `workspace.package.rust-version`, read via `CARGO_PKG_RUST_VERSION`, so the hand-written pin cannot drift above the manifest.

## Verified

- `riri-ncd --no-default-features` drops 22 crates: `ureq`, `rustls`, `ring`, `webpki-roots`, `flate2`, `http`, `httparse` and friends. 78 -> 56.
- `FileRegistry` layout unchanged (`{dir}/{name}.json`, scoped names nesting), so xtask README regeneration and the RSS benches still resolve. Its tests now run in lean builds, where the code was not compiled before.
- `nce/cli.rs` yarn special case gone; every insta snapshot unchanged.
- All three MSRV configs compile on a real 1.88.0 toolchain, and the pin test fails when `RUST_MSRV` is moved off 1.88.0.
- Root README is generated: the prose changes are in `xtask/templates/readme-root.tera`, and `regen-readme --check --crate-name root` is clean.
- `cargo test --workspace`, clippy `--workspace --all-targets`, `fmt --check`, and prek all clean.

## Not done

- Pre-existing: `nce/cli.rs` reads `package.json` twice; `riri_npm::version_for` allocates per lookup; `riri-semver-range` prerelease mismatch from #274.

